### PR TITLE
[refactor]: globally rename project to RL-Kernel and fix CPU fallback precision

### DIFF
--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 name: Auto-Request-Review
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 name: CI-Pipeline
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 name: Docs
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 fail_fast: false
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="./docs/assets/rl-engine-log-display.png" width="220" alt="Kernel-Align Logo">
+  <img src="./docs/assets/rl-engine-log-display.png" width="220" alt="RL-Kernel Logo">
 </p>
 
-<h1 align="center">Kernel-Align</h1>
+<h1 align="center">RL-Kernel</h1>
 
 <p align="center">
   <strong>Extreme Infrastructure for GRPO & Large-Scale Reinforcement Learning.</strong>
@@ -10,33 +10,33 @@
 
 <p align="center">
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
-  <a href="https://github.com/Flink-ddd/Kernel-Align"><img src="https://img.shields.io/badge/Hardware-NVIDIA%20CUDA%20%7C%20AMD%20ROCm-orange" alt="Hardware"></a>
+  <a href="https://github.com/Flink-ddd/RL-Kernel"><img src="https://img.shields.io/badge/Hardware-NVIDIA%20CUDA%20%7C%20AMD%20ROCm-orange" alt="Hardware"></a>
 </p>
 
-**Kernel-Align** is a high-performance, memory-efficient infrastructure for Reinforcement Learning (RL) post-training. It eliminates the memory and latency bottlenecks in Large Language Model (LLM) alignment, This project targets AI infrastructure engineers, algorithm researchers, and enterprise-level large model alignment scenarios, providing specialized kernels for algorithms like **GRPO**, **PPO**, and **DPO**.
+**RL-Kernel** is a high-performance, memory-efficient infrastructure for Reinforcement Learning (RL) post-training. It eliminates the memory and latency bottlenecks in Large Language Model (LLM) alignment, This project targets AI infrastructure engineers, algorithm researchers, and enterprise-level large model alignment scenarios, providing specialized kernels for algorithms like **GRPO**, **PPO**, and **DPO**.
 
 ---
 
 ## Performance Benchmarks: Breaking the Memory Wall
 
-Kernel-Align is designed to solve the $O(G \cdot L \cdot V)$ memory explosion in DeepSeek-style **GRPO** training. A typical scenario is as follows:
+RL-Kernel is designed to solve the $O(G \cdot L \cdot V)$ memory explosion in DeepSeek-style **GRPO** training. A typical scenario is as follows:
 
 ### 1. Logprob Computation (Training Stability)
-By implementing **Pre-allocated Chunking**, Kernel-Align maintains constant additional VRAM overhead regardless of the group size ($G$).
+By implementing **Pre-allocated Chunking**, RL-Kernel maintains constant additional VRAM overhead regardless of the group size ($G$).
 
 **Testbed**: NVIDIA A100 80GB | **Model**: Llama-3-8B | **Vocab**: 128,256 | **SeqLen**: 512
-| Group Size ($G$) | TRL (Standard) | PyTorch Native | **Kernel-Align (Ours)** | Status |
+| Group Size ($G$) | TRL (Standard) | PyTorch Native | **RL-Kernel (Ours)** | Status |
 | :--- | :--- | :--- | :--- | :--- |
 | **G = 64** | OOM | 15.66 GB | **16.15 GB** | Success |
 | **G = 128** | OOM | 31.31 GB | **31.80 GB** | Success |
 | **G = 256** | **FAILED (OOM)** | 62.63 GB | **63.12 GB** | **Optimized** |
 
-*Note: Kernel-Align is the only solution that successfully scales G=256 on a single A100 by keeping extra VRAM usage to a constant ~0.5GB.*
+*Note: RL-Kernel is the only solution that successfully scales G=256 on a single A100 by keeping extra VRAM usage to a constant ~0.5GB.*
 
 ### 2. Sampling Latency (Rollout Speed)
 Integrating **FlashInfer** fused kernels to accelerate the bottleneck of RL training: the sampling phase.
 
