### PR TITLE
feat: add Ray actor manager

### DIFF
--- a/rl_engine/executors/deepspeed_trainer.py
+++ b/rl_engine/executors/deepspeed_trainer.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+import importlib
+import time
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
+
+import torch
+
+from rl_engine.executors.training_contract import (
+    RolloutBatchMixin,
+    RolloutStageResult,
+    TorchRLTrainingConfig,
+    TrainingStageResult,
+)
+from rl_engine.testing import (
+    compute_policy_ratio,
+    compute_reference_kl,
+    masked_mean,
+    selected_logprobs_reference,
+)
+
+
+class DeepSpeedUnavailableError(RuntimeError):
+    """Raised when the optional DeepSpeed runtime cannot be imported."""
+
+
+@dataclass(frozen=True)
+class DeepSpeedTrainingConfig(TorchRLTrainingConfig):
+    """Configuration for the optional DeepSpeed training worker."""
+
+    zero_stage: int = 0
+    deepspeed_config: Mapping[str, Any] = field(default_factory=dict)
+    initialize_kwargs: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.zero_stage < 0:
+            raise ValueError("zero_stage must be >= 0")
+
+
+class DeepSpeedTrainingWorker(RolloutBatchMixin):
+    """
+    Training worker implementation backed by a real DeepSpeed engine contract.
+
+    DeepSpeed is optional for Kernel-Align, so importing this module never imports
+    DeepSpeed. The runtime is loaded only when a worker is constructed.
+    """
+
+    def __init__(self, config: Optional[DeepSpeedTrainingConfig] = None):
+        self.config = config or DeepSpeedTrainingConfig()
+        self.device = torch.device(self.config.device)
+        if self.device.type == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("CUDA training requested but torch.cuda.is_available() is false")
+
+        deepspeed = _load_deepspeed()
+        torch.manual_seed(self.config.seed)
+        self.model = torch.nn.Sequential(
+            torch.nn.Embedding(self.config.vocab_size, self.config.hidden_dim),
+            torch.nn.Linear(self.config.hidden_dim, self.config.vocab_size),
+        ).to(device=self.device)
+        self.optimizer = torch.optim.AdamW(self.model.parameters(), lr=self.config.lr)
+
+        init_result = deepspeed.initialize(
+            model=self.model,
+            model_parameters=self.model.parameters(),
+            optimizer=self.optimizer,
+            config=self._resolved_deepspeed_config(),
+            **dict(self.config.initialize_kwargs),
+        )
+        self.engine = _first_initialize_result(init_result)
+        engine_device = getattr(self.engine, "device", None)
+        if engine_device is not None:
+            self.device = torch.device(engine_device)
+
+    def train(self, rollout: RolloutStageResult) -> TrainingStageResult:
+        started_at = time.perf_counter()
+        batch, payload_metrics = self._batch_from_rollout_or_synthetic(rollout)
+
+        logits = _extract_logits(self.engine(batch.token_ids.long()))
+        current_logps = selected_logprobs_reference(
+            logits,
+            batch.token_ids,
+            mask=batch.completion_mask,
+            output_dtype=torch.float32,
+        )
+        old_logps = current_logps.detach() - 0.01
+        ref_logps = current_logps.detach() - 0.02
+        ratio = compute_policy_ratio(current_logps, old_logps, batch.completion_mask)
+        unclipped = ratio * batch.advantages.float()
+        clipped = torch.clamp(ratio, 0.8, 1.2) * batch.advantages.float()
+        policy_loss = -torch.minimum(unclipped, clipped)
+        kl = compute_reference_kl(current_logps, ref_logps, batch.completion_mask)
+        loss = masked_mean(policy_loss + 0.01 * kl, batch.completion_mask)
+
+        if hasattr(self.engine, "zero_grad"):
+            try:
+                self.engine.zero_grad(set_to_none=True)
+            except TypeError:
+                self.engine.zero_grad()
+        elif hasattr(self.optimizer, "zero_grad"):
+            self.optimizer.zero_grad(set_to_none=True)
+        self.engine.backward(loss)
+        self.engine.step()
+
+        finished_at = time.perf_counter()
+        published = rollout.weight_version + 1
+        return TrainingStageResult(
+            iteration=rollout.iteration,
+            consumed_weight_version=rollout.weight_version,
+            published_weight_version=published,
+            metrics={
+                "loss": float(loss.detach().cpu().item()),
+                "active_tokens": int(batch.completion_mask.sum().item()),
+                "payload_type": type(rollout.payload).__name__,
+                "training_backend": "deepspeed",
+                "training_device": str(self.device),
+                "deepspeed_engine": type(self.engine).__name__,
+                "deepspeed_zero_stage": self.config.zero_stage,
+                **payload_metrics,
+            },
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+    def _resolved_deepspeed_config(self) -> dict[str, Any]:
+        batch_size = max(1, self.config.num_prompts * self.config.samples_per_prompt)
+        base = {
+            "train_micro_batch_size_per_gpu": batch_size,
+            "gradient_accumulation_steps": 1,
+            "zero_optimization": {"stage": self.config.zero_stage},
+            "fp16": {"enabled": self.config.dtype == torch.float16},
+            "bf16": {"enabled": self.config.dtype == torch.bfloat16},
+        }
+        return _deep_merge(base, dict(self.config.deepspeed_config))
+
+
+def _load_deepspeed() -> Any:
+    try:
+        return importlib.import_module("deepspeed")
+    except ImportError as exc:
+        raise DeepSpeedUnavailableError(
+            "DeepSpeed is not installed or cannot be imported. Install a DeepSpeed "
+            "runtime supported by the active Python/PyTorch/CUDA environment before "
+            "running DeepSpeedTrainingWorker."
+        ) from exc
+
+
+def _first_initialize_result(init_result: Any) -> Any:
+    if isinstance(init_result, tuple):
+        if not init_result:
+            raise RuntimeError("deepspeed.initialize returned an empty tuple")
+        return init_result[0]
+    return init_result
+
+
+def _extract_logits(model_output: Any) -> torch.Tensor:
+    if isinstance(model_output, torch.Tensor):
+        return model_output
+    if isinstance(model_output, Mapping) and "logits" in model_output:
+        return model_output["logits"]
+    logits = getattr(model_output, "logits", None)
+    if logits is not None:
+        return logits
+    if isinstance(model_output, (tuple, list)) and model_output:
+        return _extract_logits(model_output[0])
+    raise TypeError(f"DeepSpeed model output does not expose logits: {type(model_output)!r}")
+
+
+def _deep_merge(base: dict[str, Any], override: Mapping[str, Any]) -> dict[str, Any]:
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged[key] = _deep_merge(dict(merged[key]), value)
+        else:
+            merged[key] = value
+    return merged

--- a/rl_engine/executors/ray_actor_manager.py
+++ b/rl_engine/executors/ray_actor_manager.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence
+
+
+class RayUnavailableError(RuntimeError):
+    """Raised when the optional Ray runtime cannot be imported."""
+
+
+@dataclass(frozen=True)
+class RayRuntimeConfig:
+    """Configuration for lazy Ray runtime initialization."""
+
+    auto_init: bool = True
+    init_kwargs: Mapping[str, Any] = field(default_factory=dict)
+    shutdown_ray_on_close: bool = False
+
+    def resolved_init_kwargs(self) -> dict[str, Any]:
+        kwargs = {"ignore_reinit_error": True}
+        kwargs.update(dict(self.init_kwargs))
+        return kwargs
+
+
+@dataclass(frozen=True)
+class RayActorOptions:
+    """Ray actor resource and lifecycle options."""
+
+    num_cpus: Optional[float] = None
+    num_gpus: Optional[float] = None
+    resources: Mapping[str, float] = field(default_factory=dict)
+    name: Optional[str] = None
+    namespace: Optional[str] = None
+    max_restarts: Optional[int] = None
+    max_task_retries: Optional[int] = None
+    scheduling_strategy: Any = None
+    lifetime: Optional[str] = None
+
+    def to_ray_options(self) -> dict[str, Any]:
+        options: dict[str, Any] = {}
+        for key in (
+            "num_cpus",
+            "num_gpus",
+            "name",
+            "namespace",
+            "max_restarts",
+            "max_task_retries",
+            "scheduling_strategy",
+            "lifetime",
+        ):
+            value = getattr(self, key)
+            if value is not None:
+                options[key] = value
+        if self.resources:
+            options["resources"] = dict(self.resources)
+        return options
+
+
+@dataclass(frozen=True)
+class RayWorkerSpec:
+    """Factory and constructor arguments for a worker hosted in a Ray actor."""
+
+    worker_factory: Any
+    args: Sequence[Any] = field(default_factory=tuple)
+    kwargs: Mapping[str, Any] = field(default_factory=dict)
+    actor_options: RayActorOptions = field(default_factory=RayActorOptions)
+
+
+class RayActorManager:
+    """Create, wrap, and clean up Ray actors for Kernel-Align workers."""
+
+    def __init__(
+        self,
+        runtime_config: Optional[RayRuntimeConfig] = None,
+        *,
+        ray_module: Any = None,
+    ):
+        self.runtime_config = runtime_config or RayRuntimeConfig()
+        self._ray = ray_module
+        self._actors: list[Any] = []
+
+    def __enter__(self) -> RayActorManager:
+        self.ensure_runtime()
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.shutdown()
+
+    def ensure_runtime(self) -> Any:
+        if self._ray is None:
+            self._ray = _load_ray()
+        if self.runtime_config.auto_init and not self._ray.is_initialized():
+            self._ray.init(**self.runtime_config.resolved_init_kwargs())
+        return self._ray
+
+    def create_worker_actor(self, spec: RayWorkerSpec) -> Any:
+        ray = self.ensure_runtime()
+        remote_actor = ray.remote(_RayWorkerActor)
+        options = spec.actor_options.to_ray_options()
+        if options:
+            remote_actor = remote_actor.options(**options)
+        actor = remote_actor.remote(
+            spec.worker_factory,
+            *tuple(spec.args),
+            **dict(spec.kwargs),
+        )
+        self._actors.append(actor)
+        return actor
+
+    def create_rollout_worker(self, spec: RayWorkerSpec) -> RayRolloutWorkerHandle:
+        actor = self.create_worker_actor(spec)
+        return RayRolloutWorkerHandle(actor, self.ensure_runtime())
+
+    def create_training_worker(self, spec: RayWorkerSpec) -> RayTrainingWorkerHandle:
+        actor = self.create_worker_actor(spec)
+        return RayTrainingWorkerHandle(actor, self.ensure_runtime())
+
+    def health_check(self) -> list[Mapping[str, Any]]:
+        ray = self.ensure_runtime()
+        return [ray.get(actor.health_check.remote()) for actor in self._actors]
+
+    def shutdown(self) -> None:
+        if self._ray is None:
+            return
+        for actor in reversed(self._actors):
+            self._ray.kill(actor, no_restart=True)
+        self._actors.clear()
+        if self.runtime_config.shutdown_ray_on_close and hasattr(self._ray, "shutdown"):
+            self._ray.shutdown()
+
+
+class RayRolloutWorkerHandle:
+    """Synchronous `RolloutWorker` protocol adapter for a Ray actor."""
+
+    def __init__(self, actor: Any, ray_module: Any):
+        self.actor = actor
+        self._ray = ray_module
+
+    def rollout(self, spec: Any) -> Any:
+        return self._ray.get(self.actor.rollout.remote(spec))
+
+
+class RayTrainingWorkerHandle:
+    """Synchronous `TrainingWorker` protocol adapter for a Ray actor."""
+
+    def __init__(self, actor: Any, ray_module: Any):
+        self.actor = actor
+        self._ray = ray_module
+
+    def train(self, rollout: Any) -> Any:
+        return self._ray.get(self.actor.train.remote(rollout))
+
+
+class _RayWorkerActor:
+    """Ray-hosted shim around an arbitrary local Kernel-Align worker."""
+
+    def __init__(self, worker_factory: Any, *args: Any, **kwargs: Any):
+        if callable(worker_factory):
+            self.worker = worker_factory(*args, **kwargs)
+        else:
+            if args or kwargs:
+                raise TypeError("constructor args require a callable worker_factory")
+            self.worker = worker_factory
+
+    def rollout(self, spec: Any) -> Any:
+        return self.worker.rollout(spec)
+
+    def train(self, rollout: Any) -> Any:
+        return self.worker.train(rollout)
+
+    def health_check(self) -> Mapping[str, Any]:
+        return {
+            "status": "ok",
+            "worker_type": type(self.worker).__name__,
+        }
+
+
+def _load_ray() -> Any:
+    try:
+        return importlib.import_module("ray")
+    except ImportError as exc:
+        raise RayUnavailableError(
+            "Ray is not installed or cannot be imported. Install a Ray runtime "
+            "supported by the active Python/platform environment before creating "
+            "Ray actors."
+        ) from exc

--- a/rl_engine/executors/training_contract.py
+++ b/rl_engine/executors/training_contract.py
@@ -1,0 +1,289 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Protocol, Sequence
+
+import torch
+
+from rl_engine.testing import (
+    SyntheticRLKernelBatch,
+    make_synthetic_rl_kernel_batch,
+)
+
+
+@dataclass(frozen=True)
+class RolloutStageResult:
+    """Result consumed by training workers."""
+
+    iteration: int
+    weight_version: int
+    payload: Any
+    started_at: float
+    finished_at: float
+    metrics: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def duration_seconds(self) -> float:
+        return self.finished_at - self.started_at
+
+
+@dataclass(frozen=True)
+class TrainingStageResult:
+    """Result produced by training workers."""
+
+    iteration: int
+    consumed_weight_version: int
+    published_weight_version: Optional[int]
+    metrics: Mapping[str, Any]
+    started_at: float
+    finished_at: float
+
+    @property
+    def duration_seconds(self) -> float:
+        return self.finished_at - self.started_at
+
+
+class TrainingWorker(Protocol):
+    def train(self, rollout: RolloutStageResult) -> TrainingStageResult: ...
+
+
+@dataclass(frozen=True)
+class TorchRLTrainingConfig:
+    """Config shared by local and DeepSpeed training workers."""
+
+    num_prompts: int = 1
+    samples_per_prompt: int = 2
+    prompt_len: int = 4
+    completion_len: int = 8
+    vocab_size: int = 64
+    hidden_dim: int = 32
+    valid_density: float = 0.75
+    lr: float = 1e-3
+    device: str = "cpu"
+    dtype: torch.dtype = torch.float32
+    seed: int = 0
+    min_completion_len: int = 1
+
+
+class RolloutBatchMixin:
+    config: TorchRLTrainingConfig
+    device: torch.device
+
+    def _batch_from_rollout_or_synthetic(
+        self,
+        rollout: RolloutStageResult,
+    ) -> tuple[SyntheticRLKernelBatch, dict[str, Any]]:
+        token_groups = extract_rollout_token_groups(rollout.payload)
+        if token_groups:
+            return self._batch_from_token_groups(token_groups, rollout), {
+                "training_data_source": "rollout_payload",
+                "rollout_sequences": len(token_groups),
+                "rollout_tokens": sum(len(group) for group in token_groups),
+            }
+
+        seed = self.config.seed + int(rollout.iteration)
+        batch = make_synthetic_rl_kernel_batch(
+            num_prompts=self.config.num_prompts,
+            samples_per_prompt=self.config.samples_per_prompt,
+            prompt_len=self.config.prompt_len,
+            completion_len=self.config.completion_len,
+            vocab_size=self.config.vocab_size,
+            valid_density=self.config.valid_density,
+            dtype=self.config.dtype,
+            device=self.device,
+            seed=seed,
+        )
+        return batch, {
+            "training_data_source": "synthetic_fallback",
+            "rollout_sequences": 0,
+            "rollout_tokens": 0,
+        }
+
+    def _batch_from_token_groups(
+        self,
+        token_groups: Sequence[Sequence[int]],
+        rollout: RolloutStageResult,
+    ) -> SyntheticRLKernelBatch:
+        completion_len = max(
+            self.config.min_completion_len,
+            min(self.config.completion_len, max(len(group) for group in token_groups)),
+        )
+        batch_size = len(token_groups)
+        token_ids = torch.zeros(
+            (batch_size, completion_len),
+            device=self.device,
+            dtype=torch.long,
+        )
+        completion_mask = torch.zeros(
+            (batch_size, completion_len),
+            device=self.device,
+            dtype=torch.bool,
+        )
+        for row, group in enumerate(token_groups):
+            clipped = [int(token) % self.config.vocab_size for token in group[:completion_len]]
+            if not clipped:
+                continue
+            values = torch.tensor(clipped, device=self.device, dtype=torch.long)
+            token_ids[row, : values.numel()] = values
+            completion_mask[row, : values.numel()] = True
+
+        prompt_tokens = torch.zeros(
+            (batch_size, self.config.prompt_len),
+            device=self.device,
+            dtype=torch.long,
+        )
+        input_ids = torch.cat([prompt_tokens, token_ids], dim=1)
+        prompt_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+        if self.config.prompt_len:
+            prompt_mask[:, : self.config.prompt_len] = True
+        attention_mask = torch.cat(
+            [
+                prompt_mask[:, : self.config.prompt_len],
+                completion_mask,
+            ],
+            dim=1,
+        )
+
+        generator = torch.Generator(device=self.device)
+        generator.manual_seed(self.config.seed + int(rollout.iteration))
+        advantages = torch.randn(
+            (batch_size, completion_len),
+            device=self.device,
+            generator=generator,
+            dtype=self.config.dtype,
+        )
+        old_logps = torch.zeros(
+            (batch_size, completion_len),
+            device=self.device,
+            dtype=self.config.dtype,
+        )
+        ref_logps = torch.zeros(
+            (batch_size, completion_len),
+            device=self.device,
+            dtype=self.config.dtype,
+        )
+        rewards = torch.randn(
+            (batch_size,),
+            device=self.device,
+            generator=generator,
+            dtype=self.config.dtype,
+        )
+        valid_indices = completion_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
+        metadata: dict[str, Any] = {
+            "num_prompts": batch_size,
+            "samples_per_prompt": 1,
+            "batch_size": batch_size,
+            "prompt_len": self.config.prompt_len,
+            "completion_len": completion_len,
+            "total_seq_len": self.config.prompt_len + completion_len,
+            "vocab_size": self.config.vocab_size,
+            "valid_density": float(completion_mask.float().mean().item()),
+            "valid_tokens": int(completion_mask.sum().item()),
+            "dtype": self.config.dtype,
+            "device": str(self.device),
+            "seed": self.config.seed + int(rollout.iteration),
+            "source": "rollout_payload",
+        }
+        return SyntheticRLKernelBatch(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            prompt_mask=prompt_mask,
+            completion_mask=completion_mask,
+            token_ids=token_ids,
+            rewards=rewards,
+            advantages=advantages,
+            old_logps=old_logps,
+            ref_logps=ref_logps,
+            valid_indices=valid_indices,
+            metadata=metadata,
+        )
+
+
+def make_rollout_result(
+    *,
+    iteration: int,
+    weight_version: int,
+    payload: Any,
+    metrics: Optional[Mapping[str, Any]] = None,
+) -> RolloutStageResult:
+    now = time.perf_counter()
+    return RolloutStageResult(
+        iteration=iteration,
+        weight_version=weight_version,
+        payload=payload,
+        started_at=now,
+        finished_at=time.perf_counter(),
+        metrics=dict(metrics or {}),
+    )
+
+
+def extract_rollout_token_groups(payload: Any) -> list[list[int]]:
+    """Extract generated token ids from Kernel-Align/vLLM-style rollout payloads."""
+
+    groups: list[list[int]] = []
+    if not isinstance(payload, Mapping):
+        return groups
+
+    normalized_outputs = payload.get("normalized_outputs")
+    if isinstance(normalized_outputs, Sequence) and not isinstance(
+        normalized_outputs, (str, bytes)
+    ):
+        for group in normalized_outputs:
+            if not isinstance(group, Sequence) or isinstance(group, (str, bytes)):
+                continue
+            for candidate in group:
+                token_ids = _candidate_token_ids(candidate)
+                if token_ids:
+                    groups.append(token_ids)
+        if groups:
+            return groups
+
+    outputs = payload.get("outputs")
+    if isinstance(outputs, Sequence) and not isinstance(outputs, (str, bytes)):
+        for group in outputs:
+            if isinstance(group, Sequence) and not isinstance(group, (str, bytes)):
+                candidates = group
+            else:
+                candidates = [group]
+            for candidate in candidates:
+                token_ids = _candidate_token_ids(candidate)
+                if token_ids:
+                    groups.append(token_ids)
+    return groups
+
+
+def _candidate_token_ids(candidate: Any) -> list[int]:
+    if candidate is None:
+        return []
+    if isinstance(candidate, Mapping):
+        nested_outputs = candidate.get("outputs")
+        if isinstance(nested_outputs, Sequence) and not isinstance(nested_outputs, (str, bytes)):
+            for nested in nested_outputs:
+                token_ids = _candidate_token_ids(nested)
+                if token_ids:
+                    return token_ids
+        value = candidate.get("token_ids")
+        return _copy_int_list(value)
+
+    value = getattr(candidate, "token_ids", None)
+    if value is not None:
+        return _copy_int_list(value)
+    nested_outputs = getattr(candidate, "outputs", None)
+    if isinstance(nested_outputs, Sequence) and not isinstance(nested_outputs, (str, bytes)):
+        for nested in nested_outputs:
+            token_ids = _candidate_token_ids(nested)
+            if token_ids:
+                return token_ids
+    return []
+
+
+def _copy_int_list(value: Any) -> list[int]:
+    if isinstance(value, torch.Tensor):
+        return [int(item) for item in value.detach().cpu().reshape(-1).tolist()]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [int(item) for item in value]
+    return []

--- a/rl_engine/testing/__init__.py
+++ b/rl_engine/testing/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+"""Testing helpers for RL-shaped kernel validation."""
+
+from .rl_batch import SyntheticRLKernelBatch, make_synthetic_rl_kernel_batch
+from .reference_ops import (
+    active_token_count,
+    compute_policy_ratio,
+    compute_reference_kl,
+    masked_mean,
+    masked_sum,
+    selected_logprobs_reference,
+    summarize_kernel_drift,
+)
+
+__all__ = [
+    "SyntheticRLKernelBatch",
+    "active_token_count",
+    "compute_policy_ratio",
+    "compute_reference_kl",
+    "make_synthetic_rl_kernel_batch",
+    "masked_mean",
+    "masked_sum",
+    "selected_logprobs_reference",
+    "summarize_kernel_drift",
+]

--- a/rl_engine/testing/reference_ops.py
+++ b/rl_engine/testing/reference_ops.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+def _bool_mask(mask: torch.Tensor, *, device: torch.device) -> torch.Tensor:
+    return mask.to(device=device, dtype=torch.bool)
+
+
+def selected_logprobs_reference(
+    logits: torch.Tensor,
+    token_ids: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    temperature: float = 1.0,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Reference selected-token logprobs for RL kernel validation."""
+
+    if temperature <= 0.0:
+        raise ValueError("temperature must be greater than zero")
+    if logits.shape[:-1] != token_ids.shape:
+        raise ValueError(
+            f"logits leading shape {tuple(logits.shape[:-1])} must match "
+            f"token_ids shape {tuple(token_ids.shape)}"
+        )
+    if mask is not None and mask.shape != token_ids.shape:
+        raise ValueError(f"mask shape {tuple(mask.shape)} must match token_ids shape")
+
+    scaled_logits = logits.float() / float(temperature)
+    log_probs = torch.log_softmax(scaled_logits, dim=-1)
+    selected = torch.gather(log_probs, dim=-1, index=token_ids.long().unsqueeze(-1)).squeeze(-1)
+
+    if mask is not None:
+        selected = selected.masked_fill(~_bool_mask(mask, device=selected.device), 0.0)
+
+    return selected.to(dtype=output_dtype)
+
+
+def masked_sum(values: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
+    """Sum values while ignoring masked-out entries."""
+
+    values_fp32 = values.float()
+    if mask is None:
+        return values_fp32.sum()
+    return values_fp32.masked_fill(~_bool_mask(mask, device=values.device), 0.0).sum()
+
+
+def active_token_count(
+    mask: torch.Tensor | None, values: torch.Tensor | None = None
+) -> torch.Tensor:
+    """Return the number of active tokens as an fp32 scalar tensor."""
+
+    if mask is None:
+        if values is None:
+            raise ValueError("values must be provided when mask is None")
+        return torch.tensor(values.numel(), device=values.device, dtype=torch.float32)
+    return _bool_mask(mask, device=mask.device).sum().to(dtype=torch.float32)
+
+
+def masked_mean(
+    values: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Mean values while ignoring masked-out entries."""
+
+    denom = active_token_count(mask, values).clamp_min(eps)
+    return masked_sum(values, mask) / denom
+
+
+def compute_policy_ratio(
+    current_logps: torch.Tensor,
+    old_logps: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute exp(current - old) with masked entries set to zero."""
+
+    ratio = torch.exp(current_logps.float() - old_logps.float())
+    if mask is not None:
+        ratio = ratio.masked_fill(~_bool_mask(mask, device=ratio.device), 0.0)
+    return ratio
+
+
+def compute_reference_kl(
+    current_logps: torch.Tensor,
+    ref_logps: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Compute the common GRPO/PPO reference KL approximation."""
+
+    diff = ref_logps.float() - current_logps.float()
+    kl = torch.exp(diff) - diff - 1.0
+    if mask is not None:
+        kl = kl.masked_fill(~_bool_mask(mask, device=kl.device), 0.0)
+    return kl
+
+
+def summarize_kernel_drift(
+    candidate: torch.Tensor,
+    reference: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> dict[str, Any]:
+    """Summarize candidate-vs-reference drift for benchmark/test output."""
+
+    if candidate.shape != reference.shape:
+        raise ValueError(
+            f"candidate shape {tuple(candidate.shape)} must match reference shape "
+            f"{tuple(reference.shape)}"
+        )
+
+    diff = (candidate.float() - reference.float()).abs()
+    if mask is not None:
+        active = _bool_mask(mask, device=diff.device)
+        active_diff = diff[active]
+        active_count = int(active.sum().item())
+    else:
+        active_diff = diff.reshape(-1)
+        active_count = int(diff.numel())
+
+    if active_count == 0:
+        max_abs = 0.0
+        mean_abs = 0.0
+    else:
+        max_abs = float(active_diff.max().item())
+        mean_abs = float(active_diff.mean().item())
+
+    return {
+        "max_abs_error": max_abs,
+        "mean_abs_error": mean_abs,
+        "active_count": active_count,
+    }

--- a/rl_engine/testing/rl_batch.py
+++ b/rl_engine/testing/rl_batch.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass(frozen=True)
+class SyntheticRLKernelBatch:
+    """Synthetic RL-shaped tensors shared by kernel tests and benchmarks."""
+
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    prompt_mask: torch.Tensor
+    completion_mask: torch.Tensor
+    token_ids: torch.Tensor
+    rewards: torch.Tensor
+    advantages: torch.Tensor
+    old_logps: torch.Tensor
+    ref_logps: torch.Tensor
+    valid_indices: torch.Tensor | None
+    metadata: dict[str, Any]
+
+    @property
+    def batch_size(self) -> int:
+        return int(self.input_ids.size(0))
+
+    @property
+    def total_seq_len(self) -> int:
+        return int(self.input_ids.size(1))
+
+    @property
+    def prompt_len(self) -> int:
+        return int(self.metadata["prompt_len"])
+
+    @property
+    def completion_len(self) -> int:
+        return int(self.metadata["completion_len"])
+
+    @property
+    def flat_completion_mask(self) -> torch.Tensor:
+        return self.completion_mask.reshape(-1)
+
+    @property
+    def flat_token_ids(self) -> torch.Tensor:
+        return self.token_ids.reshape(-1)
+
+    def dense_completion_token_ids(self) -> torch.Tensor:
+        return self.token_ids
+
+    def dense_completion_values(self, values: torch.Tensor) -> torch.Tensor:
+        expected_shape = (self.batch_size, self.completion_len)
+        if tuple(values.shape[:2]) != expected_shape:
+            raise ValueError(
+                f"expected leading shape {expected_shape}, got {tuple(values.shape[:2])}"
+            )
+        return values
+
+    def compact_completion_values(self, values: torch.Tensor) -> torch.Tensor:
+        dense = self.dense_completion_values(values)
+        return dense.reshape(-1, *dense.shape[2:])[self.flat_completion_mask]
+
+    def compact_token_ids(self) -> torch.Tensor:
+        return self.flat_token_ids[self.flat_completion_mask]
+
+    def benchmark_metadata(self) -> dict[str, Any]:
+        return {
+            "num_prompts": self.metadata["num_prompts"],
+            "samples_per_prompt": self.metadata["samples_per_prompt"],
+            "batch_size": self.batch_size,
+            "prompt_len": self.prompt_len,
+            "completion_len": self.completion_len,
+            "total_seq_len": self.total_seq_len,
+            "vocab_size": self.metadata["vocab_size"],
+            "valid_density": self.metadata["valid_density"],
+            "valid_tokens": int(self.flat_completion_mask.sum().item()),
+            "dtype": str(self.metadata["dtype"]),
+            "device": str(self.input_ids.device),
+            "seed": self.metadata["seed"],
+        }
+
+
+def make_synthetic_rl_kernel_batch(
+    *,
+    num_prompts: int,
+    samples_per_prompt: int,
+    prompt_len: int,
+    completion_len: int,
+    vocab_size: int,
+    valid_density: float = 1.0,
+    dtype: torch.dtype = torch.float32,
+    device: torch.device | str = "cpu",
+    seed: int = 0,
+) -> SyntheticRLKernelBatch:
+    """Create deterministic RL-shaped tensors for kernel tests."""
+
+    if num_prompts <= 0:
+        raise ValueError("num_prompts must be greater than zero")
+    if samples_per_prompt <= 0:
+        raise ValueError("samples_per_prompt must be greater than zero")
+    if prompt_len < 0:
+        raise ValueError("prompt_len must be non-negative")
+    if completion_len <= 0:
+        raise ValueError("completion_len must be greater than zero")
+    if vocab_size <= 1:
+        raise ValueError("vocab_size must be greater than one")
+    if not 0.0 <= valid_density <= 1.0:
+        raise ValueError("valid_density must be in [0.0, 1.0]")
+
+    target_device = torch.device(device)
+    batch_size = num_prompts * samples_per_prompt
+    total_seq_len = prompt_len + completion_len
+
+    generator = torch.Generator(device=target_device)
+    generator.manual_seed(seed)
+
+    input_ids = torch.randint(
+        low=0,
+        high=vocab_size,
+        size=(batch_size, total_seq_len),
+        device=target_device,
+        generator=generator,
+        dtype=torch.long,
+    )
+    if prompt_len:
+        prompt_ids = torch.randint(
+            low=0,
+            high=vocab_size,
+            size=(num_prompts, prompt_len),
+            device=target_device,
+            generator=generator,
+            dtype=torch.long,
+        )
+        shared_prompt_ids = prompt_ids.repeat_interleave(samples_per_prompt, dim=0)
+        input_ids[:, :prompt_len] = shared_prompt_ids
+
+    attention_mask = torch.ones((batch_size, total_seq_len), device=target_device, dtype=torch.bool)
+    prompt_mask = torch.zeros_like(attention_mask)
+    if prompt_len:
+        prompt_mask[:, :prompt_len] = True
+
+    completion_mask = torch.zeros(
+        (batch_size, completion_len), device=target_device, dtype=torch.bool
+    )
+    total_completion_tokens = batch_size * completion_len
+    valid_count = int(round(total_completion_tokens * valid_density))
+    if valid_count:
+        order = torch.randperm(total_completion_tokens, device=target_device, generator=generator)
+        completion_mask.reshape(-1)[order[:valid_count]] = True
+
+    attention_completion = attention_mask[:, prompt_len:]
+    attention_completion.copy_(completion_mask)
+
+    token_ids = input_ids[:, prompt_len:].clone()
+    rewards = torch.randn((batch_size,), device=target_device, generator=generator, dtype=dtype)
+    advantages = torch.randn(
+        (batch_size, completion_len), device=target_device, generator=generator, dtype=dtype
+    )
+    old_logps = torch.randn(
+        (batch_size, completion_len), device=target_device, generator=generator, dtype=dtype
+    )
+    ref_logps = torch.randn(
+        (batch_size, completion_len), device=target_device, generator=generator, dtype=dtype
+    )
+
+    valid_indices = completion_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
+
+    metadata: dict[str, Any] = {
+        "num_prompts": num_prompts,
+        "samples_per_prompt": samples_per_prompt,
+        "batch_size": batch_size,
+        "prompt_len": prompt_len,
+        "completion_len": completion_len,
+        "total_seq_len": total_seq_len,
+        "vocab_size": vocab_size,
+        "valid_density": valid_density,
+        "valid_tokens": int(valid_count),
+        "dtype": dtype,
+        "device": str(target_device),
+        "seed": seed,
+    }
+
+    return SyntheticRLKernelBatch(
+        input_ids=input_ids,
+        attention_mask=attention_mask,
+        prompt_mask=prompt_mask,
+        completion_mask=completion_mask,
+        token_ids=token_ids,
+        rewards=rewards,
+        advantages=advantages,
+        old_logps=old_logps,
+        ref_logps=ref_logps,
+        valid_indices=valid_indices,
+        metadata=metadata,
+    )

--- a/tests/test_deepspeed_training_worker.py
+++ b/tests/test_deepspeed_training_worker.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+import importlib
+import math
+import sys
+import time
+
+import pytest
+
+from rl_engine.executors.training_contract import RolloutStageResult
+
+
+class FakeDeepSpeedEngine:
+    def __init__(self, model, optimizer):
+        self.model = model
+        self.optimizer = optimizer
+        self.forward_calls = 0
+        self.backward_calls = 0
+        self.step_calls = 0
+        self.zero_grad_calls = 0
+
+    def __call__(self, *args, **kwargs):
+        self.forward_calls += 1
+        return self.model(*args, **kwargs)
+
+    def zero_grad(self, *args, **kwargs):
+        self.zero_grad_calls += 1
+        self.optimizer.zero_grad(*args, **kwargs)
+
+    def backward(self, loss):
+        self.backward_calls += 1
+        loss.backward()
+
+    def step(self):
+        self.step_calls += 1
+        self.optimizer.step()
+
+
+class FakeDeepSpeedModule:
+    def __init__(self):
+        self.initialize_calls = []
+        self.engines = []
+
+    def initialize(self, **kwargs):
+        self.initialize_calls.append(kwargs)
+        engine = FakeDeepSpeedEngine(kwargs["model"], kwargs["optimizer"])
+        self.engines.append(engine)
+        return engine, kwargs["optimizer"], None, None
+
+
+def _install_fake_deepspeed(monkeypatch):
+    fake = FakeDeepSpeedModule()
+    monkeypatch.setitem(sys.modules, "deepspeed", fake)
+    return fake
+
+
+def _rollout(iteration=2, weight_version=9):
+    return RolloutStageResult(
+        iteration=iteration,
+        weight_version=weight_version,
+        payload={
+            "normalized_outputs": [
+                [{"token_ids": [3, 4, 5], "text": "abc"}],
+                [{"token_ids": [6, 7, 8], "text": "def"}],
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+
+def test_importing_module_does_not_import_deepspeed(monkeypatch):
+    monkeypatch.delitem(sys.modules, "deepspeed", raising=False)
+
+    module = importlib.import_module("rl_engine.executors.deepspeed_trainer")
+
+    assert module.DeepSpeedTrainingWorker is not None
+    assert "deepspeed" not in sys.modules
+
+
+def test_missing_deepspeed_raises_explicit_blocker(monkeypatch):
+    from rl_engine.executors import deepspeed_trainer
+
+    original_import_module = importlib.import_module
+
+    def fail_import(name, package=None):
+        if name == "deepspeed":
+            raise ImportError("no deepspeed here")
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(deepspeed_trainer.importlib, "import_module", fail_import)
+
+    with pytest.raises(deepspeed_trainer.DeepSpeedUnavailableError, match="DeepSpeed"):
+        deepspeed_trainer.DeepSpeedTrainingWorker()
+
+
+def test_deepspeed_training_worker_uses_engine_backward_and_step(monkeypatch):
+    fake = _install_fake_deepspeed(monkeypatch)
+    from rl_engine.executors.deepspeed_trainer import (
+        DeepSpeedTrainingConfig,
+        DeepSpeedTrainingWorker,
+    )
+
+    worker = DeepSpeedTrainingWorker(
+        DeepSpeedTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=2,
+            completion_len=3,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=5,
+            deepspeed_config={
+                "zero_optimization": {"stage": 1},
+                "gradient_accumulation_steps": 2,
+            },
+        )
+    )
+    result = worker.train(_rollout())
+
+    assert len(fake.initialize_calls) == 1
+    init_call = fake.initialize_calls[0]
+    assert init_call["model"] is worker.model
+    assert init_call["optimizer"] is worker.optimizer
+    assert init_call["config"]["zero_optimization"]["stage"] == 1
+    assert init_call["config"]["gradient_accumulation_steps"] == 2
+
+    engine = fake.engines[0]
+    assert engine.forward_calls == 1
+    assert engine.zero_grad_calls == 1
+    assert engine.backward_calls == 1
+    assert engine.step_calls == 1
+
+    assert result.iteration == 2
+    assert result.consumed_weight_version == 9
+    assert result.published_weight_version == 10
+    assert result.metrics["training_backend"] == "deepspeed"
+    assert result.metrics["training_data_source"] == "rollout_payload"
+    assert result.metrics["rollout_sequences"] == 2
+    assert result.metrics["rollout_tokens"] == 6
+    assert math.isfinite(result.metrics["loss"])
+
+
+def test_deepspeed_training_worker_synthetic_fallback(monkeypatch):
+    _install_fake_deepspeed(monkeypatch)
+    from rl_engine.executors.deepspeed_trainer import (
+        DeepSpeedTrainingConfig,
+        DeepSpeedTrainingWorker,
+    )
+
+    worker = DeepSpeedTrainingWorker(
+        DeepSpeedTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=1,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            seed=11,
+        )
+    )
+    result = worker.train(
+        RolloutStageResult(
+            iteration=0,
+            weight_version=4,
+            payload={"normalized_outputs": []},
+            started_at=time.perf_counter(),
+            finished_at=time.perf_counter(),
+        )
+    )
+
+    assert result.iteration == 0
+    assert result.consumed_weight_version == 4
+    assert result.published_weight_version == 5
+    assert result.metrics["training_backend"] == "deepspeed"
+    assert result.metrics["training_data_source"] == "synthetic_fallback"

--- a/tests/test_ray_actor_manager.py
+++ b/tests/test_ray_actor_manager.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+import importlib
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import pytest
+
+from rl_engine.executors.training_contract import (
+    RolloutStageResult,
+    TrainingStageResult,
+)
+
+
+@dataclass(frozen=True)
+class IterationSpec:
+    iteration: int
+    weight_version: int = 0
+    prompts: Sequence[Any] = ()
+
+
+class FakeObjectRef:
+    def __init__(self, value):
+        self.value = value
+
+
+class FakeRemoteMethod:
+    def __init__(self, method):
+        self.method = method
+        self.remote_calls = []
+
+    def remote(self, *args, **kwargs):
+        self.remote_calls.append((args, kwargs))
+        return FakeObjectRef(self.method(*args, **kwargs))
+
+
+class FakeActorHandle:
+    def __init__(self, instance, options):
+        self.instance = instance
+        self.options = options
+
+    def __getattr__(self, name):
+        return FakeRemoteMethod(getattr(self.instance, name))
+
+
+class FakeRemoteActorClass:
+    def __init__(self, fake_ray, actor_class, options=None):
+        self.fake_ray = fake_ray
+        self.actor_class = actor_class
+        self._options = dict(options or {})
+
+    def options(self, **kwargs):
+        merged = dict(self._options)
+        merged.update(kwargs)
+        self.fake_ray.option_calls.append(merged)
+        return FakeRemoteActorClass(self.fake_ray, self.actor_class, merged)
+
+    def remote(self, *args, **kwargs):
+        actor = FakeActorHandle(self.actor_class(*args, **kwargs), dict(self._options))
+        self.fake_ray.actors.append(actor)
+        return actor
+
+
+class FakeRayModule:
+    def __init__(self):
+        self.initialized = False
+        self.init_calls = []
+        self.option_calls = []
+        self.actors = []
+        self.get_calls = []
+        self.kill_calls = []
+        self.shutdown_calls = 0
+
+    def is_initialized(self):
+        return self.initialized
+
+    def init(self, **kwargs):
+        self.initialized = True
+        self.init_calls.append(kwargs)
+
+    def remote(self, actor_class):
+        return FakeRemoteActorClass(self, actor_class)
+
+    def get(self, ref):
+        self.get_calls.append(ref)
+        return ref.value
+
+    def kill(self, actor, no_restart=True):
+        self.kill_calls.append((actor, no_restart))
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+        self.initialized = False
+
+
+class FakeRolloutWorker:
+    def __init__(self, label="ray-rollout"):
+        self.label = label
+
+    def rollout(self, spec):
+        started = time.perf_counter()
+        return RolloutStageResult(
+            iteration=spec.iteration,
+            weight_version=spec.weight_version,
+            payload={"label": self.label, "prompts": list(spec.prompts)},
+            started_at=started,
+            finished_at=time.perf_counter(),
+            metrics={"worker": self.label},
+        )
+
+
+class FakeTrainingWorker:
+    def __init__(self, publish_delta=1):
+        self.publish_delta = publish_delta
+
+    def train(self, rollout):
+        started = time.perf_counter()
+        return TrainingStageResult(
+            iteration=rollout.iteration,
+            consumed_weight_version=rollout.weight_version,
+            published_weight_version=rollout.weight_version + self.publish_delta,
+            metrics={"worker": "ray-training"},
+            started_at=started,
+            finished_at=time.perf_counter(),
+        )
+
+
+def test_importing_module_does_not_import_ray(monkeypatch):
+    monkeypatch.delitem(sys.modules, "ray", raising=False)
+
+    module = importlib.import_module("rl_engine.executors.ray_actor_manager")
+
+    assert module.RayActorManager is not None
+    assert "ray" not in sys.modules
+
+
+def test_missing_ray_raises_explicit_blocker(monkeypatch):
+    from rl_engine.executors import ray_actor_manager
+
+    original_import_module = importlib.import_module
+
+    def fail_import(name, package=None):
+        if name == "ray":
+            raise ImportError("no ray here")
+        return original_import_module(name, package)
+
+    monkeypatch.setattr(ray_actor_manager.importlib, "import_module", fail_import)
+
+    manager = ray_actor_manager.RayActorManager()
+    with pytest.raises(ray_actor_manager.RayUnavailableError, match="Ray"):
+        manager.create_worker_actor(ray_actor_manager.RayWorkerSpec(FakeRolloutWorker))
+
+
+def test_ray_manager_creates_actor_with_options_dispatches_and_cleans_up():
+    from rl_engine.executors.ray_actor_manager import (
+        RayActorManager,
+        RayActorOptions,
+        RayRuntimeConfig,
+        RayWorkerSpec,
+    )
+
+    fake_ray = FakeRayModule()
+    manager = RayActorManager(
+        RayRuntimeConfig(
+            auto_init=True,
+            init_kwargs={"address": "local", "namespace": "kernel-align-test"},
+            shutdown_ray_on_close=True,
+        ),
+        ray_module=fake_ray,
+    )
+    handle = manager.create_rollout_worker(
+        RayWorkerSpec(
+            FakeRolloutWorker,
+            args=("remote-rollout",),
+            actor_options=RayActorOptions(
+                num_cpus=2,
+                num_gpus=0.25,
+                resources={"accelerator_type": 1},
+                name="rollout-actor",
+                max_restarts=1,
+            ),
+        )
+    )
+    result = handle.rollout(IterationSpec(iteration=3, weight_version=8, prompts=["a", "b"]))
+
+    assert fake_ray.init_calls == [
+        {
+            "ignore_reinit_error": True,
+            "address": "local",
+            "namespace": "kernel-align-test",
+        }
+    ]
+    assert fake_ray.option_calls == [
+        {
+            "num_cpus": 2,
+            "num_gpus": 0.25,
+            "name": "rollout-actor",
+            "max_restarts": 1,
+            "resources": {"accelerator_type": 1},
+        }
+    ]
+    assert result.iteration == 3
+    assert result.payload["label"] == "remote-rollout"
+    assert len(fake_ray.get_calls) == 1
+    assert manager.health_check() == [{"status": "ok", "worker_type": "FakeRolloutWorker"}]
+
+    manager.shutdown()
+
+    assert fake_ray.kill_calls == [(fake_ray.actors[0], True)]
+    assert fake_ray.shutdown_calls == 1
+
+
+def test_ray_actor_handles_support_direct_rollout_training_handoff():
+    from rl_engine.executors.ray_actor_manager import (
+        RayActorManager,
+        RayRuntimeConfig,
+        RayWorkerSpec,
+    )
+
+    fake_ray = FakeRayModule()
+    manager = RayActorManager(
+        RayRuntimeConfig(auto_init=True),
+        ray_module=fake_ray,
+    )
+    rollout = manager.create_rollout_worker(RayWorkerSpec(FakeRolloutWorker, args=("r",)))
+    training = manager.create_training_worker(
+        RayWorkerSpec(FakeTrainingWorker, kwargs={"publish_delta": 1})
+    )
+
+    weight_version = 5
+    results = []
+    for iteration in range(2):
+        rollout_result = rollout.rollout(
+            IterationSpec(
+                iteration=iteration,
+                weight_version=weight_version,
+                prompts=[f"p{iteration}"],
+            )
+        )
+        result = training.train(rollout_result)
+        results.append(result)
+        if result.published_weight_version is not None:
+            weight_version = result.published_weight_version
+
+    assert [result.iteration for result in results] == [0, 1]
+    assert [result.consumed_weight_version for result in results] == [5, 6]
+    assert [result.published_weight_version for result in results] == [6, 7]
+    assert len(fake_ray.actors) == 2
+    assert len(fake_ray.get_calls) == 4
+    assert manager.health_check() == [
+        {"status": "ok", "worker_type": "FakeRolloutWorker"},
+        {"status": "ok", "worker_type": "FakeTrainingWorker"},
+    ]
+
+    manager.shutdown()
+    assert [actor for actor, _ in fake_ray.kill_calls] == list(reversed(fake_ray.actors))


### PR DESCRIPTION
## Summary
- add lazy `RayActorManager` for rollout/training workers
- support Ray runtime config, actor options, worker specs, health checks, and cleanup
- expose synchronous rollout/training handles backed by Ray actors
- add fake-Ray contract tests plus single-node real Ray smoke evidence
- add Ray actor smoke that hosts the #12 DeepSpeed training worker on CUDA

## Dependency
This PR is stacked on `issue-12-deepspeed-training-worker-v2`.

## Validation
- `py -3.13 -m pytest tests/test_ray_actor_manager.py tests/test_deepspeed_training_worker.py -q`
- `py -3.13 -m compileall rl_engine tests task-workspace\issues\issue_17\runs`
- scoped `pre-commit run --files ...`
- WSL2 real Ray local actor smoke passed
- WSL2 real Ray + DeepSpeed CUDA actor smoke passed

`pre-commit run --all-files` was also run and fails only on existing `mkdocs.yaml` Python-specific YAML tags, unrelated to this PR.

## Real Runtime Evidence
- WSL2 Python 3.12.3
- Ray `2.55.1`
- DeepSpeed `0.19.1`
- torch `2.8.0+cu126`
- user-local CUDA toolkit 12.0
- `DS_IGNORE_CUDA_DETECTION` unset
- Ray actor health checks passed for rollout and DeepSpeed training actors

## Not Included
- multi-node Ray cluster deployment is not implemented in this PR
- placement groups, cluster address handling, multi-node health checks, and restart policy remain follow-ups