### PR TITLE
[docs]: add MkDocs Material documentation site skeleton

### DIFF
--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const candidateReviewers = ['Flink-ddd', 'EthanZero2Hero', 'inaniloquentee', 'Schatten'];
+            const candidateReviewers = ['Flink-ddd', 'EthanZero2Hero', 'inaniloquentee', 'bitborne'];
 
             const prAuthor = context.payload.pull_request.user.login;
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,23 @@ jobs:
       - name: Run Mocked Hardware Discovery Tests
         run: |
           python -m pytest rl_engine/tests/test_dispatch.py -v
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install Documentation Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-docs.txt
+
+      - name: Build Documentation
+        run: mkdocs build --strict -f mkdocs.yaml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+name: Docs
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+
+      - name: Install Documentation Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-docs.txt
+
+      - name: Build Documentation
+        run: mkdocs build --strict -f mkdocs.yaml
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #uv.lock
+.uv-cache/
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,0 +1,26 @@
+nav:
+  - Home: README.md
+  - User Guide:
+    - usage/README.md
+    - Getting Started:
+      - getting_started/quickstart.md
+      - getting_started/installation.md
+    - Operators:
+      - operators/README.md
+      - operators/fused-logp.md
+      - operators/sampling.md
+  - Developer Guide:
+    - contributing/README.md
+    - General:
+      - contributing/*
+      - contributing/operator-doc-template.md
+    - Design Documents:
+      - design/*
+  - Benchmarking:
+    - benchmarking/README.md
+  - API Reference:
+    - api/README.md
+  - CLI Reference:
+    - cli/README.md
+  - Community:
+    - community/*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,41 @@
-# Kernel-Align
-
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Hardware](https://img.shields.io/badge/Hardware-AMD%20ROCm%20%7C%20NVIDIA%20CUDA-orange)](https://github.com/Flink-ddd/RL-Engine-Lab)
-
-**Kernel-Align** is a transparent, high-performance infrastructure for Reinforcement Learning post-training. It bridges the gap between high-level alignment algorithms (DPO, GRPO, PPO) and low-level hardware optimizations on both AMD (ROCm) and NVIDIA (CUDA) platforms.
-
-## Key Features
-
-- **Hardware-Aware Design**: Built-in support for AMD/NVIDIA with automatic backend discovery.
-- **Inference Optimized**: Native integration with **vLLM** for fast rollout/sampling.
-- **Alignment Ready**: Clean implementations of DPO and GRPO (DeepSeek-style).
-- **Infra-First**: Designed for learning and extending RLHF toolchains (DeepSpeed, Ray, Triton).
-
 ---
-*Stay hungry, stay infra.*
+hide:
+  - navigation
+  - toc
+---
+
+# Welcome to Kernel-Align
+
+<figure markdown="span">
+  ![](./assets/rl-engine-log-display.png){ align="center" alt="Kernel-Align" width="38%" }
+</figure>
+
+<p style="text-align:center">
+<strong>High-performance kernels and runtime infrastructure for RL post-training.</strong>
+</p>
+
+<p style="text-align:center">
+<script async defer src="https://buttons.github.io/buttons.js"></script>
+<a class="github-button" href="https://github.com/Flink-ddd/Kernel-Align" data-show-count="true" data-size="large" aria-label="Star">Star</a>
+<a class="github-button" href="https://github.com/Flink-ddd/Kernel-Align/subscription" data-show-count="true" data-icon="octicon-eye" data-size="large" aria-label="Watch">Watch</a>
+<a class="github-button" href="https://github.com/Flink-ddd/Kernel-Align/fork" data-show-count="true" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork">Fork</a>
+</p>
+
+Kernel-Align bridges high-level alignment algorithms and low-level hardware optimizations.
+It targets GRPO, PPO, DPO, and other reinforcement learning post-training workloads where
+log probability computation, sampling, and memory pressure dominate the critical path.
+
+Where to get started depends on the type of user:
+
+- Run Kernel-Align locally with the [Quickstart Guide](./getting_started/quickstart.md).
+- Understand supported kernels from the [Operators](./operators/README.md) section.
+- Add a new operator by following the [Developer Guide](./contributing/README.md).
+- Read dispatch details in the [Runtime Dispatch design document](./design/runtime-dispatch.md).
+
+Kernel-Align focuses on:
+
+- Hardware-aware dispatch for CUDA, ROCm, and PyTorch fallback paths.
+- Fused GPU operators for post-training bottlenecks.
+- Operator documentation as part of the merge contract.
+- A documentation structure that can grow with the project as more operators,
+  runtime features, benchmarks, and APIs are added.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,14 @@
+# API Reference
+
+This section is reserved for generated or curated API reference pages.
+
+Current public entry points to document first:
+
+- `rl_engine.kernels.registry.KernelRegistry`
+- `rl_engine.kernels.registry.kernel_registry`
+- `rl_engine.kernels.sampling.SamplerBackend`
+- `rl_engine.kernels.ops.cuda.FusedLogpSM90Op`
+- `rl_engine.kernels.ops.cuda.FusedLogpGenericOp`
+
+As the project grows, this section can adopt generated API pages for public Python
+interfaces.

--- a/docs/benchmarking/README.md
+++ b/docs/benchmarking/README.md
@@ -1,0 +1,14 @@
+# Benchmarking
+
+Kernel-Align benchmarks track operator latency, memory behavior, and dispatch overhead.
+
+Current benchmark entry points:
+
+```bash
+python benchmarks/benchmark_sampling.py
+python benchmarks/benchmark_grpo_op.py
+python scripts/run_perf.py
+```
+
+When adding a new operator, document the benchmark command on the operator page and keep
+the tested shapes close to the target RL workload.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,0 +1,14 @@
+# CLI Reference
+
+This section is reserved for command-line tools exposed by Kernel-Align.
+
+Current developer commands:
+
+```bash
+python scripts/run_perf.py
+python benchmarks/benchmark_sampling.py
+python benchmarks/benchmark_grpo_op.py
+```
+
+When a stable CLI is added, document command syntax, arguments, examples, and expected
+outputs in this section.

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,0 +1,9 @@
+# Community
+
+Kernel-Align is developed in the open at:
+
+- [GitHub repository](https://github.com/Flink-ddd/Kernel-Align)
+- [Apache-2.0 license](https://github.com/Flink-ddd/Kernel-Align/blob/main/LICENSE)
+
+Use GitHub issues and pull requests for bug reports, operator proposals, and documentation
+improvements.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,0 +1,18 @@
+# Developer Guide
+
+This section collects general contribution material, design documents, and operator
+development notes for Kernel-Align.
+
+Before merging a new operator, include:
+
+- The implementation and dispatch registration.
+- A focused correctness test or documented validation path.
+- A dedicated page under `docs/operators/`.
+- Navigation updates in `docs/.nav.yml`.
+- A passing documentation build with `mkdocs build --strict -f mkdocs.yaml`.
+
+Useful pages:
+
+- [Documentation Guide](documentation.md)
+- [Testing](testing.md)
+- [Runtime Dispatch](../design/runtime-dispatch.md)

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -1,0 +1,29 @@
+# Documentation Guide
+
+Kernel-Align documentation is built with MkDocs Material and published as a static GitHub
+Pages site.
+
+## Local Build
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs build --strict -f mkdocs.yaml
+```
+
+## Local Preview
+
+```bash
+mkdocs serve
+```
+
+## Adding an Operator Page
+
+1. Copy `docs/contributing/operator-doc-template.md` to `docs/operators/<operator-name>.md`.
+2. Fill in the operator contract, backend list, examples, tests, and limitations.
+3. Add the page to the `Operators` section in `docs/.nav.yml`.
+4. Run `mkdocs build --strict -f mkdocs.yaml`.
+
+## CI Requirement
+
+Documentation changes must keep `mkdocs build --strict -f mkdocs.yaml` passing. The CI
+docs job validates navigation, links, and Markdown extension configuration.

--- a/docs/contributing/operator-doc-template.md
+++ b/docs/contributing/operator-doc-template.md
@@ -1,0 +1,50 @@
+# Operator Doc Template
+
+Copy this template when adding a new operator page.
+
+## Summary
+
+Describe what the operator does, which RL workload it targets, and why it exists.
+
+## Entry Point
+
+```python
+# Show the public Python API used by callers.
+```
+
+## Backends
+
+| Backend | Wrapper | Native symbol | Status |
+| --- | --- | --- | --- |
+| CUDA |  |  |  |
+| ROCm |  |  |  |
+| PyTorch fallback |  |  |  |
+
+## Tensor Contract
+
+| Argument | Shape | Dtype | Requirements |
+| --- | --- | --- | --- |
+|  |  |  |  |
+
+## Dispatch Behavior
+
+Explain how the registry chooses this operator and what happens when a backend is
+unavailable.
+
+## Accuracy
+
+Document the PyTorch reference implementation, tolerance, and any dtype-specific behavior.
+
+## Performance Notes
+
+List the benchmark command and the workload sizes used to evaluate the operator.
+
+## Tests
+
+```bash
+python -m pytest path/to/test.py -v
+```
+
+## Known Limitations
+
+Track unsupported shapes, dtypes, devices, or architecture constraints.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,0 +1,24 @@
+# Testing
+
+Kernel-Align uses focused tests for dispatch behavior and operator accuracy.
+
+## Dispatch Tests
+
+```bash
+python -m pytest rl_engine/tests/test_dispatch.py -v
+```
+
+## Operator Accuracy
+
+```bash
+python tests/test_op_accuracy.py
+```
+
+## Documentation Build
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs build --strict -f mkdocs.yaml
+```
+
+Run the documentation build whenever adding a new operator page or changing navigation.

--- a/docs/design/runtime-dispatch.md
+++ b/docs/design/runtime-dispatch.md
@@ -1,0 +1,29 @@
+# Runtime Dispatch
+
+Kernel-Align routes operators through `KernelRegistry`. Callers request an operator by
+logical type, and the registry selects the first available backend for the current device.
+
+## Dispatch Flow
+
+1. Detect platform from `device_ctx`.
+2. Load the priority list for the requested operator type.
+3. Try each backend in priority order.
+4. Cache successfully constructed operator instances.
+5. Skip backends that already failed in the current process.
+
+## LogP Priority
+
+| Platform | Priority |
+| --- | --- |
+| CUDA | SM90 fused LogP when available, CUDA generic, FlashInfer, Triton generic, PyTorch native |
+| ROCm | AITER, Triton generic, PyTorch native |
+| CPU | PyTorch native |
+
+For CUDA devices with compute capability 9.0 or newer, the registry inserts the SM90
+LogP backend at the front of the CUDA priority list.
+
+## Relevant Files
+
+- `rl_engine/kernels/registry.py`
+- `rl_engine/platforms/device.py`
+- `rl_engine/kernels/ops/`

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,0 +1,37 @@
+# Installation
+
+Kernel-Align requires Python 3.10 or newer and PyTorch. CUDA builds require a working
+CUDA toolchain; ROCm builds require a compatible ROCm environment.
+
+## From Source
+
+```bash
+git clone https://github.com/Flink-ddd/Kernel-Align.git
+cd Kernel-Align
+pip install -e .
+```
+
+## Optional Backends
+
+```bash
+pip install -e ".[cuda]"
+```
+
+```bash
+pip install -e ".[rocm]"
+```
+
+## Development Dependencies
+
+```bash
+pip install -e ".[dev]"
+pip install -r requirements-docs.txt
+```
+
+## Documentation Preview
+
+```bash
+mkdocs serve
+```
+
+Then open the local URL printed by MkDocs.

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,0 +1,30 @@
+# Quick Start
+
+Kernel-Align exposes operators through a runtime registry. The registry selects a backend
+based on the current device and available compiled extensions.
+
+```python
+import torch
+from rl_engine.kernels.registry import kernel_registry
+
+logits = torch.randn(16, 4096, device="cuda", dtype=torch.bfloat16).contiguous()
+token_ids = torch.randint(0, 4096, (16,), device="cuda", dtype=torch.int32)
+
+logp = kernel_registry.get_op("logp")
+selected_log_probs = logp(logits, token_ids)
+```
+
+For environments without a compiled CUDA/ROCm extension, the registry falls back to the
+available PyTorch implementation when supported by the operator type.
+
+## Validate Dispatch
+
+```bash
+python -m pytest rl_engine/tests/test_dispatch.py -v
+```
+
+## Validate Operator Accuracy
+
+```bash
+python tests/test_op_accuracy.py
+```

--- a/docs/mkdocs/stylesheets/extra.css
+++ b/docs/mkdocs/stylesheets/extra.css
@@ -1,0 +1,20 @@
+/* Kernel-Align documentation refinements for the Material theme. */
+
+body[data-md-color-scheme="default"] .md-nav__item--section > label.md-nav__link .md-ellipsis {
+  color: rgba(0, 0, 0, 0.7) !important;
+  font-weight: 700;
+}
+
+body[data-md-color-scheme="slate"] .md-nav__item--section > label.md-nav__link .md-ellipsis {
+  color: rgba(255, 255, 255, 0.75) !important;
+  font-weight: 700;
+}
+
+.md-typeset .tabbed-set {
+  border: 0.075rem solid var(--md-default-fg-color);
+  border-radius: 0.2rem;
+}
+
+.md-typeset .tabbed-content {
+  padding: 0 0.6em;
+}

