### PR TITLE
[FEAT][kernels]: implement TMA-accelerated Online Softmax Fused LogP for SM90+

### DIFF
--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const candidateReviewers = ['Flink-ddd', 'EthanZero2Hero', 'inaniloquentee'];
+            const candidateReviewers = ['Flink-ddd', 'EthanZero2Hero', 'inaniloquentee', 'Schatten'];
 
             const prAuthor = context.payload.pull_request.user.login;
 

--- a/csrc/cuda/fused_logp_sm90.cu
+++ b/csrc/cuda/fused_logp_sm90.cu
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kernel-Align Contributors
+
+#include "../utils/tma_utils.cuh"
+#include <torch/extension.h>
+#include <cub/cub.cuh>
+
+#define TILE_V 4096
+
+template<int NUM_WARPS>
+__global__ void fused_logp_online_tma_kernel(
+    const __grid_constant__ CUtensorMap logits_tmap,
+    const int* __restrict__ labels,
+    const nv_bfloat16* __restrict__ logits_gmem,
+    float* __restrict__ output_logp,
+    int batch_size,
+    int vocab_size)
+{
+    const int tid = threadIdx.x;
+    const int warp_id = tid / 32;
+    const int lane_id = tid % 32;
+    const int row_idx = blockIdx.x;
+
+    extern __shared__ __align__(1024) char smem[];
+    const int smem_addr = static_cast<int>(__cvta_generic_to_shared(smem));
+    nv_bfloat16* smem_logits = reinterpret_cast<nv_bfloat16*>(smem);
+
+    const int tma_mbar_addr = smem_addr + (TILE_V * sizeof(nv_bfloat16));
+    const int mma_mbar_addr = tma_mbar_addr + 8;
+
+    if (warp_id == 0 && lane_id == 0) {
+        mbarrier_init(tma_mbar_addr, 1);
+        mbarrier_init(mma_mbar_addr, (NUM_WARPS - 1) * 32);
+        asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+    __syncthreads();
+
+    int num_tiles = (vocab_size + TILE_V - 1) / TILE_V;
+    int phase = 0;
+
+    if (warp_id == 0) {
+        for (int step = 0; step < num_tiles; ++step) {
+            int col_offset = step * TILE_V;
+            int current_tile_size = min(TILE_V, vocab_size - col_offset);
+
+            if (step > 0) mbarrier_wait(mma_mbar_addr, phase ^ 1);
+
+            if (lane_id == 0) {
+                tma_2d_g2s(smem_addr, &logits_tmap, col_offset, row_idx, tma_mbar_addr);
+                mbarrier_arrive_expect_tx(tma_mbar_addr, current_tile_size * sizeof(nv_bfloat16));
+            }
+            phase ^= 1;
+        }
+    }
+    else {
+        const int consumer_tid = (warp_id - 1) * 32 + lane_id;
+        const int num_consumers = (NUM_WARPS - 1) * 32;
+
+        using BlockReduce = cub::BlockReduce<float, (NUM_WARPS - 1) * 32>;
+        __shared__ typename BlockReduce::TempStorage temp_storage;
+
+        float row_max = -CUDART_INF_F;
+        float row_sum = 0.0f;
+
+        for (int step = 0; step < num_tiles; ++step) {
+            int current_tile_size = min(TILE_V, vocab_size - (step * TILE_V));
+
+            mbarrier_wait(tma_mbar_addr, phase);
+
+            float tile_max = -CUDART_INF_F;
+            for (int i = consumer_tid; i < current_tile_size; i += num_consumers) {
+                float val = __bfloat162float(smem_logits[i]);
+                tile_max = max(tile_max, val);
+            }
+            float block_tile_max = BlockReduce(temp_storage).Reduce(tile_max, cub::Max());
+            __shared__ float s_tile_max;
+            if (consumer_tid == 0) s_tile_max = block_tile_max;
+            asm volatile("bar.sync 1, %0;" :: "n"(num_consumers));
+
+            float tile_sum = 0.0f;
+            for (int i = consumer_tid; i < current_tile_size; i += num_consumers) {
+                float val = __bfloat162float(smem_logits[i]);
+                tile_sum += expf(val - s_tile_max);
+            }
+            float block_tile_sum = BlockReduce(temp_storage).Reduce(tile_sum, cub::Sum());
+            __shared__ float s_tile_sum;
+            if (consumer_tid == 0) s_tile_sum = block_tile_sum;
+            asm volatile("bar.sync 1, %0;" :: "n"(num_consumers));
+
+            if (consumer_tid == 0) {
+                float new_max = max(row_max, s_tile_max);
+                row_sum = row_sum * expf(row_max - new_max) + s_tile_sum * expf(s_tile_max - new_max);
+                row_max = new_max;
+            }
+            asm volatile("bar.sync 1, %0;" :: "n"(num_consumers));
+
+            mbarrier_arrive(mma_mbar_addr);
+            phase ^= 1;
+        }
+
+        if (consumer_tid == 0) {
+            int label_idx = labels[row_idx];
+            float label_val = __bfloat162float(logits_gmem[row_idx * vocab_size + label_idx]);
+            output_logp[row_idx] = label_val - row_max - logf(row_sum);
+        }
+    }
+}
+
+torch::Tensor fused_logp_sm90_forward(torch::Tensor logits, torch::Tensor labels) {
+    int B = logits.size(0);
+    int V = logits.size(1);
+    auto output = torch::empty({B}, logits.options().dtype(torch::kFloat));
+
+    CUtensorMap logits_tmap;
+    init_tensor_map(&logits_tmap, logits.data_ptr<at::BFloat16>(), B, V, 1, TILE_V);
+
+    int smem_size = (TILE_V * sizeof(nv_bfloat16)) + 16;
+    fused_logp_online_tma_kernel<4><<<B, 128, smem_size>>>(
+        logits_tmap, labels.data_ptr<int>(),
+        reinterpret_cast<const nv_bfloat16*>(logits.data_ptr<at::BFloat16>()),
+        output.data_ptr<float>(), B, V
+    );
+    return output;
+}

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -1,7 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
 #include <torch/extension.h>
 
 torch::Tensor fused_logp_forward(torch::Tensor logits, torch::Tensor token_ids);
 
+#ifdef __CUDACC__
+torch::Tensor fused_logp_sm90_forward(torch::Tensor logits, torch::Tensor labels);
+#endif
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.def("fused_logp", &fused_logp_forward, "Fused logp forward");
+    m.doc() = "Kernel-Align High-Performance Operator Extension Library";
+
+    m.def(
+        "fused_logp",
+        &fused_logp_forward,
+        "Generic Fused LogP Forward Operator"
+    );
+
+#ifdef __CUDACC__
+    m.def(
+        "fused_logp_sm90",
+        &fused_logp_sm90_forward,
+        "TMA-accelerated Online Softmax Fused LogP for SM90+ (Warp Specialization)"
+    );
+#endif
 }