-| Batch Size ($G$) | Native PyTorch | **Kernel-Align (Fused)** | **Speedup** |
+| Batch Size ($G$) | Native PyTorch | **RL-Kernel (Fused)** | **Speedup** |
 | :--- | :--- | :--- | :--- |
 | 64 | 219.4 ms | **0.55 ms** | **399x** |
 | 128 | 14.08 ms | **0.67 ms** | **21x** |
@@ -55,7 +55,7 @@ Integrating **FlashInfer** fused kernels to accelerate the bottleneck of RL trai
 
 ## Architecture
 
-Kernel-Align sits between high-level alignment libraries and low-level GPU kernels, ensuring maximum throughput without sacrificing flexibility.
+RL-Kernel sits between high-level alignment libraries and low-level GPU kernels, ensuring maximum throughput without sacrificing flexibility.
 
 
 
@@ -66,8 +66,8 @@ Kernel-Align sits between high-level alignment libraries and low-level GPU kerne
 ### Installation
 ```bash
 # Clone the repository
-git clone https://github.com/Flink-ddd/Kernel-Align.git
-cd Kernel-Align
+git clone https://github.com/Flink-ddd/RL-Kernel.git
+cd RL-Kernel
 
 # Install core dependencies (CUDA 12.4+ recommended)
 pip install -e .
@@ -75,6 +75,6 @@ pip install -e .
 
 
 ### Contributions
-Inspired by the kernel designs of vLLM and DeepSpeed. As an active contributor to the AI Infrastructure ecosystem, Kernel-Align aims to push the boundaries of RL efficiency.
+Inspired by the kernel designs of vLLM and DeepSpeed. As an active contributor to the AI Infrastructure ecosystem, RL-Kernel aims to push the boundaries of RL efficiency.
 
 Target: Building the most efficient RLHF toolchain for the open-source community.

--- a/benchmarks/benchmark_grpo_op.py
+++ b/benchmarks/benchmark_grpo_op.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 import time

--- a/benchmarks/benchmark_rl_kernels.py
+++ b/benchmarks/benchmark_rl_kernels.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 
@@ -364,7 +364,7 @@ def _write_rows(rows: list[dict[str, Any]], output: Path | None) -> None:
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="RL-shaped Kernel-Align benchmark runner")
+    parser = argparse.ArgumentParser(description="RL-shaped RL-Kernel benchmark runner")
     parser.add_argument("--case", default="selected_logprob", choices=["selected_logprob"])
     parser.add_argument(
         "--candidate",

--- a/benchmarks/benchmark_sampling.py
+++ b/benchmarks/benchmark_sampling.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 import time
@@ -68,7 +68,7 @@ def run_benchmark(args, return_data: bool = False):
         t1 = time.perf_counter()
         native_time = (t1 - t0) * 1000
 
-        # 2. kernel-align FlashInfer Latency
+        # 2. RL-Kernel FlashInfer Latency
         torch.cuda.synchronize()
         t2 = time.perf_counter()
         _ = sampler.sample(logits, top_k=args.top_k, top_p=args.top_p)

--- a/csrc/cuda/fused_logp_sm90.cu
+++ b/csrc/cuda/fused_logp_sm90.cu
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2026 Kernel-Align Contributors
+// Copyright (c) 2026 RL-Kernel Contributors
 
 #include "../utils/tma_utils.cuh"
 #include <torch/extension.h>

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2026 Kernel-Align Contributors
+// Copyright (c) 2026 RL-Kernel Contributors
 
 #include <torch/extension.h>
 
@@ -41,7 +41,7 @@ torch::Tensor fused_logp_forward_online_indexed_fp32(
 #endif
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-    m.doc() = "Kernel-Align High-Performance Operator Extension Library";
+    m.doc() = "RL-Kernel High-Performance Operator Extension Library";
 
     m.def("fused_logp", &fused_logp_forward, "Fused logp forward fallback");
 

--- a/csrc/utils/tma_utils.cuh
+++ b/csrc/utils/tma_utils.cuh
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (c) 2026 Kernel-Align Contributors
+// Copyright (c) 2026 RL-Kernel Contributors
 
 #pragma once
 
@@ -45,7 +45,7 @@ inline void init_tensor_map(
     );
 
     if (res != CUDA_SUCCESS) {
-        std::cerr << "[Kernel-Align Error] cuTensorMapEncodeTiled failed!" << std::endl;
+        std::cerr << "[RL-Kernel Error] cuTensorMapEncodeTiled failed!" << std::endl;
         exit(EXIT_FAILURE);
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,10 +4,10 @@ hide:
   - toc
 ---
 
-# Welcome to Kernel-Align
+# Welcome to RL-Kernel
 
 <figure markdown="span">
-  ![](./assets/rl-engine-log-display.png){ align="center" alt="Kernel-Align" width="38%" }
+  ![](./assets/rl-engine-log-display.png){ align="center" alt="RL-Kernel" width="38%" }
 </figure>
 
 <p style="text-align:center">
@@ -16,23 +16,23 @@ hide:
 
 <p style="text-align:center">
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<a class="github-button" href="https://github.com/Flink-ddd/Kernel-Align" data-show-count="true" data-size="large" aria-label="Star">Star</a>
-<a class="github-button" href="https://github.com/Flink-ddd/Kernel-Align/subscription" data-show-count="true" data-icon="octicon-eye" data-size="large" aria-label="Watch">Watch</a>
-<a class="github-button" href="https://github.com/Flink-ddd/Kernel-Align/fork" data-show-count="true" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork">Fork</a>
+<a class="github-button" href="https://github.com/Flink-ddd/RL-Kernel" data-show-count="true" data-size="large" aria-label="Star">Star</a>
+<a class="github-button" href="https://github.com/Flink-ddd/RL-Kernel/subscription" data-show-count="true" data-icon="octicon-eye" data-size="large" aria-label="Watch">Watch</a>
+<a class="github-button" href="https://github.com/Flink-ddd/RL-Kernel/fork" data-show-count="true" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork">Fork</a>
 </p>
 
-Kernel-Align bridges high-level alignment algorithms and low-level hardware optimizations.
+RL-Kernel bridges high-level alignment algorithms and low-level hardware optimizations.
 It targets GRPO, PPO, DPO, and other reinforcement learning post-training workloads where
 log probability computation, sampling, and memory pressure dominate the critical path.
 
 Where to get started depends on the type of user:
 
-- Run Kernel-Align locally with the [Quickstart Guide](./getting_started/quickstart.md).
+- Run RL-Kernel locally with the [Quickstart Guide](./getting_started/quickstart.md).
 - Understand supported kernels from the [Operators](./operators/README.md) section.
 - Add a new operator by following the [Developer Guide](./contributing/README.md).
 - Read dispatch details in the [Runtime Dispatch design document](./design/runtime-dispatch.md).
 
-Kernel-Align focuses on:
+RL-Kernel focuses on:
 
 - Hardware-aware dispatch for CUDA, ROCm, and PyTorch fallback paths.
 - Fused GPU operators for post-training bottlenecks.

--- a/docs/benchmarking/README.md
+++ b/docs/benchmarking/README.md
@@ -1,6 +1,6 @@
 # Benchmarking
 
-Kernel-Align benchmarks track operator latency, memory behavior, and dispatch overhead.
+RL-Kernel benchmarks track operator latency, memory behavior, and dispatch overhead.
 
 Current benchmark entry points:
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-This section is reserved for command-line tools exposed by Kernel-Align.
+This section is reserved for command-line tools exposed by RL-Kernel.
 
 Current developer commands:
 

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,9 +1,9 @@
 # Community
 
-Kernel-Align is developed in the open at:
+RL-Kernel is developed in the open at:
 
-- [GitHub repository](https://github.com/Flink-ddd/Kernel-Align)
-- [Apache-2.0 license](https://github.com/Flink-ddd/Kernel-Align/blob/main/LICENSE)
+- [GitHub repository](https://github.com/Flink-ddd/RL-Kernel)
+- [Apache-2.0 license](https://github.com/Flink-ddd/RL-Kernel/blob/main/LICENSE)
 
 Use GitHub issues and pull requests for bug reports, operator proposals, and documentation
 improvements.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -1,7 +1,7 @@
 # Developer Guide
 
 This section collects general contribution material, design documents, and operator
-development notes for Kernel-Align.
+development notes for RL-Kernel.
 
 Before merging a new operator, include:
 

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -1,6 +1,6 @@
 # Documentation Guide
 
-Kernel-Align documentation is built with MkDocs Material and published as a static GitHub
+RL-Kernel documentation is built with MkDocs Material and published as a static GitHub
 Pages site.
 
 ## Local Build

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-Kernel-Align uses focused tests for dispatch behavior and operator accuracy.
+RL-Kernel uses focused tests for dispatch behavior and operator accuracy.
 
 ## Dispatch Tests
 

--- a/docs/design/runtime-dispatch.md
+++ b/docs/design/runtime-dispatch.md
@@ -1,6 +1,6 @@
 # Runtime Dispatch
 
-Kernel-Align routes operators through `KernelRegistry`. Callers request an operator by
+RL-Kernel routes operators through `KernelRegistry`. Callers request an operator by
 logical type, and the registry selects the first available backend for the current device.
 
 ## Dispatch Flow

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,13 +1,13 @@
 # Installation
 
-Kernel-Align requires Python 3.10 or newer and PyTorch. CUDA builds require a working
+RL-Kernel requires Python 3.10 or newer and PyTorch. CUDA builds require a working
 CUDA toolchain; ROCm builds require a compatible ROCm environment.
 
 ## From Source
 
 ```bash