--- a/docs/operators/README.md
+++ b/docs/operators/README.md
@@ -1,0 +1,23 @@
+# Operators
+
+Each upstreamed operator must be documented in this section. Treat the documentation page
+as part of the operator contract: inputs, outputs, supported backends, dispatch behavior,
+accuracy expectations, and known limitations should be clear before merge.
+
+## Required Page Content
+
+Every operator page should include:
+
+- Purpose and target workload.
+- Public Python entry point.
+- Backend implementations and fallback behavior.
+- Input and output tensor shapes, dtypes, devices, and contiguity requirements.
+- Accuracy or numerical tolerance expectations.
+- Minimal usage example.
+- Related tests and benchmarks.
+
+## Current Pages
+
+- [Fused LogP](fused-logp.md)
+- [Sampling](sampling.md)
+- [Operator Doc Template](../contributing/operator-doc-template.md)

--- a/docs/operators/fused-logp.md
+++ b/docs/operators/fused-logp.md
@@ -1,0 +1,54 @@
+# Fused LogP
+
+Fused LogP computes selected token log probabilities from model logits. It targets RL
+post-training workloads where repeated `log_softmax + gather` operations create memory
+pressure at large group sizes.
+
+## Entry Point
+
+```python
+from rl_engine.kernels.registry import kernel_registry
+
+logp_op = kernel_registry.get_op("logp")
+output = logp_op(logits, token_ids)
+```
+
+## Backends
+
+| Backend | Wrapper | Native symbol | Notes |
+| --- | --- | --- | --- |
+| CUDA SM90 | `FusedLogpSM90Op` | `_C.fused_logp_sm90` | TMA-oriented path for Hopper-class GPUs. |
+| CUDA generic | `FusedLogpGenericOp` | `_C.fused_logp` | Generic compiled extension fallback. |
+| PyTorch native | `NativeOp` | None | Baseline fallback path. |
+
+## Tensor Contract
+
+| Argument | Shape | Dtype | Requirements |
+| --- | --- | --- | --- |
+| `logits` | `[N, V]` | `bfloat16` for SM90 path | Contiguous, on the target device. |
+| `token_ids` / `labels` | `[N]` | Converted to `int32` | Same logical device as `logits`. |
+| Output | `[N]` | Backend-defined tensor dtype | One selected log probability per row. |
+
+## Reference Semantics
+
+```python
+ref = torch.log_softmax(logits.float(), dim=-1)
+ref = torch.gather(ref, dim=-1, index=token_ids.unsqueeze(-1).long()).squeeze(-1)
+```
+
+## Tests
+
+```bash
+python tests/test_op_accuracy.py
+```
+
+The current accuracy test compares the dispatched operator with a PyTorch reference and
+uses a dtype-dependent threshold.
+
+## Implementation Files
+
+- `rl_engine/kernels/registry.py`
+- `rl_engine/kernels/ops/cuda.py`
+- `csrc/ops.cpp`
+- `csrc/fused_logp_kernel.cu`
+- `csrc/cuda/fused_logp_sm90.cu`