--- a/csrc/utils/tma_utils.cuh
+++ b/csrc/utils/tma_utils.cuh
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 Kernel-Align Contributors
+
+#pragma once
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cudaTypedefs.h>
+#include <iostream>
+
+// Type Traits for TMA
+template <typename T> struct TmaTypeTraits;
+
+template<> struct TmaTypeTraits<nv_bfloat16> {
+    static constexpr CUtensorMapDataType tmap_dtype = CU_TENSOR_MAP_DATA_TYPE_BFLOAT16;
+};
+template<> struct TmaTypeTraits<float> {
+    static constexpr CUtensorMapDataType tmap_dtype = CU_TENSOR_MAP_DATA_TYPE_FLOAT32;
+};
+
+// Host API
+template <typename InType>
+inline void init_tensor_map(
+    CUtensorMap *tmap_ptr, const InType *gmem_ptr,
+    uint64_t gmem_height, uint64_t gmem_width,
+    uint32_t smem_height, uint32_t smem_width
+) {
+    constexpr uint32_t rank = 2;
+    uint64_t size[rank]        = {gmem_width, gmem_height};
+    uint64_t stride[rank - 1]  = {gmem_width * sizeof(InType)};
+    uint32_t box_size[rank]    = {smem_width, smem_height};
+    uint32_t elem_stride[rank] = {1, 1};
+
+    const uint32_t smem_stride_B = smem_width * sizeof(InType);
+    CUtensorMapSwizzle swizzle = CU_TENSOR_MAP_SWIZZLE_NONE;
+    if (smem_stride_B == 32)       swizzle = CU_TENSOR_MAP_SWIZZLE_32B;
+    else if (smem_stride_B == 64)  swizzle = CU_TENSOR_MAP_SWIZZLE_64B;
+    else if (smem_stride_B == 128) swizzle = CU_TENSOR_MAP_SWIZZLE_128B;
+
+    CUresult res = cuTensorMapEncodeTiled(
+        tmap_ptr, TmaTypeTraits<InType>::tmap_dtype, rank,
+        (void *)gmem_ptr, size, stride, box_size, elem_stride,
+        CU_TENSOR_MAP_INTERLEAVE_NONE, swizzle,
+        CU_TENSOR_MAP_L2_PROMOTION_NONE, CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+    );
+
+    if (res != CUDA_SUCCESS) {
+        std::cerr << "[Kernel-Align Error] cuTensorMapEncodeTiled failed!" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+
+// Device API
+__device__ inline void mbarrier_init(int addr, int count) {
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;" :: "r"(addr), "r"(count));
+}
+
+__device__ inline void mbarrier_arrive(int addr) {
+    asm volatile("mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];" :: "r"(addr) : "memory");
+}
+
+__device__ inline void mbarrier_arrive_expect_tx(int addr, int size) {
+    asm volatile("mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;"
+                 :: "r"(addr), "r"(size) : "memory");
+}
+
+__device__ inline void mbarrier_wait(int mbar_addr, int phase) {
+    int ticks = 0x989680;
+    asm volatile(
+        "{\n"
+        ".reg .pred P1;\n"
+        "LAB_WAIT:\n"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64 P1, [%0], %1, %2;\n"
+        "@!P1 bra.uni LAB_WAIT;\n"
+        "}" :: "r"(mbar_addr), "r"(phase), "r"(ticks)
+    );
+}
+
+__device__ inline void tma_2d_g2s(int dst_smem_addr, const void *tmap_ptr, int x, int y, int mbar_addr) {
+    asm volatile("cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::complete_tx::bytes "
+                 "[%0], [%1, {%2, %3}], [%4];"
+                 :: "r"(dst_smem_addr), "l"(tmap_ptr), "r"(x), "r"(y), "r"(mbar_addr) : "memory");
+}

--- a/rl_engine/_C.pyi
+++ b/rl_engine/_C.pyi
@@ -1,0 +1,6 @@
+# rl_engine/_C.pyi
+# This file is a type stub for the compiled C++ extension module.
+import torch
+
+def fused_logp(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor: ...
+def fused_logp_sm90(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor: ...

--- a/rl_engine/kernels/ops/cuda.py
+++ b/rl_engine/kernels/ops/cuda.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+import torch
+from rl_engine.utils.logger import logger
+
+try:
+    from rl_engine import _C
+
+    _EXT_AVAILABLE = True
+except ImportError as e:
+    logger.warning(f"Core binary extension (_C) unavailable: {e}. Falling back to native code.")
+    _EXT_AVAILABLE = False
+
+
+class FusedLogpSM90Op:
+    """TMA-accelerated Fused LogP for SM90+ cards."""
+
+    def __init__(self):
+        if not _EXT_AVAILABLE or not hasattr(_C, "fused_logp_sm90"):
+            raise RuntimeError(
+                "TMA Fused LogP kernel is not compiled or unsupported on this card architecture. "
+                "Please rebuild extension using 'pip install -e .'"
+            )
+        self.op = _C.fused_logp_sm90
+        logger.info("Successfully linked to precompiled _C.fused_logp_sm90 kernel.")
+
+    def __call__(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        assert logits.dtype == torch.bfloat16, "TMA logp currently requires bfloat16 logits"
+        assert logits.is_contiguous(), "Logits must be contiguous for TMA block loading"
+        labels_fused = labels.to(device=logits.device, dtype=torch.int32).contiguous()
+        return self.op(logits, labels_fused)
+
+
+class FusedLogpGenericOp:
+    """Generic custom CUDA/ROCm fallback Fused LogP."""
+
+    def __init__(self):
+        if not _EXT_AVAILABLE or not hasattr(_C, "fused_logp"):
+            raise RuntimeError("Base custom kernel 'fused_logp' is unavailable.")
+        self.op = _C.fused_logp
+        logger.info("Successfully linked to precompiled _C.fused_logp fallback kernel.")
+
+    def __call__(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
+        token_ids_fused = token_ids.to(device=logits.device, dtype=torch.int32).contiguous()
+        return self.op(logits, token_ids_fused)

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -24,6 +24,10 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     FLASH_ATTN = "rl_engine.kernels.cuda.flash_attn.FlashAttentionOp"
     FLASHINFER = "rl_engine.kernels.cuda.flashinfer.FlashInferOp"
 
+    # TMA-accelerated LogP for SM90+ (Warp Specialization)
+    CUDA_FUSED_LOGP_SM90 = "rl_engine.kernels.ops.cuda.FusedLogpSM90Op"
+    CUDA_FUSED_LOGP_GENERIC = "rl_engine.kernels.ops.cuda.FusedLogpGenericOp"
+
     # AMD ROCm optimized stack
     ROCM_AITER = "rl_engine.kernels.rocm.aiter.AiterOp"
     ROCM_CK = "rl_engine.kernels.rocm.composable_kernel.CKOp"
@@ -45,8 +49,14 @@ class KernelRegistry:
 
         self._priority_map = {
             "cuda": {
-                "logp": [OpBackend.FLASHINFER, OpBackend.TRITON_GENERIC, OpBackend.PYTORCH_NATIVE],
+                "logp": [
+                    OpBackend.CUDA_FUSED_LOGP_GENERIC,
+                    OpBackend.FLASHINFER,
+                    OpBackend.TRITON_GENERIC,
+                    OpBackend.PYTORCH_NATIVE,
+                ],
                 "attn": [OpBackend.FLASH_ATTN, OpBackend.TRITON_GENERIC, OpBackend.PYTORCH_NATIVE],
+                ## Default dispatch logic for new operators
             },
             "rocm": {
                 "logp": [OpBackend.ROCM_AITER, OpBackend.TRITON_GENERIC, OpBackend.PYTORCH_NATIVE],
@@ -58,6 +68,29 @@ class KernelRegistry:
             },
         }
         logger.info(f"KernelRegistry initialized for {device_ctx.device_type}")
+        self._adjust_priority_for_hardware()
+
+    def _adjust_priority_for_hardware(self):
+        """
+        Probe NVIDIA Compute Capability; if >= 90,
+        inject the fused logp operator with the highest priority.
+        """
+        if device_ctx.device_type == "cuda":
+            try:
+                import torch
+
+                cc_major, cc_minor = torch.cuda.get_device_capability()
+                cc = cc_major * 10 + cc_minor
+                if cc >= 90:
+                    logger.info(
+                        f"Detected Advanced Architecture (SM{cc}). "
+                        "Enabling TMA & Warp Specialization."
+                    )
+                    logp_list = self._priority_map["cuda"]["logp"]
+                    if OpBackend.CUDA_FUSED_LOGP_SM90 not in logp_list:
+                        logp_list.insert(0, OpBackend.CUDA_FUSED_LOGP_SM90)
+            except Exception as e:
+                logger.warning(f"Failed to probe device capability: {e}")
 
     def get_op(self, op_type: str) -> Any:
         """Core distribution logic: Automatically select the best operator

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,28 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 Kernel-Align Contributors
 
-from setuptools import setup, find_packages
+import os
+import torch
+from setuptools import find_packages, setup
 from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 try:
     from torch.utils.cpp_extension import ROCMExtension
 except ImportError:
     ROCMExtension = None
-import torch
 
 
 def get_extensions():
     extensions = []
-
     is_rocm = torch.version.hip is not None
 
     if is_rocm:
         extensions.append(
             ROCMExtension(
-                name="kernel_align_ops",
+                name="rl_engine._C",
                 sources=[
                     "csrc/ops.cpp",
-                    "csrc/fused_logp_kernel.cpp",  # ROCm uses .cpp for HIP kernels
+                    "csrc/fused_logp_kernel.cpp",
                 ],
                 extra_compile_args={
                     "cxx": ["-O3", "-std=c++17"],
@@ -31,17 +31,30 @@ def get_extensions():
             )
         )
     elif torch.cuda.is_available():
+        cuda_sources = [
+            "csrc/ops.cpp",
+            "csrc/fused_logp_kernel.cu",
+        ]
+
+        cc_major, _ = torch.cuda.get_device_capability()
+        nvcc_flags = ["-O3", "--use_fast_math", "-Xfatbin", "-compress-all"]
+        extra_link_args = []
+
+        tma_src = "csrc/cuda/fused_logp_sm90.cu"
+        if cc_major >= 9 or os.path.exists(tma_src):
+            cuda_sources.append(tma_src)
+            nvcc_flags.append("-gencode=arch=compute_90a,code=sm_90a")
+            extra_link_args.append("-lcuda")
+
         extensions.append(
             CUDAExtension(
-                name="kernel_align_ops",
-                sources=[
-                    "csrc/ops.cpp",
-                    "csrc/fused_logp_kernel.cu",
-                ],
+                name="rl_engine._C",
+                sources=cuda_sources,
                 extra_compile_args={
                     "cxx": ["-O3", "-std=c++17"],
-                    "nvcc": ["-O3", "--use_fast_math", "-Xfatbin", "-compress-all"],
+                    "nvcc": nvcc_flags,
                 },
+                extra_link_args=extra_link_args,
             )
         )
     return extensions

--- a/tests/test_op_accuracy.py
+++ b/tests/test_op_accuracy.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 Kernel-Align Contributors
 
 import torch
-from rl_engine.kernels.fused_ops import FusedLogp
+from rl_engine.kernels.registry import kernel_registry
 from rl_engine.platforms.device import device_ctx
 from rl_engine.utils.logger import logger
 
@@ -15,33 +15,34 @@ def test_accuracy():
 
     G, L, V = 16, 128, 4096
 
-    logits = torch.randn(G, L, V, device=device, dtype=dtype)
-    token_ids = torch.randint(0, V, (G, L), device=device)
+    logits = torch.randn(G * L, V, device=device, dtype=dtype)
+    token_ids = torch.randint(0, V, (G * L,), device=device, dtype=torch.int32)
 
     if device.type == "cuda":
         torch.cuda.synchronize()
 
     with torch.no_grad():
         ref_logp = torch.log_softmax(logits.float(), dim=-1)
-        ref_logp = torch.gather(ref_logp, dim=-1, index=token_ids.unsqueeze(-1)).squeeze(-1)
+        ref_logp = torch.gather(ref_logp, dim=-1, index=token_ids.unsqueeze(-1).long()).squeeze(-1)
         ref_logp = ref_logp.to(dtype)
 
     if device.type == "cuda":
         torch.cuda.synchronize()
 
     try:
-        custom_logp = FusedLogp.apply(logits, token_ids)
+        logp_operator = kernel_registry.get_op("logp")
+        custom_logp = logp_operator(logits, token_ids)
     except Exception as e:
         logger.error(f"Failed to execute FusedLogp: {e}")
         return
 
-    diff = torch.abs(ref_logp - custom_logp).max().item()
-
-    threshold = 1e-5 if dtype == torch.float32 else 1e-3
+    diff = torch.abs(ref_logp.float() - custom_logp.float()).max().item()
+    threshold = 1e-3 if dtype == torch.bfloat16 else 1e-5
 
     print("\n" + "=" * 50)
     print(f"RESULTS FOR {str(device).upper()}")
     print("-" * 50)
+    print(f"Dispatched Operator Class: {logp_operator.__class__.__name__}")
     print(f"Max Difference: {diff:.8e}")
 
     if diff < threshold:


### PR DESCRIPTION
## Overview
This PR introduces a highly optimized, hardware-aware fused LogP kernel utilizing TMA and Warp Specialization targeting NVIDIA Hopper (SM90) and Blackwell (SM100/SM120) architectures. 

By eliminating the intermediate memory bottlenecks of the standard LogP computation in DPO/GRPO pipelines, this implementation drastically reduces global memory traffic and pushes the kernel performance closer to the hardware limit.

### Key Technical Architectures
1. **Warp Specialization**: 
   **Warp 0  Producer**: Dedicates to orchestration, issuing asynchronous cp.async.bulk.tensor.2d instructions to load logits tiles into Shared Memory via hardware mbarrier synchronization.
   **Warps 1-3  Consumers**: Dedicates to math execution, performing high-performance block-level reductions asynchronously without stalling data transfers.
2. **Tiling & Online Softmax Algorithm**: 
   Instead of allocating massive Shared Memory for the entire vocabulary, which causes OOM on larger vocabularies, we implement an Online Softmax  reduction. Logits are streamed in chunks of TILE_V=4096, calculating local maximums and running scaling factors dynamically.
3. **Dynamic Hardware-Aware Dispatching**:
   Integrated into KernelRegistry. The registry dynamically checks the GPU compute capability at runtime. If cc >= 90, the TMA-accelerated fused kernel is automatically prioritized over FlashInfer and Triton fallbacks.

Closes #25