### PR TITLE
feat: add RL synthetic fixtures, reference ops, and minimal loss-step tests

### DIFF
--- a/rl_engine/testing/__init__.py
+++ b/rl_engine/testing/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+"""Testing helpers for RL-shaped kernel validation."""
+
+from .rl_batch import SyntheticRLKernelBatch, make_synthetic_rl_kernel_batch
+from .reference_ops import (
+    active_token_count,
+    compute_policy_ratio,
+    compute_reference_kl,
+    masked_mean,
+    masked_sum,
+    selected_logprobs_reference,
+    summarize_kernel_drift,
+)
+
+__all__ = [
+    "SyntheticRLKernelBatch",
+    "active_token_count",
+    "compute_policy_ratio",
+    "compute_reference_kl",
+    "make_synthetic_rl_kernel_batch",
+    "masked_mean",
+    "masked_sum",
+    "selected_logprobs_reference",
+    "summarize_kernel_drift",
+]

--- a/rl_engine/testing/reference_ops.py
+++ b/rl_engine/testing/reference_ops.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+def _bool_mask(mask: torch.Tensor, *, device: torch.device) -> torch.Tensor:
+    return mask.to(device=device, dtype=torch.bool)
+
+
+def selected_logprobs_reference(
+    logits: torch.Tensor,
+    token_ids: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    temperature: float = 1.0,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Reference selected-token logprobs for RL kernel validation."""
+
+    if temperature <= 0.0:
+        raise ValueError("temperature must be greater than zero")
+    if logits.shape[:-1] != token_ids.shape:
+        raise ValueError(
+            f"logits leading shape {tuple(logits.shape[:-1])} must match "
+            f"token_ids shape {tuple(token_ids.shape)}"
+        )
+    if mask is not None and mask.shape != token_ids.shape:
+        raise ValueError(f"mask shape {tuple(mask.shape)} must match token_ids shape")
+
+    scaled_logits = logits.float() / float(temperature)
+    log_probs = torch.log_softmax(scaled_logits, dim=-1)
+    selected = torch.gather(log_probs, dim=-1, index=token_ids.long().unsqueeze(-1)).squeeze(-1)
+
+    if mask is not None:
+        selected = selected.masked_fill(~_bool_mask(mask, device=selected.device), 0.0)
+
+    return selected.to(dtype=output_dtype)
+
+
+def masked_sum(values: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    """Sum values while ignoring masked-out entries."""
+
+    values_fp32 = values.float()
+    if mask is None:
+        return values_fp32.sum()
+    return values_fp32.masked_fill(~_bool_mask(mask, device=values.device), 0.0).sum()
+
+
+def active_token_count(
+    mask: torch.Tensor | None, values: torch.Tensor | None = None
+) -> torch.Tensor:
+    """Return the number of active tokens as an fp32 scalar tensor."""
+
+    if mask is None:
+        if values is None:
+            raise ValueError("values must be provided when mask is None")
+        return torch.tensor(values.numel(), device=values.device, dtype=torch.float32)
+    return _bool_mask(mask, device=mask.device).sum().to(dtype=torch.float32)
+
+
+def masked_mean(
+    values: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Mean values while ignoring masked-out entries."""
+
+    denom = active_token_count(mask, values).clamp_min(eps)
+    return masked_sum(values, mask) / denom
+
+
+def compute_policy_ratio(
+    current_logps: torch.Tensor,
+    old_logps: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute exp(current - old) with masked entries set to zero."""
+
+    ratio = torch.exp(current_logps.float() - old_logps.float())
+    if mask is not None:
+        ratio = ratio.masked_fill(~_bool_mask(mask, device=ratio.device), 0.0)
+    return ratio
+
+
+def compute_reference_kl(
+    current_logps: torch.Tensor,
+    ref_logps: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute the common GRPO/PPO reference KL approximation."""
+
+    diff = ref_logps.float() - current_logps.float()
+    kl = torch.exp(diff) - diff - 1.0
+    if mask is not None:
+        kl = kl.masked_fill(~_bool_mask(mask, device=kl.device), 0.0)
+    return kl
+
+
+def summarize_kernel_drift(
+    candidate: torch.Tensor,
+    reference: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> dict[str, Any]:
+    """Summarize candidate-vs-reference drift for benchmark/test output."""
+
+    if candidate.shape != reference.shape:
+        raise ValueError(
+            f"candidate shape {tuple(candidate.shape)} must match reference shape "
+            f"{tuple(reference.shape)}"
+        )
+
+    diff = (candidate.float() - reference.float()).abs()
+    if mask is not None:
+        active = _bool_mask(mask, device=diff.device)
+        active_diff = diff[active]
+        active_count = int(active.sum().item())
+    else:
+        active_diff = diff.reshape(-1)
+        active_count = int(diff.numel())
+
+    if active_count == 0:
+        max_abs = 0.0
+        mean_abs = 0.0
+    else:
+        max_abs = float(active_diff.max().item())
+        mean_abs = float(active_diff.mean().item())
+
+    return {
+        "max_abs_error": max_abs,
+        "mean_abs_error": mean_abs,
+        "active_count": active_count,
+    }

--- a/rl_engine/testing/rl_batch.py
+++ b/rl_engine/testing/rl_batch.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass(frozen=True)
+class SyntheticRLKernelBatch:
+    """Synthetic RL-shaped tensors shared by kernel tests and benchmarks."""
+
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    prompt_mask: torch.Tensor
+    completion_mask: torch.Tensor
+    token_ids: torch.Tensor
+    rewards: torch.Tensor
+    advantages: torch.Tensor
+    old_logps: torch.Tensor
+    ref_logps: torch.Tensor
+    valid_indices: torch.Tensor | None
+    metadata: dict[str, Any]
+
+    @property
+    def batch_size(self) -> int:
+        return int(self.input_ids.size(0))
+
+    @property
+    def total_seq_len(self) -> int:
+        return int(self.input_ids.size(1))
+
+    @property
+    def prompt_len(self) -> int:
+        return int(self.metadata["prompt_len"])
+
+    @property
+    def completion_len(self) -> int:
+        return int(self.metadata["completion_len"])
+
+    @property
+    def flat_completion_mask(self) -> torch.Tensor:
+        return self.completion_mask.reshape(-1)
+
+    @property
+    def flat_token_ids(self) -> torch.Tensor:
+        return self.token_ids.reshape(-1)
+
+    def dense_completion_token_ids(self) -> torch.Tensor:
+        return self.token_ids
+
+    def dense_completion_values(self, values: torch.Tensor) -> torch.Tensor:
+        expected_shape = (self.batch_size, self.completion_len)
+        if tuple(values.shape[:2]) != expected_shape:
+            raise ValueError(
+                f"expected leading shape {expected_shape}, got {tuple(values.shape[:2])}"
+            )
+        return values
+
+    def compact_completion_values(self, values: torch.Tensor) -> torch.Tensor:
+        dense = self.dense_completion_values(values)
+        return dense.reshape(-1, *dense.shape[2:])[self.flat_completion_mask]
+
+    def compact_token_ids(self) -> torch.Tensor:
+        return self.flat_token_ids[self.flat_completion_mask]
+
+    def benchmark_metadata(self) -> dict[str, Any]:
+        return {
+            "num_prompts": self.metadata["num_prompts"],
+            "samples_per_prompt": self.metadata["samples_per_prompt"],
+            "batch_size": self.batch_size,
+            "prompt_len": self.prompt_len,
+            "completion_len": self.completion_len,
+            "total_seq_len": self.total_seq_len,
+            "vocab_size": self.metadata["vocab_size"],
+            "valid_density": self.metadata["valid_density"],
+            "valid_tokens": int(self.flat_completion_mask.sum().item()),
+            "dtype": str(self.metadata["dtype"]),
+            "device": str(self.input_ids.device),
+            "seed": self.metadata["seed"],
+        }
+
+
+def make_synthetic_rl_kernel_batch(
+    *,
+    num_prompts: int,
+    samples_per_prompt: int,
+    prompt_len: int,
+    completion_len: int,
+    vocab_size: int,
+    valid_density: float = 1.0,
+    dtype: torch.dtype = torch.float32,
+    device: torch.device | str = "cpu",
+    seed: int = 0,
+) -> SyntheticRLKernelBatch:
+    """Create deterministic RL-shaped tensors for kernel tests."""
+
+    if num_prompts <= 0:
+        raise ValueError("num_prompts must be greater than zero")
+    if samples_per_prompt <= 0:
+        raise ValueError("samples_per_prompt must be greater than zero")
+    if prompt_len < 0:
+        raise ValueError("prompt_len must be non-negative")
+    if completion_len <= 0:
+        raise ValueError("completion_len must be greater than zero")
+    if vocab_size <= 1:
+        raise ValueError("vocab_size must be greater than one")
+    if not 0.0 <= valid_density <= 1.0:
+        raise ValueError("valid_density must be in [0.0, 1.0]")
+
+    target_device = torch.device(device)
+    batch_size = num_prompts * samples_per_prompt
+    total_seq_len = prompt_len + completion_len
+
+    generator = torch.Generator(device=target_device)
+    generator.manual_seed(seed)
+
+    input_ids = torch.randint(
+        low=0,
+        high=vocab_size,
+        size=(batch_size, total_seq_len),
+        device=target_device,
+        generator=generator,
+        dtype=torch.long,
+    )
+    if prompt_len:
+        prompt_ids = torch.randint(
+            low=0,
+            high=vocab_size,
+            size=(num_prompts, prompt_len),
+            device=target_device,
+            generator=generator,
+            dtype=torch.long,
+        )
+        shared_prompt_ids = prompt_ids.repeat_interleave(samples_per_prompt, dim=0)
+        input_ids[:, :prompt_len] = shared_prompt_ids
+
+    attention_mask = torch.ones((batch_size, total_seq_len), device=target_device, dtype=torch.bool)
+    prompt_mask = torch.zeros_like(attention_mask)
+    if prompt_len:
+        prompt_mask[:, :prompt_len] = True
+
+    completion_mask = torch.zeros(
+        (batch_size, completion_len), device=target_device, dtype=torch.bool
+    )
+    total_completion_tokens = batch_size * completion_len
+    valid_count = int(round(total_completion_tokens * valid_density))
+    if valid_count:
+        order = torch.randperm(total_completion_tokens, device=target_device, generator=generator)
+        completion_mask.reshape(-1)[order[:valid_count]] = True
+
+    attention_completion = attention_mask[:, prompt_len:]
+    attention_completion.copy_(completion_mask)
+
+    token_ids = input_ids[:, prompt_len:].clone()
+    rewards = torch.randn((batch_size,), device=target_device, generator=generator, dtype=dtype)
+    advantages = torch.randn(
+        (batch_size, completion_len), device=target_device, generator=generator, dtype=dtype
+    )
+    old_logps = torch.randn(
+        (batch_size, completion_len), device=target_device, generator=generator, dtype=dtype
+    )
+    ref_logps = torch.randn(
+        (batch_size, completion_len), device=target_device, generator=generator, dtype=dtype
+    )
+
+    valid_indices = completion_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
+
+    metadata: dict[str, Any] = {
+        "num_prompts": num_prompts,
+        "samples_per_prompt": samples_per_prompt,
+        "batch_size": batch_size,
+        "prompt_len": prompt_len,
+        "completion_len": completion_len,
+        "total_seq_len": total_seq_len,
+        "vocab_size": vocab_size,
+        "valid_density": valid_density,
+        "valid_tokens": int(valid_count),
+        "dtype": dtype,
+        "device": str(target_device),
+        "seed": seed,
+    }
+
+    return SyntheticRLKernelBatch(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        prompt_mask=prompt_mask,
+        completion_mask=completion_mask,
+        token_ids=token_ids,
+        rewards=rewards,
+        advantages=advantages,
+        old_logps=old_logps,
+        ref_logps=ref_logps,
+        valid_indices=valid_indices,
+        metadata=metadata,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+import os
+import pathlib
+import sys
+
+
+def _add_windows_dll_dirs():
+    if sys.platform != "win32" or not hasattr(os, "add_dll_directory"):
+        return
+
+    try:
+        import torch
+    except ImportError:
+        return
+
+    candidate_dirs = [pathlib.Path(torch.__file__).parent / "lib"]
+
+    cuda_path = os.environ.get("CUDA_PATH")
+    if cuda_path:
+        candidate_dirs.append(pathlib.Path(cuda_path) / "bin")
+
+    for path in candidate_dirs:
+        if path.exists():
+            os.add_dll_directory(str(path))
+
+
+_add_windows_dll_dirs()

--- a/tests/test_reference_ops.py
+++ b/tests/test_reference_ops.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+import pytest
+import torch
+
+from rl_engine.testing import (
+    active_token_count,
+    compute_policy_ratio,
+    compute_reference_kl,
+    masked_mean,
+    masked_sum,
+    selected_logprobs_reference,
+    summarize_kernel_drift,
+)
+
+
+def test_selected_logprobs_reference_matches_pytorch():
+    logits = torch.tensor([[[1.0, 2.0, 3.0], [0.5, -0.5, 1.5]]])
+    token_ids = torch.tensor([[2, 0]])
+
+    actual = selected_logprobs_reference(logits, token_ids)
+    expected = (
+        torch.log_softmax(logits.float(), dim=-1).gather(-1, token_ids.unsqueeze(-1)).squeeze(-1)
+    )
+
+    assert torch.allclose(actual, expected)
+    assert actual.dtype == torch.float32
+
+
+def test_selected_logprobs_reference_mask_and_dtype():
+    logits = torch.randn(2, 3, 5)
+    token_ids = torch.tensor([[0, 1, 2], [3, 4, 0]])
+    mask = torch.tensor([[True, False, True], [False, True, True]])
+
+    actual = selected_logprobs_reference(logits, token_ids, mask=mask, output_dtype=torch.float16)
+
+    assert actual.dtype == torch.float16
+    assert torch.equal(actual[~mask], torch.zeros_like(actual[~mask]))
+
+
+def test_selected_logprobs_reference_temperature():
+    logits = torch.tensor([[1.0, 3.0, -1.0]])
+    token_ids = torch.tensor([1])
+
+    actual = selected_logprobs_reference(logits, token_ids, temperature=0.5)
+    expected = (
+        torch.log_softmax(logits.float() / 0.5, dim=-1)
+        .gather(-1, token_ids.unsqueeze(-1))
+        .squeeze(-1)
+    )
+
+    assert torch.allclose(actual, expected)
+
+
+def test_selected_logprobs_reference_rejects_bad_temperature():
+    with pytest.raises(ValueError, match="temperature"):
+        selected_logprobs_reference(torch.randn(1, 3), torch.tensor([0]), temperature=0.0)
+
+
+def test_masked_reductions_ignore_inactive_tokens():
+    values = torch.tensor([[1.0, 100.0], [3.0, 4.0]])
+    mask = torch.tensor([[True, False], [True, True]])
+
+    assert torch.equal(active_token_count(mask), torch.tensor(3.0))
+    assert torch.equal(masked_sum(values, mask), torch.tensor(8.0))
+    assert torch.allclose(masked_mean(values, mask), torch.tensor(8.0 / 3.0))
+
+
+def test_ratio_kl_and_drift_helpers():
+    current = torch.tensor([[0.0, -1.0], [-2.0, -3.0]])
+    old = torch.tensor([[-0.5, -1.5], [-2.5, -3.5]])
+    ref = torch.tensor([[-0.25, -1.25], [-2.25, -3.25]])
+    mask = torch.tensor([[True, False], [True, True]])
+
+    ratio = compute_policy_ratio(current, old, mask)
+    kl = compute_reference_kl(current, ref, mask)
+
+    assert torch.equal(ratio[~mask], torch.zeros_like(ratio[~mask]))
+    assert torch.equal(kl[~mask], torch.zeros_like(kl[~mask]))
+
+    summary = summarize_kernel_drift(current + 0.1, current, mask)
+
+    assert summary["active_count"] == 3
+    assert summary["max_abs_error"] == pytest.approx(0.1, rel=1e-6)
+    assert summary["mean_abs_error"] == pytest.approx(0.1, rel=1e-6)

--- a/tests/test_rl_batch_fixture.py
+++ b/tests/test_rl_batch_fixture.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+import pytest
+import torch
+
+from rl_engine.testing import make_synthetic_rl_kernel_batch
+
+
+def test_synthetic_rl_batch_shapes_and_masks():
+    batch = make_synthetic_rl_kernel_batch(
+        num_prompts=2,
+        samples_per_prompt=3,
+        prompt_len=4,
+        completion_len=5,
+        vocab_size=128,
+        valid_density=0.6,
+        dtype=torch.float32,
+        seed=7,
+    )
+
+    assert batch.batch_size == 6
+    assert batch.total_seq_len == 9
+    assert batch.input_ids.shape == (6, 9)
+    assert batch.attention_mask.shape == (6, 9)
+    assert batch.prompt_mask.shape == (6, 9)
+    assert batch.completion_mask.shape == (6, 5)
+    assert batch.token_ids.shape == (6, 5)
+    assert batch.advantages.shape == (6, 5)
+    assert batch.old_logps.shape == (6, 5)
+    assert batch.ref_logps.shape == (6, 5)
+
+    assert batch.prompt_mask[:, :4].all()
+    assert not batch.prompt_mask[:, 4:].any()
+    assert torch.equal(batch.attention_mask[:, 4:], batch.completion_mask)
+    assert batch.valid_indices is not None
+    assert batch.valid_indices.numel() == int(round(6 * 5 * 0.6))
+
+
+def test_synthetic_rl_batch_is_deterministic():
+    kwargs = dict(
+        num_prompts=2,
+        samples_per_prompt=2,
+        prompt_len=3,
+        completion_len=4,
+        vocab_size=64,
+        valid_density=0.5,
+        dtype=torch.float32,
+        seed=123,
+    )
+    first = make_synthetic_rl_kernel_batch(**kwargs)
+    second = make_synthetic_rl_kernel_batch(**kwargs)
+
+    for field in (
+        "input_ids",
+        "attention_mask",
+        "prompt_mask",
+        "completion_mask",
+        "token_ids",
+        "rewards",
+        "advantages",
+        "old_logps",
+        "ref_logps",
+        "valid_indices",
+    ):
+        assert torch.equal(getattr(first, field), getattr(second, field))
+
+
+def test_grouped_samples_share_prompt_tokens():
+    batch = make_synthetic_rl_kernel_batch(
+        num_prompts=2,
+        samples_per_prompt=3,
+        prompt_len=4,
+        completion_len=5,
+        vocab_size=64,
+        seed=21,
+    )
+
+    prompt_tokens = batch.input_ids[:, : batch.prompt_len]
+    assert torch.equal(prompt_tokens[0], prompt_tokens[1])
+    assert torch.equal(prompt_tokens[1], prompt_tokens[2])
+    assert torch.equal(prompt_tokens[3], prompt_tokens[4])
+    assert torch.equal(prompt_tokens[4], prompt_tokens[5])
+    assert not torch.equal(prompt_tokens[0], prompt_tokens[3])
+
+
+def test_compact_completion_values_follow_valid_indices():
+    batch = make_synthetic_rl_kernel_batch(
+        num_prompts=1,
+        samples_per_prompt=2,
+        prompt_len=2,
+        completion_len=6,
+        vocab_size=32,
+        valid_density=0.5,
+        seed=9,
+    )
+    values = torch.arange(batch.batch_size * batch.completion_len).reshape(
+        batch.batch_size, batch.completion_len
+    )
+
+    compact = batch.compact_completion_values(values)
+    expected = values.reshape(-1)[batch.flat_completion_mask]
+
+    assert torch.equal(compact, expected)
+    assert torch.equal(batch.compact_token_ids(), batch.flat_token_ids[batch.flat_completion_mask])
+    assert torch.equal(
+        batch.valid_indices, batch.flat_completion_mask.nonzero(as_tuple=False).squeeze(-1)
+    )
+
+
+def test_benchmark_metadata_is_reproducible():
+    batch = make_synthetic_rl_kernel_batch(
+        num_prompts=3,
+        samples_per_prompt=2,
+        prompt_len=1,
+        completion_len=5,
+        vocab_size=100,
+        valid_density=0.4,
+        dtype=torch.float16,
+        seed=11,
+    )
+    metadata = batch.benchmark_metadata()
+
+    assert metadata["num_prompts"] == 3
+    assert metadata["samples_per_prompt"] == 2
+    assert metadata["batch_size"] == 6
+    assert metadata["prompt_len"] == 1
+    assert metadata["completion_len"] == 5
+    assert metadata["vocab_size"] == 100
+    assert metadata["valid_tokens"] == int(batch.flat_completion_mask.sum().item())
+    assert metadata["seed"] == 11
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_synthetic_rl_batch_cuda_smoke():
+    batch = make_synthetic_rl_kernel_batch(
+        num_prompts=1,
+        samples_per_prompt=1,
+        prompt_len=2,
+        completion_len=3,
+        vocab_size=16,
+        dtype=torch.float16,
+        device="cuda",
+        seed=1,
+    )
+
+    assert batch.input_ids.is_cuda
+    assert batch.completion_mask.is_cuda
+    assert batch.advantages.dtype == torch.float16

--- a/tests/test_rl_kernel_loss_step.py
+++ b/tests/test_rl_kernel_loss_step.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+import pytest
+import torch
+
+from rl_engine.testing import (
+    active_token_count,
+    compute_policy_ratio,
+    compute_reference_kl,
+    make_synthetic_rl_kernel_batch,
+    masked_mean,
+    selected_logprobs_reference,
+    summarize_kernel_drift,
+)
+
+
+def _minimal_rl_loss(
+    current_logps,
+    old_logps,
+    ref_logps,
+    advantages,
+    completion_mask,
+    eps=0.2,
+    beta=0.01,
+):
+    ratio = compute_policy_ratio(current_logps, old_logps, completion_mask)
+    unclipped = ratio * advantages.float()
+    clipped = torch.clamp(ratio, 1.0 - eps, 1.0 + eps) * advantages.float()
+    policy_loss = -torch.minimum(unclipped, clipped)
+    kl = compute_reference_kl(current_logps, ref_logps, completion_mask)
+    loss_terms = policy_loss + beta * kl
+    loss = masked_mean(loss_terms, completion_mask)
+    return {
+        "loss": loss,
+        "ratio": ratio,
+        "kl": kl,
+        "active_tokens": active_token_count(completion_mask),
+    }
+
+
+def _make_loss_inputs(device="cpu", dtype=torch.float32):
+    batch = make_synthetic_rl_kernel_batch(
+        num_prompts=2,
+        samples_per_prompt=2,
+        prompt_len=4,
+        completion_len=6,
+        vocab_size=64,
+        valid_density=0.75,
+        dtype=dtype,
+        device=device,
+        seed=42,
+    )
+    generator = torch.Generator(device=torch.device(device))
+    generator.manual_seed(99)
+    logits = torch.randn(
+        batch.batch_size,
+        batch.completion_len,
+        batch.metadata["vocab_size"],
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+    return batch, logits
+
+
+def test_minimal_rl_loss_step_reference_path():
+    batch, logits = _make_loss_inputs()
+
+    current_logps = selected_logprobs_reference(
+        logits,
+        batch.token_ids,
+        mask=batch.completion_mask,
+        output_dtype=torch.float32,
+    )
+    result = _minimal_rl_loss(
+        current_logps=current_logps,
+        old_logps=batch.old_logps,
+        ref_logps=batch.ref_logps,
+        advantages=batch.advantages,
+        completion_mask=batch.completion_mask,
+    )
+
+    assert torch.isfinite(result["loss"])
+    assert result["active_tokens"].item() == batch.completion_mask.sum().item()
+    assert torch.equal(
+        result["ratio"][~batch.completion_mask],
+        torch.zeros_like(result["ratio"][~batch.completion_mask]),
+    )
+    assert torch.equal(
+        result["kl"][~batch.completion_mask],
+        torch.zeros_like(result["kl"][~batch.completion_mask]),
+    )
+
+
+def test_masked_tokens_do_not_affect_minimal_loss():
+    batch, logits = _make_loss_inputs()
+    current_logps = selected_logprobs_reference(
+        logits,
+        batch.token_ids,
+        mask=batch.completion_mask,
+        output_dtype=torch.float32,
+    )
+
+    baseline = _minimal_rl_loss(
+        current_logps,
+        batch.old_logps,
+        batch.ref_logps,
+        batch.advantages,
+        batch.completion_mask,
+    )["loss"]
+
+    perturbed_current = current_logps.clone()
+    perturbed_old = batch.old_logps.clone()
+    perturbed_ref = batch.ref_logps.clone()
+    perturbed_advantages = batch.advantages.clone()
+    inactive = ~batch.completion_mask
+    perturbed_current[inactive] = 1000.0
+    perturbed_old[inactive] = -1000.0
+    perturbed_ref[inactive] = 500.0
+    perturbed_advantages[inactive] = -500.0
+
+    perturbed = _minimal_rl_loss(
+        perturbed_current,
+        perturbed_old,
+        perturbed_ref,
+        perturbed_advantages,
+        batch.completion_mask,
+    )["loss"]
+
+    assert torch.allclose(baseline, perturbed)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_minimal_rl_loss_step_fused_logp_candidate_cuda():
+    from rl_engine.kernels.registry import kernel_registry
+
+    batch, logits = _make_loss_inputs(device="cuda", dtype=torch.float16)
+
+    reference_logps = selected_logprobs_reference(
+        logits,
+        batch.token_ids,
+        mask=batch.completion_mask,
+        output_dtype=torch.float32,
+    )
+    old_logps = reference_logps - 0.01
+    ref_logps = reference_logps - 0.02
+    candidate_op = kernel_registry.get_op("logp")
+    if candidate_op.__class__.__name__ != "FusedLogpGenericOp":
+        pytest.skip("fused logp CUDA backend is unavailable")
+
+    candidate_logps = candidate_op(logits, batch.token_ids).float()
+    candidate_logps = candidate_logps.masked_fill(~batch.completion_mask, 0.0)
+
+    reference = _minimal_rl_loss(
+        reference_logps,
+        old_logps,
+        ref_logps,
+        batch.advantages,
+        batch.completion_mask,
+    )
+    candidate = _minimal_rl_loss(
+        candidate_logps,
+        old_logps,
+        ref_logps,
+        batch.advantages,
+        batch.completion_mask,
+    )
+
+    logp_drift = summarize_kernel_drift(
+        candidate_logps,
+        reference_logps,
+        batch.completion_mask,
+    )
+    ratio_drift = summarize_kernel_drift(
+        candidate["ratio"], reference["ratio"], batch.completion_mask
+    )
+    kl_drift = summarize_kernel_drift(candidate["kl"], reference["kl"], batch.completion_mask)
+
+    assert logp_drift["max_abs_error"] < 1e-2
+    assert ratio_drift["max_abs_error"] < 2e-2
+    assert kl_drift["max_abs_error"] < 2e-2
+    assert torch.allclose(
+        candidate["loss"],
+        reference["loss"],
+        atol=2e-2,
+        rtol=2e-2,
+    )


### PR DESCRIPTION
## Summary

This PR adds the minimal RL-shaped validation stack needed to test kernel behavior without a full trainer or serving runtime.

It includes:

- reusable synthetic RL batch fixtures
- explicit PyTorch reference operators for selected logprobs, masked reductions, ratio, KL, and drift summaries
- minimal RL loss-step integration tests that validate kernel output inside objective math

## What changed

- Added l_engine.testing helpers for RL-shaped synthetic batches and reference ops.
- Added fixture coverage for determinism, masks, compact valid-token indexing, CUDA smoke, and grouped prompt sampling layout.
- Added minimal loss-step tests that verify masked tokens do not leak into ratio, KL, or loss computation.
- The CUDA fused-logp candidate path now skips cleanly when the fused backend is unavailable instead of failing through a generic fallback.

## Notes

- Grouped samples now share prompt tokens within each prompt group while keeping completions independent.
- The fixture and reference APIs are intentionally generic so future RL kernel tests and benchmarks can reuse them.

## Validation

`powershell
py -3.13 -m pytest tests/test_rl_batch_fixture.py tests/test_reference_ops.py tests/test_rl_kernel_loss_step.py -q
py -3.13 -m pytest tests -q
py -3.13 -m compileall rl_engine tests benchmarks
pre-commit run --files rl_engine/testing/__init__.py rl_engine/testing/rl_batch.py rl_engine/testing/reference_ops.py tests/conftest.py tests/test_rl_batch_fixture.py tests/test_reference_ops.py tests/test_rl_kernel_loss_step.py --show-diff-on-failure
`

## Issues

Closes #27  
Closes #28  
Closes #30