--- a/docs/operators/sampling.md
+++ b/docs/operators/sampling.md
@@ -1,0 +1,50 @@
+# Sampling
+
+The sampling backend provides a unified interface for rollout token sampling. It routes
+to optimized vendor libraries when available and falls back to PyTorch sampling logic.
+
+## Entry Point
+
+```python
+from rl_engine.kernels.sampling import SamplerBackend
+
+sampler = SamplerBackend()
+tokens = sampler.sample(logits, top_k=50, top_p=0.95, temperature=1.0)
+```
+
+## Backends
+
+| Platform | Backend | Status |
+| --- | --- | --- |
+| NVIDIA CUDA | FlashInfer | Active |
+| AMD ROCm | AITER | Planned integration point |
+| CPU / fallback | PyTorch | Active fallback |
+
+## Supported Modes
+
+- Unfiltered sampling from logits.
+- Top-k sampling.
+- Top-p sampling.
+- Combined top-k and top-p sampling when the FlashInfer backend is available.
+- Deterministic sampling when supported by the backend.
+
+## Tensor Contract
+
+| Argument | Shape | Dtype | Requirements |
+| --- | --- | --- | --- |
+| `logits` | `[B, V]` or compatible backend shape | Floating point | Converted to contiguous layout. |
+| Output | `[B]` | Integer token IDs | One sampled token per row. |
+
+## Tests and Benchmarks
+
+```bash
+python benchmarks/benchmark_sampling.py
+```
+
+Add focused tests when changing backend routing, supported sampling modes, or numerical
+behavior.
+
+## Implementation Files
+
+- `rl_engine/kernels/sampling.py`
+- `rl_engine/platforms/constants.py`

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,0 +1,10 @@
+# User Guide
+
+This section is for Kernel-Align users who want to install the package, call operators,
+and understand supported runtime behavior.
+
+Start with:
+
+- [Quickstart](../getting_started/quickstart.md)
+- [Installation](../getting_started/installation.md)
+- [Operators](../operators/README.md)

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,0 +1,91 @@
+site_name: Kernel-Align
+site_url: https://flink-ddd.github.io/Kernel-Align/
+repo_url: https://github.com/Flink-ddd/Kernel-Align
+edit_uri: edit/main/docs/
+exclude_docs: |
+
+theme:
+  name: material
+  logo: assets/rl-engine-log.png
+  favicon: assets/rl-engine-log.png
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: white
+      accent: deep orange
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: deep orange
+      toggle:
+        icon: material/brightness-2
+        name: Switch to system preference
+  features:
+    - content.action.edit
+    - content.code.copy
+    - content.tabs.link
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.indexes
+    - navigation.top
+    - navigation.path
+    - search.highlight
+    - search.share
+    - toc.follow
+
+plugins:
+  - meta
+  - search
+  - awesome-nav
+  - git-revision-date-localized:
+      exclude:
+        - api/*
+
+markdown_extensions:
+  - attr_list
+  - def_list
+  - md_in_html
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+  - pymdownx.arithmatex:
+      generic: true
+
+extra_css:
+  - mkdocs/stylesheets/extra.css
+
+extra_javascript:
+  - https://unpkg.com/mathjax@3.2.2/es5/tex-mml-chtml.js
+
+strict: true

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+mkdocs<2.0.0
+mkdocs-awesome-nav
+mkdocs-git-revision-date-localized-plugin
+mkdocs-material


### PR DESCRIPTION
## Summary

This PR adds the initial Kernel-Align documentation site skeleton using MkDocs, Material Theme, and GitHub Pages.

The documentation structure is prepared for future user guides, developer guides, operator docs, benchmarks, API references, CLI references, and community pages.

## Changes

- Add `mkdocs.yaml` for the MkDocs Material site configuration.
- Add `requirements-docs.txt` for documentation dependencies.
- Add `docs/.nav.yml` for documentation navigation.
- Update `docs/README.md` into the documentation site home page.
- Add initial documentation sections:
  - `docs/usage/`
  - `docs/getting_started/`
  - `docs/operators/`
  - `docs/contributing/`
  - `docs/design/`
  - `docs/benchmarking/`
  - `docs/api/`
  - `docs/cli/`
  - `docs/community/`
- Add initial operator pages for Fused LogP and Sampling.
- Add an operator documentation template for future kernels.
- Add documentation build validation to CI.
- Add GitHub Pages deployment workflow.

## Overwrite / Deletion Review

- `docs/README.md` is intentionally rewritten from the previous short docs README into the documentation home page.
- `.github/workflows/ci.yml` is extended with a docs build job.
- `.gitignore` adds `.uv-cache/`.
- No tracked files are deleted.

## Validation

```bash
mkdocs build --strict -f mkdocs.yaml
```

The docs CI job installs dependencies from `requirements-docs.txt` and runs the same strict build.

## Notes

- The `git-revision-date-localized` plugin may warn locally for newly added files before they are committed because they do not yet have git history.
- `site_url` currently targets the default GitHub Pages project URL: `https://flink-ddd.github.io/Kernel-Align/`. It can be updated later if the project uses a custom docs domain.

Closes #31