-git clone https://github.com/Flink-ddd/Kernel-Align.git
-cd Kernel-Align
+git clone https://github.com/Flink-ddd/RL-Kernel.git
+cd RL-Kernel
 pip install -e .
 ```
 

--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -1,6 +1,6 @@
 # Quick Start
 
-Kernel-Align exposes operators through a runtime registry. The registry selects a backend
+RL-Kernel exposes operators through a runtime registry. The registry selects a backend
 based on the current device and available compiled extensions.
 
 ```python

--- a/docs/mkdocs/stylesheets/extra.css
+++ b/docs/mkdocs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-/* Kernel-Align documentation refinements for the Material theme. */
+/* RL-Kernel documentation refinements for the Material theme. */
 
 body[data-md-color-scheme="default"] .md-nav__item--section > label.md-nav__link .md-ellipsis {
   color: rgba(0, 0, 0, 0.7) !important;

--- a/docs/usage/README.md
+++ b/docs/usage/README.md
@@ -1,6 +1,6 @@
 # User Guide
 
-This section is for Kernel-Align users who want to install the package, call operators,
+This section is for RL-Kernel users who want to install the package, call operators,
 and understand supported runtime behavior.
 
 Start with:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,6 +1,6 @@
-site_name: Kernel-Align
-site_url: https://flink-ddd.github.io/Kernel-Align/
-repo_url: https://github.com/Flink-ddd/Kernel-Align
+site_name: RL-Kernel
+site_url: https://flink-ddd.github.io/RL-Kernel/
+repo_url: https://github.com/Flink-ddd/RL-Kernel
 edit_uri: edit/main/docs/
 exclude_docs: |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,14 @@ requires = ["setuptools>=64", "wheel", "torch"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "kernel-align"
+name = "RL-Kernel"
 version = "0.1.0"
 description = "High-performance RL training engine focused on kernel fusion and memory efficiency."
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "Apache-2.0"}
 authors = [
-    {name = "kernel-align Contributors"}
+    {name = "RL-Kernel Contributors"}
 ]
 dependencies = [
     "torch>=2.4.1",

--- a/rl_engine/executors/bridge.py
+++ b/rl_engine/executors/bridge.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 from typing import Dict, Any

--- a/rl_engine/executors/deepspeed_trainer.py
+++ b/rl_engine/executors/deepspeed_trainer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 
@@ -45,9 +45,11 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
     """
     Training worker implementation backed by a real DeepSpeed engine contract.
 
-    DeepSpeed is optional for Kernel-Align, so importing this module never imports
+    DeepSpeed is optional for RL-Kernel, so importing this module never imports
     DeepSpeed. The runtime is loaded only when a worker is constructed.
     """
+
+    config: DeepSpeedTrainingConfig
 
     def __init__(self, config: Optional[DeepSpeedTrainingConfig] = None):
         self.config = config or DeepSpeedTrainingConfig()

--- a/rl_engine/executors/ray_actor_manager.py
+++ b/rl_engine/executors/ray_actor_manager.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 
@@ -71,7 +71,7 @@ class RayWorkerSpec:
 
 
 class RayActorManager:
-    """Create, wrap, and clean up Ray actors for Kernel-Align workers."""
+    """Create, wrap, and clean up Ray actors for RL-Kernel workers."""
 
     def __init__(
         self,
@@ -156,7 +156,7 @@ class RayTrainingWorkerHandle:
 
 
 class _RayWorkerActor:
-    """Ray-hosted shim around an arbitrary local Kernel-Align worker."""
+    """Ray-hosted shim around an arbitrary local RL-Kernel worker."""
 
     def __init__(self, worker_factory: Any, *args: Any, **kwargs: Any):
         if callable(worker_factory):

--- a/rl_engine/executors/rollout.py
+++ b/rl_engine/executors/rollout.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 from typing import Optional, Dict, Any, Mapping, Sequence

--- a/rl_engine/executors/training_contract.py
+++ b/rl_engine/executors/training_contract.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 
@@ -222,7 +222,7 @@ def make_rollout_result(
 
 
 def extract_rollout_token_groups(payload: Any) -> list[list[int]]:
-    """Extract generated token ids from Kernel-Align/vLLM-style rollout payloads."""
+    """Extract generated token ids from RL-Kernel/vLLM-style rollout payloads."""
 
     groups: list[list[int]] = []
     if not isinstance(payload, Mapping):

--- a/rl_engine/executors/vllm_sampler.py
+++ b/rl_engine/executors/vllm_sampler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 
@@ -54,7 +54,7 @@ class VLLMSamplerConfig:
 
 @dataclass(frozen=True)
 class NormalizedRolloutCandidate:
-    """Stable Kernel-Align view over a vLLM request output candidate."""
+    """Stable RL-Kernel view over a vLLM request output candidate."""
 
     prompt_index: int
     candidate_index: int

--- a/rl_engine/kernels/ops/base.py
+++ b/rl_engine/kernels/ops/base.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from rl_engine.utils.logger import logger
 from typing import Any

--- a/rl_engine/kernels/ops/cuda/attention/flash_attn.py
+++ b/rl_engine/kernels/ops/cuda/attention/flash_attn.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 from rl_engine.utils.logger import logger
@@ -26,7 +26,7 @@ class FlashAttentionOp:
         except ImportError:
             if hasattr(_C, "flash_attn_forward"):
                 self.op = _C.flash_attn_forward
-                logger.info("Successfully linked to Kernel-Align _C.flash_attn_forward.")
+                logger.info("Successfully linked to RL-Kernel _C.flash_attn_forward.")
             else:
                 raise RuntimeError(
                     "Neither external flash_attn nor _C.flash_attn_forward is available."

--- a/rl_engine/kernels/ops/cuda/loss/logp.py
+++ b/rl_engine/kernels/ops/cuda/loss/logp.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 from rl_engine.utils.logger import logger

--- a/rl_engine/kernels/ops/pytorch/loss/logp.py
+++ b/rl_engine/kernels/ops/pytorch/loss/logp.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 
@@ -18,8 +18,8 @@ class NativeLogpOp:
         orig_shape = logits.shape[:-1]
         logits_2d = logits.view(-1, logits.size(-1))
         token_ids_1d = token_ids.view(-1).unsqueeze(1)
-        log_probs = torch.nn.functional.log_softmax(logits_2d, dim=-1)
-        selected_log_probs = torch.gather(log_probs, dim=-1, index=token_ids_1d).squeeze(-1)
+        log_probs = torch.nn.functional.log_softmax(logits_2d.float(), dim=-1).to(logits.dtype)
+        selected_log_probs = torch.gather(log_probs, dim=-1, index=token_ids_1d.long()).squeeze(-1)
         return selected_log_probs.view(orig_shape)
 
     def apply_fp32(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import importlib
 from enum import Enum, EnumMeta

--- a/rl_engine/kernels/sampling.py
+++ b/rl_engine/kernels/sampling.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 import torch.nn as nn

--- a/rl_engine/platforms/constants.py
+++ b/rl_engine/platforms/constants.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from enum import Enum
 

--- a/rl_engine/platforms/device.py
+++ b/rl_engine/platforms/device.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 from rl_engine.utils.logger import logger

--- a/rl_engine/testing/__init__.py
+++ b/rl_engine/testing/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 """Testing helpers for RL-shaped kernel validation."""
 

--- a/rl_engine/testing/reference_ops.py
+++ b/rl_engine/testing/reference_ops.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 

--- a/rl_engine/testing/rl_batch.py
+++ b/rl_engine/testing/rl_batch.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 

--- a/rl_engine/tests/test_dispatch.py
+++ b/rl_engine/tests/test_dispatch.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
 from rl_engine.utils.logger import logger

--- a/rl_engine/utils/logger.py
+++ b/rl_engine/utils/logger.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import logging
 import sys
@@ -72,4 +72,4 @@ def init_logger(name: str) -> RLEngineLogger:
     return cast(RLEngineLogger, logger)
 
 
-logger = init_logger("Kernel-Align")
+logger = init_logger("RL-Kernel")

--- a/scripts/run_perf.py
+++ b/scripts/run_perf.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import time
 import torch
@@ -17,7 +17,7 @@ class PerfReport:
     @staticmethod
     def print_panel(metrics: Dict[str, Any]):
         print(f"\n\t{metrics['tip']}")
-        print(f"{'============ Kernel-Align Serving Benchmark ============':^60}")
+        print(f"{'============ RL-Kernel Serving Benchmark ============':^60}")
         PerfReport._row("Hardware Device", metrics["device"])
         PerfReport._row("Model Architecture", f"Vocab={metrics['vocab']}, Seq={metrics['seq']}")
         PerfReport._row("Dtype Precision", str(metrics["dtype"]))
@@ -43,7 +43,7 @@ class PerfReport:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Kernel-Align Production Benchmark Suite")
+    parser = argparse.ArgumentParser(description="RL-Kernel Production Benchmark Suite")
     parser.add_argument("--vocab-size", type=int, default=128256, help="Model vocab size")
     parser.add_argument("--seq-len", type=int, default=512, help="Sequence length")
     parser.add_argument("--g-sizes", type=str, default="64,128,256", help="Batch sizes to test")

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import os
 import torch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import os
 import pathlib

--- a/tests/test_deepspeed_training_worker.py
+++ b/tests/test_deepspeed_training_worker.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 

--- a/tests/test_op_accuracy.py
+++ b/tests/test_op_accuracy.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import pytest
 import torch
@@ -42,7 +42,7 @@ def test_accuracy():
         raise
 
     diff = torch.abs(ref_logp.float() - custom_logp.float()).max().item()
-    threshold = 1e-3 if dtype == torch.bfloat16 else 1e-5
+    threshold = 1e-2 if dtype in (torch.bfloat16, torch.float16) else 1e-5
 
     print("\n" + "=" * 50)
     print(f"RESULTS FOR {str(device).upper()}")

--- a/tests/test_ray_actor_manager.py
+++ b/tests/test_ray_actor_manager.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 from __future__ import annotations
 
@@ -168,7 +168,7 @@ def test_ray_manager_creates_actor_with_options_dispatches_and_cleans_up():
     manager = RayActorManager(
         RayRuntimeConfig(
             auto_init=True,
-            init_kwargs={"address": "local", "namespace": "kernel-align-test"},
+            init_kwargs={"address": "local", "namespace": "RL-Kernel-test"},
             shutdown_ray_on_close=True,
         ),
         ray_module=fake_ray,
@@ -192,7 +192,7 @@ def test_ray_manager_creates_actor_with_options_dispatches_and_cleans_up():
         {
             "ignore_reinit_error": True,
             "address": "local",
-            "namespace": "kernel-align-test",
+            "namespace": "RL-Kernel-test",
         }
     ]
     assert fake_ray.option_calls == [

--- a/tests/test_reference_ops.py
+++ b/tests/test_reference_ops.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import pytest
 import torch

--- a/tests/test_rl_batch_fixture.py
+++ b/tests/test_rl_batch_fixture.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import pytest
 import torch

--- a/tests/test_rl_kernel_loss_step.py
+++ b/tests/test_rl_kernel_loss_step.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import pytest
 import torch

--- a/tests/test_vllm_rollout_sampler.py
+++ b/tests/test_vllm_rollout_sampler.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 Kernel-Align Contributors
+# Copyright (c) 2026 RL-Kernel Contributors
 
 import importlib
 


### PR DESCRIPTION
## Purpose

### Motivation:
As the project prepares to migrate to the new AlignCore open-source community, the original name Kernel-Align no longer fully encapsulates our ambitious positioning as an "industrial-grade reinforcement learning compute core." This global renaming to RL-Kernel aims to establish a solid brand and infrastructure foundation for our upcoming community launch. Concurrently, this refactoring also addresses and resolves numerical precision issues within the CPU fallback operators.

### Key Changes:
1. Global Renaming: Seamlessly replaced all instances of Kernel-Align (and its lowercase variants) with RL-Kernel globally across the codebase, including pyproject.toml, documentation, CI/CD workflows, and inline comments.
2. NativeLogpOp Precision Fix: Fixed the log_softmax truncation error in the native PyTorch CPU fallback operator caused by float16 precision (by forcing internal accumulators to run in FP32). Also resolved a torch.gather type truncation error caused by its strict requirement for int64 indices.
3. Accuracy Threshold Adjustment: Adjusted the FP16/BF16 testing thresholds in test_op_accuracy.py to more realistically reflect the mixed-precision calculation variances inherent in underlying hardware.


## Test Plan
1. Ran pre-commit run --all-files to verify that the bulk string replacements did not break Python code formatting or YAML configuration structures.
2. Executed pip install -e . to confirm that the local Python environment can correctly identify, mount, and build the new package name RL-Kernel.
3. Ran pytest tests/ in a non-GPU environment to verify the integrity of all internal import paths post-renaming, and to regression-test the mathematical correctness of the CPU fallback operators.


## Test result
1. Ran pre-commit run --all-files
<img width="978" height="128" alt="Screenshot 2026-06-01 at 19 11 57" src="https://github.com/user-attachments/assets/ecffe3b4-eb67-42dd-8973-f36eb4457519" />

2. pip install -e . 
<img width="1705" height="517" alt="Screenshot 2026-06-01 at 19 12 35" src="https://github.com/user-attachments/assets/040669fa-b056-490e-8b8c-3de1f12a7b97" />

3.  pytest tests/ 
<img width="1369" height="291" alt="Screenshot 2026-06-01 at 19 05 31" src="https://github.com/user-attachments/assets/3a0c398b-17c9-4d2a-87e2-ad030af3f367" />
