### PR TITLE
feat: add zero-copy weight sync bridge

### DIFF
--- a/benchmarks/benchmark_weight_sync_bridge.py
+++ b/benchmarks/benchmark_weight_sync_bridge.py
@@ -1,0 +1,740 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib.util
+import json
+import multiprocessing as mp
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from rl_engine.executors.bridge import (  # noqa: E402
+    CUDAVMMTensorBridge,
+    IPCWeightBridge,
+    LocalTensorCopyBridge,
+    SharedMemoryTensorBridge,
+    VLLMCUDAVMMExternalStorageAdapter,
+    VLLMWeightInstallAdapter,
+    WeightBridgeUnavailableError,
+    WeightManifestValidationError,
+)
+from rl_engine.executors.rollout import RolloutExecutor  # noqa: E402
+
+
+CSV_COLUMNS = [
+    "timestamp",
+    "candidate_id",
+    "mode",
+    "status",
+    "environment",
+    "tensor_count",
+    "total_nbytes",
+    "publish_ms",
+    "import_ms",
+    "ack_ms",
+    "release_ms",
+    "active_weight_version",
+    "notes",
+]
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _environment() -> str:
+    cuda = torch.version.cuda or ""
+    if torch.cuda.is_available():
+        device = torch.cuda.get_device_name(0)
+        memory_gb = torch.cuda.get_device_properties(0).total_memory / (1024**3)
+        return f"torch={torch.__version__};cuda={cuda};gpu={device};gpu_mem_gb={memory_gb:.2f}"
+    return f"torch={torch.__version__};cuda={cuda};gpu=none"
+
+
+def _write_csv_row(row: Mapping[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    exists = output.exists() and output.stat().st_size > 0
+    if exists:
+        first_line = output.read_text(encoding="utf-8").splitlines()[0]
+        if first_line.split(",") != CSV_COLUMNS:
+            exists = False
+    with output.open("a" if exists else "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS)
+        if not exists:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def _model(hidden_dim: int, layers: int) -> torch.nn.Module:
+    modules: list[torch.nn.Module] = []
+    for _ in range(layers):
+        modules.append(torch.nn.Linear(hidden_dim, hidden_dim))
+        modules.append(torch.nn.LayerNorm(hidden_dim))
+    modules.append(torch.nn.Linear(hidden_dim, hidden_dim, bias=False))
+    return torch.nn.Sequential(*modules)
+
+
+def _run_local(args: argparse.Namespace) -> dict[str, Any]:
+    model = _model(args.hidden_dim, args.layers)
+    bridge = LocalTensorCopyBridge(source_worker="benchmark-training", source_rank=0)
+
+    publish_started = time.perf_counter()
+    manifest = bridge.publish(
+        model,
+        weight_version=args.weight_version,
+        metadata={"benchmark": "weight_sync_bridge"},
+    )
+    publish_finished = time.perf_counter()
+
+    import_started = time.perf_counter()
+    tensors = bridge.import_update(manifest)
+    import_finished = time.perf_counter()
+
+    ack_started = time.perf_counter()
+    bridge.acknowledge(manifest.update_id)
+    ack_finished = time.perf_counter()
+
+    release_started = time.perf_counter()
+    bridge.release(manifest.update_id)
+    release_finished = time.perf_counter()
+
+    if len(tensors) != manifest.tensor_count:
+        raise RuntimeError("imported tensor count did not match manifest")
+
+    return {
+        "timestamp": _timestamp(),
+        "candidate_id": "issue-13-candidate-1",
+        "mode": "local",
+        "status": "pass",
+        "environment": _environment(),
+        "tensor_count": manifest.tensor_count,
+        "total_nbytes": manifest.total_nbytes,
+        "publish_ms": (publish_finished - publish_started) * 1000,
+        "import_ms": (import_finished - import_started) * 1000,
+        "ack_ms": (ack_finished - ack_started) * 1000,
+        "release_ms": (release_finished - release_started) * 1000,
+        "active_weight_version": bridge.active_weight_version,
+        "notes": "Local clone transport validates manifest lifecycle; not zero-copy evidence.",
+    }
+
+
+def _shared_memory_manifest_child(manifest: Any, queue: Any) -> None:
+    consumer = SharedMemoryTensorBridge(source_worker="benchmark-rollout", source_rank=1)
+    imported = dict(consumer.import_update(manifest))
+    try:
+        consumer.acknowledge(manifest.update_id)
+        first_name = next(iter(imported))
+        before = float(imported[first_name].flatten()[0].item())
+        queue.put(
+            {
+                "before": before,
+                "active_weight_version": consumer.active_weight_version,
+                "tensor_count": len(imported),
+            }
+        )
+    finally:
+        consumer.release(manifest.update_id)
+
+
+def _shared_memory_manifest_tamper_child(manifest: Any, queue: Any) -> None:
+    consumer = SharedMemoryTensorBridge(source_worker="benchmark-rollout", source_rank=1)
+    imported = dict(consumer.import_update(manifest))
+    first_name = next(iter(imported))
+    imported[first_name].add_(13)
+    try:
+        consumer.acknowledge(manifest.update_id)
+    except WeightManifestValidationError as exc:
+        queue.put({"blocked": True, "error": str(exc)})
+    finally:
+        consumer.release(manifest.update_id)
+
+
+def _run_shared_memory(args: argparse.Namespace) -> dict[str, Any]:
+    model = _model(args.hidden_dim, args.layers)
+    bridge = SharedMemoryTensorBridge(source_worker="benchmark-training", source_rank=0)
+
+    publish_started = time.perf_counter()
+    manifest = bridge.publish(
+        model,
+        weight_version=args.weight_version,
+        metadata={"benchmark": "weight_sync_bridge"},
+    )
+    publish_finished = time.perf_counter()
+
+    import_started = time.perf_counter()
+    tensors = dict(bridge.import_update(manifest))
+    import_finished = time.perf_counter()
+
+    source_ptrs = bridge.debug_tensor_data_ptrs(manifest.update_id)
+    alias_count = sum(
+        1 for name, tensor in tensors.items() if int(tensor.data_ptr()) == source_ptrs[name]
+    )
+    shared_handle_count = len(manifest.metadata["weight_bridge"]["tensors"])
+
+    first_name = next(iter(tensors))
+    before = float(tensors[first_name].flatten()[0].item())
+    context = mp.get_context("spawn")
+
+    manifest_queue = context.Queue()
+    manifest_process_started = time.perf_counter()
+    manifest_process = context.Process(
+        target=_shared_memory_manifest_child,
+        args=(manifest, manifest_queue),
+    )
+    manifest_process.start()
+    manifest_process.join(timeout=10)
+    if manifest_process.exitcode != 0:
+        raise RuntimeError(f"shared-memory manifest child exited with {manifest_process.exitcode}")
+    manifest_child_result = manifest_queue.get(timeout=1)
+    manifest_process_finished = time.perf_counter()
+    parent_after_manifest_child = float(tensors[first_name].flatten()[0].item())
+    if (
+        abs(manifest_child_result["before"] - before) > 1e-5
+        or abs(parent_after_manifest_child - before) > 1e-5
+        or manifest_child_result["active_weight_version"] != manifest.weight_version
+        or manifest_child_result["tensor_count"] != manifest.tensor_count
+    ):
+        raise RuntimeError("shared-memory manifest import was not visible across processes")
+
+    ack_started = time.perf_counter()
+    bridge.acknowledge(manifest.update_id)
+    ack_finished = time.perf_counter()
+
+    release_started = time.perf_counter()
+    bridge.release(manifest.update_id)
+    release_finished = time.perf_counter()
+
+    tamper_bridge = SharedMemoryTensorBridge(source_worker="benchmark-training", source_rank=0)
+    tamper_manifest = tamper_bridge.publish(
+        model,
+        weight_version=args.weight_version + 1,
+        metadata={"benchmark": "weight_sync_bridge_tamper"},
+    )
+    tamper_queue = context.Queue()
+    tamper_process = context.Process(
+        target=_shared_memory_manifest_tamper_child,
+        args=(tamper_manifest, tamper_queue),
+    )
+    tamper_process.start()
+    tamper_process.join(timeout=10)
+    if tamper_process.exitcode != 0:
+        raise RuntimeError(f"shared-memory tamper child exited with {tamper_process.exitcode}")
+    tamper_result = tamper_queue.get(timeout=1)
+    tamper_bridge.release(tamper_manifest.update_id)
+    if not tamper_result.get("blocked"):
+        raise RuntimeError("shared-memory checksum did not block tampered update")
+
+    return {
+        "timestamp": _timestamp(),
+        "candidate_id": "issue-13-candidate-2",
+        "mode": "shared-memory",
+        "status": "pass",
+        "environment": _environment(),
+        "tensor_count": manifest.tensor_count,
+        "total_nbytes": manifest.total_nbytes,
+        "publish_ms": (publish_finished - publish_started) * 1000,
+        "import_ms": (import_finished - import_started) * 1000,
+        "ack_ms": (ack_finished - ack_started) * 1000,
+        "release_ms": (release_finished - release_started) * 1000,
+        "active_weight_version": bridge.active_weight_version,
+        "notes": (
+            "Same-node shared-memory zero-copy smoke passed; "
+            f"alias_count={alias_count}; shared_handle_count={shared_handle_count}; "
+            "checksum_tamper_blocked=True; "
+            "manifest_attach_process_visible_ms="
+            f"{(manifest_process_finished - manifest_process_started) * 1000:.4f}"
+        ),
+    }
+
+
+def _run_cuda_ipc() -> dict[str, Any]:
+    bridge = IPCWeightBridge(source_worker="benchmark-cuda-training", source_rank=0)
+    model = _model(8, 1).to("cuda") if torch.cuda.is_available() else _model(8, 1)
+    try:
+        bridge.publish(model, weight_version=1)
+    except WeightBridgeUnavailableError as exc:
+        notes = str(exc)
+    else:
+        notes = "CUDA IPC unexpectedly reported success before production validation."
+
+    return {
+        "timestamp": _timestamp(),
+        "candidate_id": "issue-13-candidate-3",
+        "mode": "cuda-ipc",
+        "status": "blocked",
+        "environment": _environment(),
+        "tensor_count": 0,
+        "total_nbytes": 0,
+        "publish_ms": "",
+        "import_ms": "",
+        "ack_ms": "",
+        "release_ms": "",
+        "active_weight_version": "",
+        "notes": notes,
+    }
+
+
+def _cuda_vmm_manifest_child(manifest: Any, queue: Any) -> None:
+    consumer = CUDAVMMTensorBridge(source_worker="benchmark-rollout", source_rank=1)
+    imported = dict(consumer.import_update(manifest))
+    tensor = None
+    try:
+        consumer.acknowledge(manifest.update_id)
+        first_name = next(iter(imported))
+        tensor = imported[first_name]
+        before = tensor.detach().cpu().flatten()[:4].tolist()
+        tensor.add_(10)
+        torch.cuda.synchronize()
+        after = tensor.detach().cpu().flatten()[:4].tolist()
+        queue.put(
+            {
+                "before": before,
+                "after": after,
+                "data_ptr": int(tensor.data_ptr()),
+                "active_weight_version": consumer.active_weight_version,
+            }
+        )
+    finally:
+        del tensor
+        imported.clear()
+        consumer.release(manifest.update_id)
+
+
+def _run_cuda_vmm(args: argparse.Namespace) -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        raise WeightBridgeUnavailableError("CUDA VMM smoke requires torch CUDA availability")
+
+    model = _model(args.hidden_dim, args.layers).to("cuda")
+    publisher = CUDAVMMTensorBridge(source_worker="benchmark-training", source_rank=0)
+
+    manifest = None
+    parent_imported: dict[str, torch.Tensor] = {}
+    try:
+        publish_started = time.perf_counter()
+        manifest = publisher.publish(
+            model,
+            weight_version=args.weight_version,
+            metadata={"benchmark": "weight_sync_bridge_cuda_vmm"},
+        )
+        publish_finished = time.perf_counter()
+
+        import_started = time.perf_counter()
+        parent_imported = dict(publisher.import_update(manifest))
+        import_finished = time.perf_counter()
+        first_name = next(iter(parent_imported))
+        parent_before = parent_imported[first_name].detach().cpu().flatten()[:4].tolist()
+        parent_ptr = int(parent_imported[first_name].data_ptr())
+
+        ack_started = time.perf_counter()
+        publisher.acknowledge(manifest.update_id)
+        ack_finished = time.perf_counter()
+
+        context = mp.get_context("spawn")
+        queue = context.Queue()
+        process_started = time.perf_counter()
+        process = context.Process(target=_cuda_vmm_manifest_child, args=(manifest, queue))
+        process.start()
+        process.join(timeout=30)
+        if process.exitcode != 0:
+            raise RuntimeError(f"CUDA VMM manifest child exited with {process.exitcode}")
+        child_result = queue.get(timeout=1)
+        process_finished = time.perf_counter()
+        torch.cuda.synchronize()
+        parent_after = parent_imported[first_name].detach().cpu().flatten()[:4].tolist()
+        if child_result["before"] != parent_before:
+            raise RuntimeError("CUDA VMM child did not observe the published tensor values")
+        if child_result["after"] != parent_after:
+            raise RuntimeError("CUDA VMM parent did not observe the child mutation")
+        same_virtual_address = child_result["data_ptr"] == parent_ptr
+    finally:
+        release_started = time.perf_counter()
+        parent_imported.clear()
+        if manifest is not None:
+            publisher.release(manifest.update_id)
+        release_finished = time.perf_counter()
+
+    metadata = manifest.metadata["weight_bridge"]
+    return {
+        "timestamp": _timestamp(),
+        "candidate_id": "issue-13-candidate-8",
+        "mode": "cuda-vmm",
+        "status": "pass",
+        "environment": _environment(),
+        "tensor_count": manifest.tensor_count,
+        "total_nbytes": manifest.total_nbytes,
+        "publish_ms": (publish_finished - publish_started) * 1000,
+        "import_ms": (import_finished - import_started) * 1000,
+        "ack_ms": (ack_finished - ack_started) * 1000,
+        "release_ms": (release_finished - release_started) * 1000,
+        "active_weight_version": publisher.active_weight_version,
+        "notes": (
+            "CUDA VMM POSIX-fd zero-copy smoke passed; "
+            f"mapped_nbytes={metadata['mapped_nbytes']}; "
+            f"parent_data_ptr={parent_ptr}; "
+            f"child_data_ptr={child_result['data_ptr']}; "
+            f"same_virtual_address={same_virtual_address}; "
+            f"child_attach_process_visible_ms={(process_finished - process_started) * 1000:.4f}; "
+            f"parent_before={parent_before}; parent_after={parent_after}"
+        ),
+    }
+
+
+def _run_rollout_update(args: argparse.Namespace) -> dict[str, Any]:
+    model = _model(args.hidden_dim, args.layers)
+    publisher = SharedMemoryTensorBridge(source_worker="benchmark-training", source_rank=0)
+    consumer = SharedMemoryTensorBridge(source_worker="benchmark-rollout", source_rank=1)
+    install_calls: list[tuple[str, int]] = []
+    adapter = VLLMWeightInstallAdapter(
+        object(),
+        install_callable=lambda manifest, tensors: install_calls.append(
+            (manifest.update_id, len(tensors))
+        ),
+    )
+    rollout = RolloutExecutor(
+        {"weight_transport": "shared-memory"},
+        weight_bridge=consumer,
+        weight_install_adapter=adapter,
+    )
+
+    publish_started = time.perf_counter()
+    manifest = publisher.publish(
+        model,
+        weight_version=args.weight_version,
+        metadata={"benchmark": "weight_sync_bridge_rollout_update"},
+    )
+    publish_finished = time.perf_counter()
+
+    update_started = time.perf_counter()
+    weights = rollout.update_weights(manifest)
+    update_finished = time.perf_counter()
+
+    if rollout.active_weight_version != manifest.weight_version:
+        raise RuntimeError("rollout active weight version did not advance")
+    if install_calls != [(manifest.update_id, manifest.tensor_count)]:
+        raise RuntimeError("vLLM install adapter did not receive the complete manifest")
+    if set(weights) != set(model.state_dict()):
+        raise RuntimeError("rollout imported tensor names did not match model state")
+
+    release_started = time.perf_counter()
+    rollout.release_weights()
+    publisher.release(manifest.update_id)
+    release_finished = time.perf_counter()
+
+    return {
+        "timestamp": _timestamp(),
+        "candidate_id": "issue-13-candidate-5",
+        "mode": "rollout-update",
+        "status": "pass",
+        "environment": _environment(),
+        "tensor_count": manifest.tensor_count,
+        "total_nbytes": manifest.total_nbytes,
+        "publish_ms": (publish_finished - publish_started) * 1000,
+        "import_ms": (update_finished - update_started) * 1000,
+        "ack_ms": "",
+        "release_ms": (release_finished - release_started) * 1000,
+        "active_weight_version": manifest.weight_version,
+        "notes": (
+            "RolloutExecutor.update_weights imported shared-memory manifest, "
+            "called vLLM install adapter, acknowledged, activated, and released."
+        ),
+    }
+
+
+def _run_cuda_vmm_rollout_update(args: argparse.Namespace) -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        raise WeightBridgeUnavailableError(
+            "CUDA VMM rollout update smoke requires torch CUDA availability"
+        )
+
+    model = _model(args.hidden_dim, args.layers).to("cuda")
+    publisher = CUDAVMMTensorBridge(source_worker="benchmark-training", source_rank=0)
+    consumer = CUDAVMMTensorBridge(source_worker="benchmark-rollout", source_rank=1)
+    install_calls: list[tuple[str, int, str]] = []
+    adapter = VLLMWeightInstallAdapter(
+        object(),
+        install_callable=lambda manifest, tensors: install_calls.append(
+            (manifest.update_id, len(tensors), str(next(iter(tensors.values())).device))
+        ),
+    )
+    rollout = RolloutExecutor(
+        {"weight_transport": "cuda-vmm"},
+        weight_bridge=consumer,
+        weight_install_adapter=adapter,
+    )
+    manifest = None
+    try:
+        publish_started = time.perf_counter()
+        manifest = publisher.publish(
+            model,
+            weight_version=args.weight_version,
+            metadata={"benchmark": "cuda_vmm_rollout_update"},
+        )
+        publish_finished = time.perf_counter()
+
+        update_started = time.perf_counter()
+        weights = rollout.update_weights(manifest)
+        update_finished = time.perf_counter()
+
+        if rollout.active_weight_version != manifest.weight_version:
+            raise RuntimeError("rollout active weight version did not advance")
+        if install_calls != [(manifest.update_id, manifest.tensor_count, "cuda:0")]:
+            raise RuntimeError("vLLM install adapter did not receive CUDA VMM tensors")
+        if set(weights) != set(model.state_dict()):
+            raise RuntimeError("rollout imported tensor names did not match model state")
+
+        first_name = next(iter(weights))
+        before = weights[first_name].detach().cpu().flatten()[:4].tolist()
+        weights[first_name].add_(7)
+        torch.cuda.synchronize()
+        after = weights[first_name].detach().cpu().flatten()[:4].tolist()
+        if not all(abs((b + 7) - a) < 1e-2 for b, a in zip(before, after, strict=False)):
+            raise RuntimeError("CUDA VMM rollout tensor mutation was not visible")
+    finally:
+        release_started = time.perf_counter()
+        rollout.release_weights()
+        if manifest is not None:
+            publisher.release(manifest.update_id)
+        release_finished = time.perf_counter()
+
+    return {
+        "timestamp": _timestamp(),
+        "candidate_id": "issue-13-candidate-9",
+        "mode": "cuda-vmm-rollout-update",
+        "status": "pass",
+        "environment": _environment(),
+        "tensor_count": manifest.tensor_count,
+        "total_nbytes": manifest.total_nbytes,
+        "publish_ms": (publish_finished - publish_started) * 1000,
+        "import_ms": (update_finished - update_started) * 1000,
+        "ack_ms": "",
+        "release_ms": (release_finished - release_started) * 1000,
+        "active_weight_version": manifest.weight_version,
+        "notes": (
+            "RolloutExecutor.update_weights consumed a CUDA VMM manifest, "
+            "called the vLLM install adapter with CUDA tensors, acknowledged, "
+            f"activated, and observed in-place CUDA alias mutation from {before} to {after}."
+        ),
+    }
+
+
+class _StateDictModule(torch.nn.Module):
+    def __init__(self, state_dict: Mapping[str, torch.Tensor]):
+        super().__init__()
+        self._state_dict = dict(state_dict)
+
+    def state_dict(self, *args: Any, **kwargs: Any) -> Mapping[str, torch.Tensor]:
+        del args, kwargs
+        return self._state_dict
+
+
+def _run_vllm_cuda_vmm_external_storage(args: argparse.Namespace) -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        raise WeightBridgeUnavailableError(
+            "vLLM CUDA VMM external-storage smoke requires torch CUDA availability"
+        )
+    model_path = getattr(args, "model", None)
+    if not model_path:
+        raise WeightBridgeUnavailableError(
+            "vLLM CUDA VMM external-storage smoke requires --model pointing to a local model"
+        )
+
+    from vllm import LLM, SamplingParams
+
+    def generate(llm: Any) -> dict[str, Any]:
+        output = llm.generate(["Hello"], SamplingParams(max_tokens=4, temperature=0.0))[0]
+        return {
+            "text": output.outputs[0].text,
+            "token_ids": list(output.outputs[0].token_ids),
+        }
+
+    def parameter_specs(model: torch.nn.Module) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": name,
+                "shape": tuple(int(dim) for dim in parameter.shape),
+                "dtype": str(parameter.dtype),
+            }
+            for name, parameter in model.named_parameters()
+        ]
+
+    llm = LLM(
+        model=model_path,
+        tokenizer=model_path,
+        dtype="float16",
+        max_model_len=64,
+        gpu_memory_utilization=0.25,
+        trust_remote_code=False,
+        enforce_eager=True,
+    )
+    before = generate(llm)
+    specs = llm.llm_engine.apply_model(parameter_specs)[0]
+    state = {
+        spec["name"]: torch.zeros(
+            tuple(spec["shape"]),
+            dtype=_dtype_from_string(spec["dtype"]),
+            device="cuda",
+        ).contiguous()
+        for spec in specs
+    }
+
+    publisher = CUDAVMMTensorBridge(source_worker="benchmark-training", source_rank=0)
+    manifest = publisher.publish(
+        _StateDictModule(state),
+        weight_version=args.weight_version,
+        metadata={"benchmark": "vllm_cuda_vmm_external_storage"},
+    )
+    adapter = VLLMCUDAVMMExternalStorageAdapter(
+        llm.llm_engine,
+        require_all_parameters=True,
+        synchronize_cuda=True,
+    )
+    try:
+        install_started = time.perf_counter()
+        adapter.install(manifest, {})
+        install_finished = time.perf_counter()
+        after = generate(llm)
+        if before == after:
+            raise RuntimeError("vLLM generation did not change after CUDA VMM storage binding")
+        rebound = adapter.last_result[0]["rebound"] if adapter.last_result else []
+        if len(rebound) != manifest.tensor_count:
+            raise RuntimeError("vLLM CUDA VMM adapter did not bind every manifest tensor")
+    finally:
+        release_started = time.perf_counter()
+        adapter.release(manifest.update_id)
+        publisher.release(manifest.update_id)
+        release_finished = time.perf_counter()
+
+    return {
+        "timestamp": _timestamp(),
+        "candidate_id": "issue-13-candidate-10",
+        "mode": "vllm-cuda-vmm-external-storage",
+        "status": "pass",
+        "environment": _environment() + f";vllm_model={model_path}",
+        "tensor_count": manifest.tensor_count,
+        "total_nbytes": manifest.total_nbytes,
+        "publish_ms": "",
+        "import_ms": (install_finished - install_started) * 1000,
+        "ack_ms": "",
+        "release_ms": (release_finished - release_started) * 1000,
+        "active_weight_version": manifest.weight_version,
+        "notes": (
+            "Real vLLM worker imported CUDA VMM manifest via apply_model, rebound "
+            f"{len(rebound)} kernel-format parameters to external storage, and generation "
+            f"changed from token_ids={before['token_ids']} to token_ids={after['token_ids']}."
+        ),
+    }
+
+
+def _dtype_from_string(value: str) -> torch.dtype:
+    dtype = getattr(torch, value.removeprefix("torch."), None)
+    if not isinstance(dtype, torch.dtype):
+        raise WeightManifestValidationError(f"unsupported dtype in vLLM spec: {value}")
+    return dtype
+
+
+def _run_runtime_blockers() -> dict[str, Any]:
+    optional_runtimes = ("deepspeed", "ray", "vllm")
+    missing = [
+        runtime for runtime in optional_runtimes if importlib.util.find_spec(runtime) is None
+    ]
+    if missing:
+        status = "blocked"
+        notes = (
+            "Real runtime validation is blocked because these optional packages "
+            f"are not installed in this environment: {', '.join(missing)}. "
+            "Contract tests use fakes and guarded adapters; no production runtime "
+            "success is claimed for the missing packages."
+        )
+    else:
+        status = "pass"
+        notes = (
+            "Optional runtime packages are importable. This row is only a capability "
+            "probe; run dedicated DeepSpeed/Ray/vLLM integration tests before claiming "
+            "production hot-weight update support."
+        )
+    return {
+        "timestamp": _timestamp(),
+        "candidate_id": "issue-13-runtime-probe",
+        "mode": "runtime-blockers",
+        "status": status,
+        "environment": _environment(),
+        "tensor_count": 0,
+        "total_nbytes": 0,
+        "publish_ms": "",
+        "import_ms": "",
+        "ack_ms": "",
+        "release_ms": "",
+        "active_weight_version": "",
+        "notes": notes,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument(
+        "--mode",
+        choices=[
+            "local",
+            "shared-memory",
+            "cuda-ipc",
+            "cuda-vmm",
+            "cuda-vmm-rollout-update",
+            "rollout-update",
+            "runtime-blockers",
+            "vllm-cuda-vmm-external-storage",
+        ],
+        default="local",
+    )
+    parser.add_argument("--hidden-dim", type=int, default=64)
+    parser.add_argument("--layers", type=int, default=4)
+    parser.add_argument("--weight-version", type=int, default=1)
+    parser.add_argument("--model", default=None)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional CSV output path. JSON is always printed to stdout.",
+    )
+    args = parser.parse_args()
+
+    if args.smoke:
+        args.hidden_dim = min(args.hidden_dim, 64)
+        args.layers = min(args.layers, 4)
+
+    if args.mode == "local":
+        row = _run_local(args)
+    elif args.mode == "shared-memory":
+        row = _run_shared_memory(args)
+    elif args.mode == "cuda-ipc":
+        row = _run_cuda_ipc()
+    elif args.mode == "cuda-vmm":
+        row = _run_cuda_vmm(args)
+    elif args.mode == "cuda-vmm-rollout-update":
+        row = _run_cuda_vmm_rollout_update(args)
+    elif args.mode == "rollout-update":
+        row = _run_rollout_update(args)
+    elif args.mode == "vllm-cuda-vmm-external-storage":
+        row = _run_vllm_cuda_vmm_external_storage(args)
+    else:
+        row = _run_runtime_blockers()
+
+    if args.output is not None:
+        _write_csv_row(row, args.output)
+    print(json.dumps(row, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/rl_engine/executors/bridge.py
+++ b/rl_engine/executors/bridge.py
@@ -1,62 +1,2358 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
 
+from __future__ import annotations
+
+import hashlib
+import inspect
+import os
+import sys
+import socket
+import time
+import uuid
+import weakref
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from multiprocessing import shared_memory
+from typing import Any, Mapping, Optional, Protocol
+
 import torch
-from typing import Dict, Any
+
 from rl_engine.utils.logger import logger
+
+
+_BRIDGE_METADATA_KEY = "weight_bridge"
+_SHARED_MEMORY_FORMAT = "python-multiprocessing-shared-memory-v1"
+_CUDA_VMM_FORMAT = "cuda-vmm-posix-fd-v1"
+_CUDA_VMM_TENSOR_ALIGNMENT = 256
+_SHARED_MEMORY_HAS_TRACK = "track" in inspect.signature(shared_memory.SharedMemory).parameters
+_SUPPORTED_LAYOUT_KINDS = {"full-state", "replicated"}
+
+
+@dataclass(frozen=True)
+class WeightLayout:
+    """
+    Describes how model state is represented in a published update.
+
+    Issue #13 only supports complete full-state or replicated layouts. ZeRO-3,
+    tensor-parallel shards, and multi-node/RDMA transfers must pass through an
+    explicit blocker until a gather/merge transport is implemented and tested.
+    """
+
+    kind: str = "full-state"
+    world_size: int = 1
+    rank: int = 0
+    tensor_parallel_size: int = 1
+    data_parallel_size: int = 1
+    zero_stage: int = 0
+    node_count: int = 1
+    rdma_enabled: bool = False
+
+    @classmethod
+    def from_metadata(cls, metadata: Optional[Mapping[str, Any]]) -> WeightLayout:
+        if metadata is None:
+            return cls()
+        raw_layout = metadata.get("layout", {})
+        if raw_layout is None:
+            return cls()
+        if not isinstance(raw_layout, Mapping):
+            raise WeightManifestValidationError("weight layout metadata must be a mapping")
+        return cls(
+            kind=str(raw_layout.get("kind", "full-state")),
+            world_size=int(raw_layout.get("world_size", 1)),
+            rank=int(raw_layout.get("rank", 0)),
+            tensor_parallel_size=int(raw_layout.get("tensor_parallel_size", 1)),
+            data_parallel_size=int(raw_layout.get("data_parallel_size", 1)),
+            zero_stage=int(raw_layout.get("zero_stage", 0)),
+            node_count=int(raw_layout.get("node_count", 1)),
+            rdma_enabled=bool(raw_layout.get("rdma_enabled", False)),
+        )
+
+    def to_metadata(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "world_size": self.world_size,
+            "rank": self.rank,
+            "tensor_parallel_size": self.tensor_parallel_size,
+            "data_parallel_size": self.data_parallel_size,
+            "zero_stage": self.zero_stage,
+            "node_count": self.node_count,
+            "rdma_enabled": self.rdma_enabled,
+        }
+
+    def validate_supported(self) -> None:
+        if self.kind not in _SUPPORTED_LAYOUT_KINDS:
+            raise WeightBridgeUnavailableError(
+                f"weight layout {self.kind!r} is not supported by this bridge. "
+                "Publish a gathered full-state update or implement a layout-aware "
+                "transport before exposing it to rollout workers."
+            )
+        if self.zero_stage >= 3:
+            raise WeightBridgeUnavailableError(
+                "DeepSpeed ZeRO-3 partitioned state is not supported by this bridge. "
+                "Run a real all-gather/full-state export before publishing weights."
+            )
+        if self.tensor_parallel_size != 1:
+            raise WeightBridgeUnavailableError(
+                "tensor-parallel weight layouts are not supported by this bridge. "
+                "Publish a complete per-consumer layout or add a tensor-parallel adapter."
+            )
+        if self.node_count != 1 or self.rdma_enabled:
+            raise WeightBridgeUnavailableError(
+                "multi-node/RDMA weight transport is not implemented. Use same-node "
+                "local/shared-memory transport or add an RDMA/NCCL transport first."
+            )
+        if self.world_size < 1 or self.rank < 0 or self.rank >= self.world_size:
+            raise WeightManifestValidationError(
+                f"invalid weight layout rank/world_size: rank={self.rank}, "
+                f"world_size={self.world_size}"
+            )
+        if self.data_parallel_size < 1:
+            raise WeightManifestValidationError("data_parallel_size must be >= 1")
+
+
+class VLLMWeightInstallAdapter:
+    """
+    Guarded adapter for installing imported tensors into a rollout engine.
+
+    vLLM does not expose one stable public hot-weight update API across versions,
+    so the adapter accepts explicit callable capability hooks instead of poking
+    private internals. That lets production integrations opt in when their vLLM
+    runtime provides a verified install method, while default construction stays
+    explicit and safe.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        install_callable: Optional[Any] = None,
+        request_builder: Optional[Any] = None,
+        release_callable: Optional[Any] = None,
+    ):
+        self.engine = engine
+        self._install_callable = install_callable
+        self._request_builder = request_builder
+        self._release_callable = release_callable
+        self.active_weight_version: Optional[int] = None
+        self.active_update_id: Optional[str] = None
+
+    def install(
+        self,
+        manifest: WeightUpdateManifest,
+        tensors: Mapping[str, torch.Tensor],
+    ) -> None:
+        tensors = dict(tensors)
+        if self._install_callable is not None:
+            self._install_callable(manifest, tensors)
+        else:
+            update_weights = getattr(self.engine, "update_weights", None)
+            if callable(update_weights):
+                if self._request_builder is None:
+                    raise WeightBridgeUnavailableError(
+                        "vLLM weight install requires a request_builder for engines "
+                        "that expose update_weights(request). vLLM does not accept a "
+                        "raw manifest/tensor mapping for this public API."
+                    )
+                try:
+                    update_weights(self._request_builder(manifest, tensors))
+                except Exception:
+                    request_builder_release = getattr(self._request_builder, "release", None)
+                    if callable(request_builder_release):
+                        request_builder_release(manifest.update_id)
+                    raise
+            else:
+                install = self._resolve_manifest_install_callable()
+                install(manifest, tensors)
+        self.active_weight_version = manifest.weight_version
+        self.active_update_id = manifest.update_id
+
+    def release(self, update_id: str) -> None:
+        if self._release_callable is not None:
+            self._release_callable(update_id)
+        request_builder_release = getattr(self._request_builder, "release", None)
+        if callable(request_builder_release):
+            request_builder_release(update_id)
+        if self.active_update_id == update_id:
+            self.active_update_id = None
+
+    def _resolve_manifest_install_callable(self) -> Any:
+        for attr in (
+            "install_weight_update",
+            "update_weights_from_manifest",
+            "load_weights_from_manifest",
+        ):
+            candidate = getattr(self.engine, attr, None)
+            if callable(candidate):
+                return candidate
+        raise WeightBridgeUnavailableError(
+            "vLLM weight install is unavailable because this engine does not expose "
+            "a verified hot-weight install capability. Pass an explicit "
+            "install_callable for the installed vLLM version."
+        )
+
+
+class VLLMIPCWeightUpdateRequestBuilder:
+    """
+    Build the public vLLM IPC weight-update request shape.
+
+    vLLM 0.18+ expects `LLM.update_weights({"update_info": ...})` for IPC
+    backends. The update info carries CUDA IPC handles produced by PyTorch's
+    `reduce_tensor`, so the source CUDA tensors must remain alive until the
+    vLLM update call completes. This builder keeps those contiguous tensors in
+    an update-scoped keepalive registry and releases them when the install
+    adapter releases the update.
+    """
+
+    def __init__(
+        self,
+        *,
+        is_checkpoint_format: bool = True,
+        reduce_tensor_fn: Optional[Any] = None,
+        gpu_uuid: Optional[str] = None,
+    ):
+        self.is_checkpoint_format = bool(is_checkpoint_format)
+        self._reduce_tensor_fn = reduce_tensor_fn
+        self._gpu_uuid = gpu_uuid
+        self._keepalive: dict[str, list[torch.Tensor]] = {}
+
+    def __call__(
+        self,
+        manifest: WeightUpdateManifest,
+        tensors: Mapping[str, torch.Tensor],
+    ) -> dict[str, Any]:
+        WeightLayout.from_metadata(manifest.metadata).validate_supported()
+        tensor_map = dict(tensors)
+        if set(tensor_map) != set(manifest.tensors):
+            missing = sorted(set(manifest.tensors) - set(tensor_map))
+            extra = sorted(set(tensor_map) - set(manifest.tensors))
+            raise WeightManifestValidationError(
+                f"vLLM IPC tensor set mismatch: missing={missing}, extra={extra}"
+            )
+
+        reduce_tensor = self._resolve_reduce_tensor()
+        gpu_uuid = self._gpu_uuid or self._current_gpu_uuid()
+        names: list[str] = []
+        dtype_names: list[str] = []
+        shapes: list[list[int]] = []
+        ipc_handles: list[dict[str, Any]] = []
+        keepalive: list[torch.Tensor] = []
+
+        for name, descriptor in manifest.tensors.items():
+            tensor = tensor_map[name]
+            if getattr(tensor.device, "type", None) != "cuda":
+                raise WeightBridgeUnavailableError(
+                    "vLLM IPC weight update requires CUDA tensors. "
+                    f"Tensor {name} is on {tensor.device}."
+                )
+            if tuple(int(dim) for dim in tensor.shape) != descriptor.shape:
+                raise WeightManifestValidationError(
+                    f"vLLM IPC tensor shape mismatch for {name}: "
+                    f"expected {descriptor.shape}, got {tuple(tensor.shape)}"
+                )
+            if str(tensor.dtype) != descriptor.dtype:
+                raise WeightManifestValidationError(
+                    f"vLLM IPC tensor dtype mismatch for {name}: "
+                    f"expected {descriptor.dtype}, got {tensor.dtype}"
+                )
+
+            weight = tensor.detach().contiguous()
+            keepalive.append(weight)
+            names.append(name)
+            dtype_names.append(str(weight.dtype).split(".")[-1])
+            shapes.append([int(dim) for dim in weight.shape])
+            ipc_handles.append({gpu_uuid: reduce_tensor(weight)})
+
+        self._keepalive[manifest.update_id] = keepalive
+        return {
+            "update_info": {
+                "names": names,
+                "dtype_names": dtype_names,
+                "shapes": shapes,
+                "ipc_handles": ipc_handles,
+                "is_checkpoint_format": self.is_checkpoint_format,
+            }
+        }
+
+    def release(self, update_id: str) -> None:
+        self._keepalive.pop(update_id, None)
+
+    def _resolve_reduce_tensor(self) -> Any:
+        if self._reduce_tensor_fn is not None:
+            return self._reduce_tensor_fn
+        try:
+            from torch.multiprocessing.reductions import reduce_tensor
+        except ImportError as exc:
+            raise WeightBridgeUnavailableError(
+                "PyTorch CUDA IPC reductions are unavailable in this runtime."
+            ) from exc
+        return reduce_tensor
+
+    def _current_gpu_uuid(self) -> str:
+        if not torch.cuda.is_available():
+            raise WeightBridgeUnavailableError(
+                "vLLM IPC weight update requires CUDA, but torch.cuda.is_available() is false."
+            )
+        device_index = torch.cuda.current_device()
+        return str(torch.cuda.get_device_properties(device_index).uuid)
+
+
+class VLLMInProcessWeightReloadAdapter:
+    """
+    Install a manifest through vLLM's in-process `reload_weights` utility path.
+
+    This adapter is for single-process vLLM deployments, for example vLLM V1
+    with `VLLM_ENABLE_V1_MULTIPROCESSING=0`. It is a real hot-weight install
+    path, but it is not CUDA IPC zero-copy: tensors are passed directly to the
+    in-process worker and vLLM performs the model reload/copy into GPU weights.
+    Multiprocess vLLM should use the IPC or NCCL public `update_weights` APIs
+    once those transports are validated on the target hardware.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        target_dtype: Optional[torch.dtype] = None,
+        target_device: Optional[torch.device | str] = None,
+        is_checkpoint_format: bool = True,
+        synchronize_cuda: bool = True,
+    ):
+        self.engine = engine
+        self.target_dtype = target_dtype
+        self.target_device = target_device
+        self.is_checkpoint_format = bool(is_checkpoint_format)
+        self.synchronize_cuda = bool(synchronize_cuda)
+        self.active_weight_version: Optional[int] = None
+        self.active_update_id: Optional[str] = None
+
+    def install(
+        self,
+        manifest: WeightUpdateManifest,
+        tensors: Mapping[str, torch.Tensor],
+    ) -> None:
+        WeightLayout.from_metadata(manifest.metadata).validate_supported()
+        tensor_map = dict(tensors)
+        if set(tensor_map) != set(manifest.tensors):
+            missing = sorted(set(manifest.tensors) - set(tensor_map))
+            extra = sorted(set(tensor_map) - set(manifest.tensors))
+            raise WeightManifestValidationError(
+                f"vLLM reload tensor set mismatch: missing={missing}, extra={extra}"
+            )
+
+        weights: list[tuple[str, torch.Tensor]] = []
+        for name, descriptor in manifest.tensors.items():
+            tensor = tensor_map[name]
+            if tuple(int(dim) for dim in tensor.shape) != descriptor.shape:
+                raise WeightManifestValidationError(
+                    f"vLLM reload tensor shape mismatch for {name}: "
+                    f"expected {descriptor.shape}, got {tuple(tensor.shape)}"
+                )
+            if str(tensor.dtype) != descriptor.dtype:
+                raise WeightManifestValidationError(
+                    f"vLLM reload tensor dtype mismatch for {name}: "
+                    f"expected {descriptor.dtype}, got {tensor.dtype}"
+                )
+
+            weight = tensor.detach()
+            if self.target_dtype is not None and weight.dtype != self.target_dtype:
+                weight = weight.to(dtype=self.target_dtype)
+            if self.target_device is not None and torch.device(self.target_device) != weight.device:
+                weight = weight.to(device=self.target_device)
+            if not weight.is_contiguous():
+                weight = weight.contiguous()
+            weights.append((name, weight))
+
+        try:
+            reload_weights = self._resolve_reload_weights()
+            reload_weights(weights)
+            if self.synchronize_cuda and torch.cuda.is_available():
+                torch.cuda.synchronize()
+        except Exception:
+            self.active_update_id = None
+            raise
+
+        self.active_weight_version = manifest.weight_version
+        self.active_update_id = manifest.update_id
+
+    def release(self, update_id: str) -> None:
+        if self.active_update_id == update_id:
+            self.active_update_id = None
+
+    def _resolve_reload_weights(self) -> Any:
+        reload_weights = getattr(self.engine, "reload_weights", None)
+        if callable(reload_weights):
+            return lambda weights: reload_weights(
+                weights_iterator=weights,
+                is_checkpoint_format=self.is_checkpoint_format,
+            )
+
+        collective_rpc = getattr(self.engine, "collective_rpc", None)
+        if not callable(collective_rpc):
+            llm_engine = getattr(self.engine, "llm_engine", None)
+            collective_rpc = getattr(llm_engine, "collective_rpc", None)
+        if callable(collective_rpc):
+            return lambda weights: collective_rpc(
+                "reload_weights",
+                kwargs={
+                    "weights_iterator": weights,
+                    "is_checkpoint_format": self.is_checkpoint_format,
+                },
+            )
+
+        raise WeightBridgeUnavailableError(
+            "vLLM in-process weight reload is unavailable because this engine "
+            "does not expose reload_weights(...) or llm_engine.collective_rpc(...)."
+        )
+
+
+class VLLMCheckpointWeightReloadAdapter:
+    """
+    Install a manifest through vLLM's checkpoint-path reload utility path.
+
+    This path works with vLLM's default EngineCore multiprocessing because the
+    worker process reloads weights from `weights_path` itself; no CUDA tensor is
+    serialized across the RPC boundary. It is a production-aligned hot reload
+    fallback for environments where CUDA IPC/NCCL transport is unavailable, but
+    it is not a zero-copy transport.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        weights_path: Optional[str] = None,
+        weights_path_resolver: Optional[Any] = None,
+        metadata_key: str = "vllm_weights_path",
+        is_checkpoint_format: bool = True,
+        synchronize_cuda: bool = True,
+    ):
+        self.engine = engine
+        self.weights_path = weights_path
+        self.weights_path_resolver = weights_path_resolver
+        self.metadata_key = metadata_key
+        self.is_checkpoint_format = bool(is_checkpoint_format)
+        self.synchronize_cuda = bool(synchronize_cuda)
+        self.active_weight_version: Optional[int] = None
+        self.active_update_id: Optional[str] = None
+
+    def install(
+        self,
+        manifest: WeightUpdateManifest,
+        tensors: Mapping[str, torch.Tensor],
+    ) -> None:
+        WeightLayout.from_metadata(manifest.metadata).validate_supported()
+        tensor_map = dict(tensors)
+        if set(tensor_map) != set(manifest.tensors):
+            missing = sorted(set(manifest.tensors) - set(tensor_map))
+            extra = sorted(set(tensor_map) - set(manifest.tensors))
+            raise WeightManifestValidationError(
+                f"vLLM checkpoint reload tensor set mismatch: missing={missing}, extra={extra}"
+            )
+
+        weights_path = self._resolve_weights_path(manifest, tensor_map)
+        try:
+            reload_weights = self._resolve_reload_weights()
+            reload_weights(weights_path)
+            if self.synchronize_cuda and torch.cuda.is_available():
+                torch.cuda.synchronize()
+        except Exception:
+            self.active_update_id = None
+            raise
+
+        self.active_weight_version = manifest.weight_version
+        self.active_update_id = manifest.update_id
+
+    def release(self, update_id: str) -> None:
+        if self.active_update_id == update_id:
+            self.active_update_id = None
+
+    def _resolve_weights_path(
+        self,
+        manifest: WeightUpdateManifest,
+        tensors: Mapping[str, torch.Tensor],
+    ) -> str:
+        if self.weights_path:
+            return self.weights_path
+        if self.weights_path_resolver is not None:
+            resolved = self.weights_path_resolver(manifest, tensors)
+            if resolved:
+                return str(resolved)
+        resolved = manifest.metadata.get(self.metadata_key)
+        if resolved:
+            return str(resolved)
+        raise WeightBridgeUnavailableError(
+            "vLLM checkpoint reload requires a weights_path, a weights_path_resolver, "
+            f"or manifest.metadata[{self.metadata_key!r}]."
+        )
+
+    def _resolve_reload_weights(self) -> Any:
+        reload_weights = getattr(self.engine, "reload_weights", None)
+        if callable(reload_weights):
+            return lambda weights_path: reload_weights(
+                weights_path=weights_path,
+                is_checkpoint_format=self.is_checkpoint_format,
+            )
+
+        collective_rpc = getattr(self.engine, "collective_rpc", None)
+        if not callable(collective_rpc):
+            llm_engine = getattr(self.engine, "llm_engine", None)
+            collective_rpc = getattr(llm_engine, "collective_rpc", None)
+        if callable(collective_rpc):
+            return lambda weights_path: collective_rpc(
+                "reload_weights",
+                kwargs={
+                    "weights_path": weights_path,
+                    "is_checkpoint_format": self.is_checkpoint_format,
+                },
+            )
+
+        raise WeightBridgeUnavailableError(
+            "vLLM checkpoint weight reload is unavailable because this engine "
+            "does not expose reload_weights(...) or llm_engine.collective_rpc(...)."
+        )
+
+
+def _install_vllm_cuda_vmm_aliases_on_worker(
+    manifest: WeightUpdateManifest,
+    *,
+    device_index: int,
+    source_worker: str,
+    source_rank: int,
+) -> Callable[[torch.nn.Module], dict[str, Any]]:
+    def install(model: torch.nn.Module) -> dict[str, Any]:
+        bridge = CUDAVMMTensorBridge(
+            source_worker=source_worker,
+            source_rank=source_rank,
+            device_index=device_index,
+        )
+        imported = dict(bridge.import_update(manifest))
+        rebound: list[str] = []
+        original_data = dict(getattr(model, "_kernel_align_cuda_vmm_original_data", {}))
+        try:
+            named_parameters = dict(model.named_parameters())
+            with torch.no_grad():
+                for name, tensor in imported.items():
+                    parameter = named_parameters.get(name)
+                    if parameter is None:
+                        continue
+                    if tuple(parameter.shape) != tuple(tensor.shape):
+                        raise WeightManifestValidationError(
+                            f"vLLM CUDA VMM parameter shape mismatch for {name}: "
+                            f"expected {tuple(parameter.shape)}, got {tuple(tensor.shape)}"
+                        )
+                    if parameter.dtype != tensor.dtype:
+                        raise WeightManifestValidationError(
+                            f"vLLM CUDA VMM parameter dtype mismatch for {name}: "
+                            f"expected {parameter.dtype}, got {tensor.dtype}"
+                        )
+                    original_data.setdefault(name, parameter.data)
+                    parameter.data = tensor
+                    rebound.append(name)
+            bridge.acknowledge(manifest.update_id)
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+            model._kernel_align_cuda_vmm_bridge = bridge
+            model._kernel_align_cuda_vmm_update_id = manifest.update_id
+            model._kernel_align_cuda_vmm_tensors = imported
+            model._kernel_align_cuda_vmm_original_data = original_data
+            return {
+                "update_id": manifest.update_id,
+                "weight_version": manifest.weight_version,
+                "rebound": rebound,
+                "tensor_count": len(imported),
+                "zero_copy": True,
+            }
+        except Exception:
+            named_parameters = dict(model.named_parameters())
+            with torch.no_grad():
+                for name in rebound:
+                    parameter = named_parameters.get(name)
+                    original = original_data.get(name)
+                    if parameter is not None and original is not None:
+                        parameter.data = original
+            for attr in (
+                "_kernel_align_cuda_vmm_bridge",
+                "_kernel_align_cuda_vmm_update_id",
+                "_kernel_align_cuda_vmm_tensors",
+                "_kernel_align_cuda_vmm_original_data",
+            ):
+                if hasattr(model, attr):
+                    delattr(model, attr)
+            imported.clear()
+            bridge.release(manifest.update_id)
+            raise
+
+    return install
+
+
+class VLLMCUDAVMMExternalStorageAdapter:
+    """
+    Bind vLLM worker parameters to tensors imported from a CUDA VMM manifest.
+
+    The vLLM worker imports the manifest itself through `apply_model`, then
+    replaces matching `torch.nn.Parameter.data` storage with CUDA VMM DLPack
+    aliases. This is a same-node zero-copy storage binding path and does not use
+    legacy PyTorch CUDA IPC.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        device_index: int = 0,
+        source_worker: str = "vllm-rollout",
+        source_rank: int = 0,
+        require_all_parameters: bool = False,
+        synchronize_cuda: bool = True,
+    ):
+        self.engine = engine
+        self.device_index = int(device_index)
+        self.source_worker = source_worker
+        self.source_rank = int(source_rank)
+        self.require_all_parameters = bool(require_all_parameters)
+        self.synchronize_cuda = bool(synchronize_cuda)
+        self.active_weight_version: Optional[int] = None
+        self.active_update_id: Optional[str] = None
+        self.last_result: list[dict[str, Any]] = []
+
+    def install(
+        self,
+        manifest: WeightUpdateManifest,
+        tensors: Mapping[str, torch.Tensor],
+    ) -> None:
+        del tensors
+        WeightLayout.from_metadata(manifest.metadata).validate_supported()
+        if manifest.transport != CUDAVMMTensorBridge.transport:
+            raise WeightBridgeUnavailableError(
+                "vLLM CUDA VMM external-storage install requires a cuda-vmm manifest."
+            )
+        previous_update_id = self.active_update_id
+        if previous_update_id is not None and previous_update_id != manifest.update_id:
+            self.release(previous_update_id)
+        apply_model = self._resolve_apply_model()
+        install_fn = _install_vllm_cuda_vmm_aliases_on_worker(
+            manifest,
+            device_index=self.device_index,
+            source_worker=self.source_worker,
+            source_rank=self.source_rank,
+        )
+        results = apply_model(install_fn)
+        if not isinstance(results, list):
+            results = [results]
+        normalized = [dict(result or {}) for result in results]
+        rebound = set().union(*(set(result.get("rebound", [])) for result in normalized))
+        missing = sorted(set(manifest.tensors) - rebound)
+        if self.require_all_parameters and missing:
+            self.release(manifest.update_id)
+            raise WeightManifestValidationError(
+                f"vLLM CUDA VMM install did not bind every manifest tensor: missing={missing}"
+            )
+        if self.synchronize_cuda and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        self.last_result = normalized
+        self.active_weight_version = manifest.weight_version
+        self.active_update_id = manifest.update_id
+
+    def release(self, update_id: str) -> None:
+        release_fn = self._resolve_release_model_fn(update_id)
+        if release_fn is not None:
+            try:
+                release_fn()
+            except Exception:
+                logger.exception("Failed to release vLLM CUDA VMM update %s", update_id)
+        if self.active_update_id == update_id:
+            self.active_update_id = None
+
+    def _resolve_apply_model(self) -> Callable[[Any], Any]:
+        apply_model = getattr(self.engine, "apply_model", None)
+        if callable(apply_model):
+            return apply_model
+        llm_engine = getattr(self.engine, "llm_engine", None)
+        apply_model = getattr(llm_engine, "apply_model", None)
+        if callable(apply_model):
+            return apply_model
+        collective_rpc = getattr(self.engine, "collective_rpc", None)
+        if not callable(collective_rpc) and llm_engine is not None:
+            collective_rpc = getattr(llm_engine, "collective_rpc", None)
+        if callable(collective_rpc):
+            return lambda fn: collective_rpc("apply_model", args=(fn,))
+        raise WeightBridgeUnavailableError(
+            "vLLM CUDA VMM external-storage install requires apply_model(...) "
+            "or llm_engine.collective_rpc('apply_model', ...)."
+        )
+
+    def _resolve_release_model_fn(self, update_id: str) -> Optional[Callable[[], Any]]:
+        try:
+            apply_model = self._resolve_apply_model()
+        except WeightBridgeUnavailableError:
+            return None
+
+        def release_worker(model: torch.nn.Module) -> dict[str, Any]:
+            active_update_id = getattr(model, "_kernel_align_cuda_vmm_update_id", None)
+            if active_update_id != update_id:
+                return {"released": False, "update_id": active_update_id}
+            bridge = getattr(model, "_kernel_align_cuda_vmm_bridge", None)
+            tensors = getattr(model, "_kernel_align_cuda_vmm_tensors", None)
+            original_data = getattr(model, "_kernel_align_cuda_vmm_original_data", None)
+            if isinstance(original_data, dict):
+                named_parameters = dict(model.named_parameters())
+                with torch.no_grad():
+                    for name, data in original_data.items():
+                        parameter = named_parameters.get(name)
+                        if parameter is not None:
+                            parameter.data = data
+            if isinstance(tensors, dict):
+                tensors.clear()
+            if bridge is not None:
+                bridge.release(update_id)
+            for attr in (
+                "_kernel_align_cuda_vmm_bridge",
+                "_kernel_align_cuda_vmm_update_id",
+                "_kernel_align_cuda_vmm_tensors",
+                "_kernel_align_cuda_vmm_original_data",
+            ):
+                if hasattr(model, attr):
+                    delattr(model, attr)
+            return {"released": True, "update_id": update_id}
+
+        return lambda: apply_model(release_worker)
+
+
+def _create_shared_memory(size: int) -> shared_memory.SharedMemory:
+    return shared_memory.SharedMemory(create=True, size=size)
+
+
+def _attach_shared_memory(name: str) -> shared_memory.SharedMemory:
+    if _SHARED_MEMORY_HAS_TRACK:
+        return shared_memory.SharedMemory(name=name, track=False)
+    return shared_memory.SharedMemory(name=name)
+
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    dtype_name = name.removeprefix("torch.")
+    dtype = getattr(torch, dtype_name, None)
+    if not isinstance(dtype, torch.dtype):
+        raise WeightManifestValidationError(f"unsupported tensor dtype in manifest: {name}")
+    return dtype
+
+
+def _required_storage_numel(
+    shape: tuple[int, ...],
+    stride: tuple[int, ...],
+    storage_offset: int,
+) -> int:
+    if any(dim < 0 for dim in shape):
+        raise WeightManifestValidationError(f"invalid tensor shape: {shape}")
+    if any(item < 0 for item in stride):
+        raise WeightManifestValidationError(f"negative strides are not supported: {stride}")
+    if len(shape) != len(stride):
+        raise WeightManifestValidationError(
+            f"shape and stride rank mismatch: shape={shape}, stride={stride}"
+        )
+    if any(dim == 0 for dim in shape):
+        return 0
+    if not shape:
+        return storage_offset + 1
+    max_offset = sum((dim - 1) * item for dim, item in zip(shape, stride, strict=False))
+    return storage_offset + max_offset + 1
+
+
+def _tensor_sha256(tensor: torch.Tensor) -> str:
+    snapshot = tensor.detach()
+    if snapshot.device.type != "cpu":
+        snapshot = snapshot.cpu()
+    if not snapshot.is_contiguous():
+        snapshot = snapshot.contiguous()
+    return hashlib.sha256(bytes(snapshot.untyped_storage())).hexdigest()
+
+
+def _send_fd(sock: socket.socket, fd: int) -> None:
+    import array
+
+    fds = array.array("i", [int(fd)])
+    sock.sendmsg([b"F"], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, fds)])
+
+
+def _recv_fd(sock: socket.socket) -> int:
+    import array
+
+    fds = array.array("i")
+    message, ancdata, _flags, _address = sock.recvmsg(1, socket.CMSG_LEN(fds.itemsize))
+    if message != b"F":
+        raise WeightBridgeUnavailableError("CUDA VMM broker returned an invalid fd message")
+    for level, control_type, data in ancdata:
+        if level == socket.SOL_SOCKET and control_type == socket.SCM_RIGHTS:
+            fds.frombytes(data[: fds.itemsize])
+            return int(fds[0])
+    raise WeightBridgeUnavailableError("CUDA VMM broker did not send a POSIX fd")
+
+
+def _dtype_to_dlpack(dtype: torch.dtype) -> tuple[int, int, int]:
+    if dtype is torch.float16:
+        return (2, 16, 1)
+    if dtype is torch.float32:
+        return (2, 32, 1)
+    if dtype is torch.float64:
+        return (2, 64, 1)
+    if dtype is torch.bfloat16:
+        return (4, 16, 1)
+    if dtype is torch.int8:
+        return (0, 8, 1)
+    if dtype is torch.int16:
+        return (0, 16, 1)
+    if dtype is torch.int32:
+        return (0, 32, 1)
+    if dtype is torch.int64:
+        return (0, 64, 1)
+    if dtype is torch.uint8:
+        return (1, 8, 1)
+    if dtype is torch.bool:
+        return (1, 1, 1)
+    raise WeightBridgeUnavailableError(f"CUDA VMM DLPack export does not support {dtype}")
+
+
+def _dlpack_ctypes():
+    import ctypes
+
+    if hasattr(_dlpack_ctypes, "_cache"):
+        return _dlpack_ctypes._cache
+
+    class _DLDevice(ctypes.Structure):
+        _fields_ = [("device_type", ctypes.c_int), ("device_id", ctypes.c_int)]
+
+    class _DLDataType(ctypes.Structure):
+        _fields_ = [
+            ("code", ctypes.c_uint8),
+            ("bits", ctypes.c_uint8),
+            ("lanes", ctypes.c_uint16),
+        ]
+
+    class _DLTensor(ctypes.Structure):
+        _fields_ = [
+            ("data", ctypes.c_void_p),
+            ("device", _DLDevice),
+            ("ndim", ctypes.c_int),
+            ("dtype", _DLDataType),
+            ("shape", ctypes.POINTER(ctypes.c_int64)),
+            ("strides", ctypes.POINTER(ctypes.c_int64)),
+            ("byte_offset", ctypes.c_uint64),
+        ]
+
+    class _DLManagedTensor(ctypes.Structure):
+        pass
+
+    deleter_type = ctypes.CFUNCTYPE(None, ctypes.POINTER(_DLManagedTensor))
+
+    @deleter_type
+    def _noop_deleter(_ptr):
+        return None
+
+    _DLManagedTensor._fields_ = [
+        ("dl_tensor", _DLTensor),
+        ("manager_ctx", ctypes.c_void_p),
+        ("deleter", deleter_type),
+    ]
+    _dlpack_ctypes._cache = (
+        ctypes,
+        _DLDevice,
+        _DLDataType,
+        _DLTensor,
+        _DLManagedTensor,
+        _noop_deleter,
+    )
+    return _dlpack_ctypes._cache
+
+
+class _DLPackOwner:
+    def __init__(
+        self,
+        *,
+        address: int,
+        shape: tuple[int, ...],
+        stride: tuple[int, ...],
+        dtype: torch.dtype,
+        device_index: int,
+    ):
+        ctypes, _DLDevice, _DLDataType, _DLTensor, _DLManagedTensor, _noop_deleter = (
+            _dlpack_ctypes()
+        )
+
+        self._ctypes = ctypes
+        self._shape = (ctypes.c_int64 * len(shape))(*shape)
+        self._stride = (ctypes.c_int64 * len(stride))(*stride)
+        code, bits, lanes = _dtype_to_dlpack(dtype)
+        self._managed = _DLManagedTensor()
+        self._managed.dl_tensor = _DLTensor(
+            ctypes.c_void_p(address),
+            _DLDevice(2, int(device_index)),
+            len(shape),
+            _DLDataType(code, bits, lanes),
+            self._shape,
+            self._stride,
+            0,
+        )
+        self._managed.manager_ctx = None
+        self._managed.deleter = _noop_deleter
+
+    def to_tensor(self) -> torch.Tensor:
+        ctypes = self._ctypes
+        capsule_new = ctypes.pythonapi.PyCapsule_New
+        capsule_new.restype = ctypes.py_object
+        capsule_new.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+        capsule = capsule_new(
+            ctypes.cast(ctypes.pointer(self._managed), ctypes.c_void_p),
+            b"dltensor",
+            None,
+        )
+        return torch.utils.dlpack.from_dlpack(capsule)
+
+
+class _CUDAVMMDriverBackend:
+    def __init__(self, *, device_index: int = 0):
+        import ctypes
+        import ctypes.util
+
+        self.ctypes = ctypes
+        self.device_index = int(device_index)
+        self.lib = ctypes.CDLL(self._find_libcuda(ctypes.util.find_library("cuda")))
+        self._configure_signatures()
+        self._ensure_context()
+
+    @staticmethod
+    def _find_libcuda(discovered_path: Optional[str]) -> str:
+        candidates = [
+            os.environ.get("KERNEL_ALIGN_LIBCUDA_PATH"),
+            discovered_path,
+            "libcuda.so.1",
+            "libcuda.so",
+        ]
+        if sys.platform.startswith("linux"):
+            candidates.extend(
+                [
+                    "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
+                    "/usr/local/cuda/lib64/stubs/libcuda.so",
+                    "/usr/lib/wsl/lib/libcuda.so.1",
+                ]
+            )
+
+        errors: list[str] = []
+        for candidate in candidates:
+            if not candidate:
+                continue
+            try:
+                import ctypes
+
+                ctypes.CDLL(candidate)
+                return candidate
+            except OSError as exc:
+                errors.append(f"{candidate}: {exc}")
+        raise WeightBridgeUnavailableError(
+            "CUDA VMM requires libcuda.so, but it could not be loaded. "
+            "Set KERNEL_ALIGN_LIBCUDA_PATH to the CUDA driver library path. "
+            f"Tried: {'; '.join(errors)}"
+        )
+
+    def _configure_signatures(self) -> None:
+        c = self.ctypes
+        for name, args in {
+            "cuInit": [c.c_uint],
+            "cuDeviceGet": [c.POINTER(c.c_int), c.c_int],
+            "cuDeviceGetAttribute": [c.POINTER(c.c_int), c.c_int, c.c_int],
+            "cuDevicePrimaryCtxRetain": [c.POINTER(c.c_void_p), c.c_int],
+            "cuCtxSetCurrent": [c.c_void_p],
+            "cuGetErrorName": [c.c_int, c.POINTER(c.c_char_p)],
+            "cuGetErrorString": [c.c_int, c.POINTER(c.c_char_p)],
+            "cuMemGetAllocationGranularity": [
+                c.POINTER(c.c_size_t),
+                c.POINTER(self.CUmemAllocationProp),
+                c.c_int,
+            ],
+            "cuMemCreate": [
+                c.POINTER(c.c_uint64),
+                c.c_size_t,
+                c.POINTER(self.CUmemAllocationProp),
+                c.c_uint64,
+            ],
+            "cuMemRelease": [c.c_uint64],
+            "cuMemAddressReserve": [
+                c.POINTER(c.c_uint64),
+                c.c_size_t,
+                c.c_size_t,
+                c.c_uint64,
+                c.c_uint64,
+            ],
+            "cuMemAddressFree": [c.c_uint64, c.c_size_t],
+            "cuMemMap": [c.c_uint64, c.c_size_t, c.c_size_t, c.c_uint64, c.c_uint64],
+            "cuMemUnmap": [c.c_uint64, c.c_size_t],
+            "cuMemSetAccess": [
+                c.c_uint64,
+                c.c_size_t,
+                c.POINTER(self.CUmemAccessDesc),
+                c.c_size_t,
+            ],
+            "cuMemExportToShareableHandle": [
+                c.c_void_p,
+                c.c_uint64,
+                c.c_int,
+                c.c_uint64,
+            ],
+            "cuMemImportFromShareableHandle": [c.POINTER(c.c_uint64), c.c_void_p, c.c_int],
+            "cuMemcpyHtoD_v2": [c.c_uint64, c.c_void_p, c.c_size_t],
+            "cuMemcpyDtoD_v2": [c.c_uint64, c.c_uint64, c.c_size_t],
+            "cuCtxSynchronize": [],
+        }.items():
+            getattr(self.lib, name).argtypes = args
+
+    @property
+    def CUmemLocation(self):
+        if hasattr(self, "_CUmemLocationType"):
+            return self._CUmemLocationType
+        c = self.ctypes
+
+        class _CUmemLocation(c.Structure):
+            _fields_ = [("type", c.c_int), ("id", c.c_int)]
+
+        self._CUmemLocationType = _CUmemLocation
+        return self._CUmemLocationType
+
+    @property
+    def CUmemAllocFlags(self):
+        if hasattr(self, "_CUmemAllocFlagsType"):
+            return self._CUmemAllocFlagsType
+        c = self.ctypes
+
+        class _CUmemAllocFlags(c.Structure):
+            _fields_ = [
+                ("compressionType", c.c_ubyte),
+                ("gpuDirectRDMACapable", c.c_ubyte),
+                ("usage", c.c_ushort),
+                ("reserved", c.c_ubyte * 4),
+            ]
+
+        self._CUmemAllocFlagsType = _CUmemAllocFlags
+        return self._CUmemAllocFlagsType
+
+    @property
+    def CUmemAllocationProp(self):
+        if hasattr(self, "_CUmemAllocationPropType"):
+            return self._CUmemAllocationPropType
+        c = self.ctypes
+        location_type = self.CUmemLocation
+        flags_type = self.CUmemAllocFlags
+
+        class _CUmemAllocationProp(c.Structure):
+            _fields_ = [
+                ("type", c.c_int),
+                ("requestedHandleTypes", c.c_int),
+                ("location", location_type),
+                ("win32HandleMetaData", c.c_void_p),
+                ("allocFlags", flags_type),
+            ]
+
+        self._CUmemAllocationPropType = _CUmemAllocationProp
+        return self._CUmemAllocationPropType
+
+    @property
+    def CUmemAccessDesc(self):
+        if hasattr(self, "_CUmemAccessDescType"):
+            return self._CUmemAccessDescType
+        c = self.ctypes
+        location_type = self.CUmemLocation
+
+        class _CUmemAccessDesc(c.Structure):
+            _fields_ = [("location", location_type), ("flags", c.c_int)]
+
+        self._CUmemAccessDescType = _CUmemAccessDesc
+        return self._CUmemAccessDescType
+
+    def _ensure_context(self) -> None:
+        c = self.ctypes
+        self._check(self.lib.cuInit(0), "cuInit")
+        device = c.c_int()
+        self._check(self.lib.cuDeviceGet(c.byref(device), self.device_index), "cuDeviceGet")
+        self.device = device.value
+        context = c.c_void_p()
+        self._check(
+            self.lib.cuDevicePrimaryCtxRetain(c.byref(context), self.device),
+            "cuDevicePrimaryCtxRetain",
+        )
+        self._check(self.lib.cuCtxSetCurrent(context), "cuCtxSetCurrent")
+        self.context = context
+        torch.cuda.init()
+
+    def _error_detail(self, code: int) -> str:
+        c = self.ctypes
+        name = c.c_char_p()
+        message = c.c_char_p()
+        self.lib.cuGetErrorName(code, c.byref(name))
+        self.lib.cuGetErrorString(code, c.byref(message))
+        return (
+            f"code={code} name={(name.value or b'').decode()} "
+            f"msg={(message.value or b'').decode()}"
+        )
+
+    def _check(self, code: int, operation: str) -> None:
+        if code:
+            raise WeightBridgeUnavailableError(
+                f"CUDA VMM operation {operation} failed: {self._error_detail(code)}"
+            )
+
+    def _allocation_prop(self):
+        prop = self.CUmemAllocationProp()
+        prop.type = 1
+        prop.requestedHandleTypes = 1
+        prop.location = self.CUmemLocation(1, self.device)
+        return prop
+
+    def _access_desc(self):
+        return self.CUmemAccessDesc(self.CUmemLocation(1, self.device), 3)
+
+    def supports_posix_fd_vmm(self) -> bool:
+        c = self.ctypes
+        for attr in (102, 103):
+            value = c.c_int()
+            self._check(
+                self.lib.cuDeviceGetAttribute(c.byref(value), attr, self.device),
+                f"cuDeviceGetAttribute({attr})",
+            )
+            if value.value != 1:
+                return False
+        return True
+
+    def granularity(self) -> int:
+        c = self.ctypes
+        value = c.c_size_t()
+        prop = self._allocation_prop()
+        self._check(
+            self.lib.cuMemGetAllocationGranularity(c.byref(value), c.byref(prop), 0),
+            "cuMemGetAllocationGranularity",
+        )
+        return int(value.value)
+
+    def create_allocation(self, requested_nbytes: int) -> tuple[Any, int, int, int]:
+        c = self.ctypes
+        granularity = self.granularity()
+        mapped_nbytes = max(
+            granularity,
+            ((int(requested_nbytes) + granularity - 1) // granularity) * granularity,
+        )
+        prop = self._allocation_prop()
+        handle = c.c_uint64()
+        address = c.c_uint64()
+        exported_fd = c.c_int(-1)
+        self._check(
+            self.lib.cuMemCreate(c.byref(handle), mapped_nbytes, c.byref(prop), 0),
+            "cuMemCreate",
+        )
+        try:
+            self._check(
+                self.lib.cuMemAddressReserve(c.byref(address), mapped_nbytes, 0, 0, 0),
+                "cuMemAddressReserve",
+            )
+            self._check(
+                self.lib.cuMemMap(address.value, mapped_nbytes, 0, handle.value, 0),
+                "cuMemMap",
+            )
+            access = self._access_desc()
+            self._check(
+                self.lib.cuMemSetAccess(address.value, mapped_nbytes, c.byref(access), 1),
+                "cuMemSetAccess",
+            )
+            self._check(
+                self.lib.cuMemExportToShareableHandle(c.byref(exported_fd), handle.value, 1, 0),
+                "cuMemExportToShareableHandle",
+            )
+        except Exception:
+            self.release_allocation(handle.value, address.value, mapped_nbytes, exported_fd.value)
+            raise
+        return handle.value, address.value, mapped_nbytes, exported_fd.value
+
+    def release_allocation(
+        self,
+        handle: Any,
+        address: int,
+        mapped_nbytes: int,
+        exported_fd: int = -1,
+    ) -> None:
+        if address:
+            self.lib.cuMemUnmap(int(address), int(mapped_nbytes))
+            self.lib.cuMemAddressFree(int(address), int(mapped_nbytes))
+        if handle:
+            self.lib.cuMemRelease(int(handle))
+        if exported_fd is not None and int(exported_fd) >= 0:
+            try:
+                os.close(int(exported_fd))
+            except OSError:
+                pass
+
+    def import_allocation(self, fd: int, mapped_nbytes: int) -> tuple[Any, int]:
+        c = self.ctypes
+        handle = c.c_uint64()
+        address = c.c_uint64()
+        self._check(
+            self.lib.cuMemImportFromShareableHandle(c.byref(handle), c.c_void_p(int(fd)), 1),
+            "cuMemImportFromShareableHandle",
+        )
+        try:
+            self._check(
+                self.lib.cuMemAddressReserve(c.byref(address), int(mapped_nbytes), 0, 0, 0),
+                "cuMemAddressReserve(import)",
+            )
+            self._check(
+                self.lib.cuMemMap(address.value, int(mapped_nbytes), 0, handle.value, 0),
+                "cuMemMap(import)",
+            )
+            access = self._access_desc()
+            self._check(
+                self.lib.cuMemSetAccess(
+                    address.value,
+                    int(mapped_nbytes),
+                    c.byref(access),
+                    1,
+                ),
+                "cuMemSetAccess(import)",
+            )
+        except Exception:
+            self.release_import(handle.value, address.value, mapped_nbytes)
+            raise
+        return handle.value, address.value
+
+    def release_import(self, handle: Any, address: int, mapped_nbytes: int) -> None:
+        if address:
+            self.lib.cuMemUnmap(int(address), int(mapped_nbytes))
+            self.lib.cuMemAddressFree(int(address), int(mapped_nbytes))
+        if handle:
+            self.lib.cuMemRelease(int(handle))
+
+    def copy_tensor_to_address(self, destination_address: int, tensor: torch.Tensor) -> None:
+        if tensor.device.type != "cuda":
+            raise WeightBridgeUnavailableError("CUDA VMM copy requires a CUDA source tensor")
+        if not tensor.is_contiguous():
+            tensor = tensor.contiguous()
+        nbytes = int(tensor.numel() * tensor.element_size())
+        self._check(
+            self.lib.cuMemcpyDtoD_v2(int(destination_address), int(tensor.data_ptr()), nbytes),
+            "cuMemcpyDtoD",
+        )
+
+    def synchronize(self) -> None:
+        self._check(self.lib.cuCtxSynchronize(), "cuCtxSynchronize")
+
+
+class WeightBridgeError(RuntimeError):
+    """Base class for weight synchronization bridge failures."""
+
+
+class WeightBridgeUnavailableError(WeightBridgeError):
+    """Raised when a requested transport is not supported by this runtime."""
+
+
+class WeightManifestValidationError(WeightBridgeError):
+    """Raised when a weight update manifest is incomplete or inconsistent."""
+
+
+class WeightUpdateRejectedError(WeightBridgeError):
+    """Raised when a weight update cannot be imported or acknowledged."""
+
+
+def _validated_manifest_metadata(metadata: Optional[Mapping[str, Any]]) -> dict[str, Any]:
+    manifest_metadata = dict(metadata or {})
+    layout = WeightLayout.from_metadata(manifest_metadata)
+    layout.validate_supported()
+    manifest_metadata["layout"] = layout.to_metadata()
+    return manifest_metadata
+
+
+@dataclass(frozen=True)
+class TensorDescriptor:
+    """Transport-independent metadata for one tensor in a weight update."""
+
+    name: str
+    shape: tuple[int, ...]
+    dtype: str
+    stride: tuple[int, ...]
+    device: str
+    numel: int
+    nbytes: int
+    sha256: str
+
+    @classmethod
+    def from_tensor(cls, name: str, tensor: torch.Tensor) -> TensorDescriptor:
+        return cls(
+            name=name,
+            shape=tuple(int(dim) for dim in tensor.shape),
+            dtype=str(tensor.dtype),
+            stride=tuple(int(item) for item in tensor.stride()),
+            device=str(tensor.device),
+            numel=int(tensor.numel()),
+            nbytes=int(tensor.numel() * tensor.element_size()),
+            sha256=_tensor_sha256(tensor),
+        )
+
+
+@dataclass(frozen=True)
+class WeightUpdateManifest:
+    """Immutable public record for a complete published weight update."""
+
+    update_id: str
+    source_worker: str
+    source_rank: int
+    weight_version: int
+    transport: str
+    tensors: Mapping[str, TensorDescriptor]
+    created_at: float
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    @property
+    def tensor_count(self) -> int:
+        return len(self.tensors)
+
+    @property
+    def total_nbytes(self) -> int:
+        return sum(descriptor.nbytes for descriptor in self.tensors.values())
+
+
+class WeightPublisher(Protocol):
+    def publish(
+        self,
+        model: torch.nn.Module,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest: ...
+
+    def release(self, update_id: str) -> None: ...
+
+
+class WeightConsumer(Protocol):
+    def import_update(self, manifest: WeightUpdateManifest) -> Mapping[str, torch.Tensor]: ...
+
+    def acknowledge(self, update_id: str) -> None: ...
+
+    def reject(self, update_id: str, reason: str) -> None: ...
+
+
+class WeightInstallAdapter(Protocol):
+    def install(
+        self,
+        manifest: WeightUpdateManifest,
+        tensors: Mapping[str, torch.Tensor],
+    ) -> None: ...
+
+    def release(self, update_id: str) -> None: ...
+
+
+@dataclass
+class _LocalUpdateRecord:
+    manifest: WeightUpdateManifest
+    tensors: dict[str, torch.Tensor]
+    state: str = "published"
+    import_count: int = 0
+    rejection_reason: Optional[str] = None
+
+
+@dataclass
+class _CUDAVMMAllocationRecord:
+    handle: Any
+    address: int
+    mapped_nbytes: int
+    exported_fd: int
+    socket_path: str
+    thread: Any
+    stop_event: Any
+
+
+@dataclass
+class _CUDAVMMImportRecord:
+    allocation_handle: Any
+    address: int
+    mapped_nbytes: int
+    socket_fd: int
+    posix_fd: int
+    dlpack_owners: list[Any] = field(default_factory=list)
+
+
+def _pack_tensors_for_cuda_vmm(
+    state_dict: Mapping[str, torch.Tensor],
+) -> tuple[dict[str, torch.Tensor], dict[str, dict[str, int]], int]:
+    tensors: dict[str, torch.Tensor] = {}
+    entries: dict[str, dict[str, int]] = {}
+    offset = 0
+    for name, tensor in state_dict.items():
+        if not isinstance(tensor, torch.Tensor):
+            continue
+        if tensor.device.type != "cuda":
+            raise WeightBridgeUnavailableError(
+                "CUDAVMMTensorBridge requires CUDA tensors. "
+                f"Tensor {name} is on {tensor.device}."
+            )
+        snapshot = tensor.detach()
+        if not snapshot.is_contiguous():
+            snapshot = snapshot.contiguous()
+        tensor_nbytes = int(snapshot.numel() * snapshot.element_size())
+        offset = (
+            (offset + _CUDA_VMM_TENSOR_ALIGNMENT - 1) // _CUDA_VMM_TENSOR_ALIGNMENT
+        ) * _CUDA_VMM_TENSOR_ALIGNMENT
+        tensors[name] = snapshot
+        entries[name] = {
+            "offset": offset,
+            "nbytes": tensor_nbytes,
+            "storage_offset": 0,
+        }
+        offset += tensor_nbytes
+    return tensors, entries, offset
+
+
+class LocalTensorCopyBridge:
+    """
+    Safe local transport for the weight synchronization protocol.
+
+    This transport intentionally copies tensors. It is not the final zero-copy
+    transport, but it exercises the same versioned publish/import/ack/release
+    lifecycle that CUDA IPC and vLLM adapters must obey later.
+    """
+
+    transport = "local-clone"
+
+    def __init__(self, *, source_worker: str = "local-training", source_rank: int = 0):
+        self.source_worker = source_worker
+        self.source_rank = int(source_rank)
+        self._updates: dict[str, _LocalUpdateRecord] = {}
+        self._latest_published_weight_version = -1
+        self.active_weight_version: Optional[int] = None
+        self.active_update_id: Optional[str] = None
+
+    def publish(
+        self,
+        model: torch.nn.Module,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest:
+        manifest_metadata = _validated_manifest_metadata(metadata)
+        version = int(weight_version)
+        if version <= self._latest_published_weight_version:
+            raise WeightManifestValidationError(
+                "weight_version must increase monotonically "
+                f"(got {version}, latest {self._latest_published_weight_version})"
+            )
+
+        tensors = self._clone_state_dict(model)
+        if not tensors:
+            raise WeightManifestValidationError("model state_dict produced no tensors")
+
+        descriptors = {
+            name: TensorDescriptor.from_tensor(name, tensor) for name, tensor in tensors.items()
+        }
+        manifest = WeightUpdateManifest(
+            update_id=str(uuid.uuid4()),
+            source_worker=self.source_worker,
+            source_rank=self.source_rank,
+            weight_version=version,
+            transport=self.transport,
+            tensors=descriptors,
+            created_at=time.perf_counter(),
+            metadata=manifest_metadata,
+        )
+        self._updates[manifest.update_id] = _LocalUpdateRecord(
+            manifest=manifest,
+            tensors=tensors,
+        )
+        self._latest_published_weight_version = version
+        logger.info(
+            "Published weight update %s version=%s tensors=%s bytes=%s",
+            manifest.update_id,
+            manifest.weight_version,
+            manifest.tensor_count,
+            manifest.total_nbytes,
+        )
+        return manifest
+
+    def import_update(self, manifest: WeightUpdateManifest) -> Mapping[str, torch.Tensor]:
+        record = self._require_record(manifest.update_id)
+        if record.state == "rejected":
+            raise WeightUpdateRejectedError(
+                f"weight update {manifest.update_id} was rejected: {record.rejection_reason}"
+            )
+        if record.state == "released":
+            raise WeightUpdateRejectedError(f"weight update {manifest.update_id} was released")
+
+        self._validate_manifest(record, manifest)
+        record.import_count += 1
+        if record.state == "published":
+            record.state = "imported"
+
+        return {
+            name: tensor.detach().clone(memory_format=torch.preserve_format)
+            for name, tensor in record.tensors.items()
+        }
+
+    def acknowledge(self, update_id: str) -> None:
+        record = self._require_record(update_id)
+        if record.state == "rejected":
+            raise WeightUpdateRejectedError(
+                f"cannot acknowledge rejected update {update_id}: {record.rejection_reason}"
+            )
+        if record.state == "released":
+            raise WeightUpdateRejectedError(f"cannot acknowledge released update {update_id}")
+        if record.import_count == 0:
+            raise WeightUpdateRejectedError(
+                f"cannot acknowledge update {update_id} before import_update succeeds"
+            )
+        self._validate_manifest(record, record.manifest)
+        record.state = "acknowledged"
+        self.active_weight_version = record.manifest.weight_version
+        self.active_update_id = update_id
+
+    def reject(self, update_id: str, reason: str) -> None:
+        record = self._require_record(update_id)
+        if record.state == "acknowledged":
+            raise WeightUpdateRejectedError(f"cannot reject acknowledged update {update_id}")
+        record.state = "rejected"
+        record.rejection_reason = reason
+
+    def release(self, update_id: str) -> None:
+        record = self._updates.pop(update_id, None)
+        if record is None:
+            return
+        record.tensors.clear()
+        record.state = "released"
+        if self.active_update_id == update_id:
+            self.active_update_id = None
+
+    def update_status(self, update_id: str) -> str:
+        record = self._updates.get(update_id)
+        if record is None:
+            return "released"
+        return record.state
+
+    def get_manifest(self, update_id: str) -> WeightUpdateManifest:
+        return self._require_record(update_id).manifest
+
+    def debug_tensor_data_ptrs(self, update_id: str) -> Mapping[str, int]:
+        """Return storage pointers for tests and benchmark transport verification."""
+
+        record = self._require_record(update_id)
+        return {name: int(tensor.data_ptr()) for name, tensor in record.tensors.items()}
+
+    def _clone_state_dict(self, model: torch.nn.Module) -> dict[str, torch.Tensor]:
+        cloned: dict[str, torch.Tensor] = {}
+        for name, tensor in model.state_dict().items():
+            if not isinstance(tensor, torch.Tensor):
+                continue
+            cloned[name] = tensor.detach().clone(memory_format=torch.preserve_format)
+        return cloned
+
+    def _require_record(self, update_id: str) -> _LocalUpdateRecord:
+        try:
+            return self._updates[update_id]
+        except KeyError as exc:
+            raise WeightUpdateRejectedError(f"unknown weight update {update_id}") from exc
+
+    def _validate_manifest(
+        self,
+        record: _LocalUpdateRecord,
+        manifest: WeightUpdateManifest,
+    ) -> None:
+        expected = record.manifest
+        WeightLayout.from_metadata(manifest.metadata).validate_supported()
+        if manifest.transport != expected.transport:
+            raise WeightManifestValidationError(
+                f"transport mismatch: expected {expected.transport}, got {manifest.transport}"
+            )
+        if manifest.weight_version != expected.weight_version:
+            raise WeightManifestValidationError(
+                "weight_version mismatch: "
+                f"expected {expected.weight_version}, got {manifest.weight_version}"
+            )
+        if set(manifest.tensors) != set(expected.tensors):
+            missing = sorted(set(expected.tensors) - set(manifest.tensors))
+            extra = sorted(set(manifest.tensors) - set(expected.tensors))
+            raise WeightManifestValidationError(
+                f"tensor manifest mismatch: missing={missing}, extra={extra}"
+            )
+        for name, descriptor in expected.tensors.items():
+            actual = manifest.tensors[name]
+            if actual != descriptor:
+                raise WeightManifestValidationError(
+                    f"tensor descriptor mismatch for {name}: "
+                    f"expected {descriptor}, got {actual}"
+                )
+            current = TensorDescriptor.from_tensor(name, record.tensors[name])
+            if current != descriptor:
+                if current.sha256 != descriptor.sha256:
+                    raise WeightManifestValidationError(
+                        f"tensor checksum mismatch for {name}: "
+                        f"expected {descriptor.sha256}, got {current.sha256}"
+                    )
+                raise WeightManifestValidationError(
+                    f"stored tensor descriptor mismatch for {name}: "
+                    f"expected {descriptor}, got {current}"
+                )
+
+
+class SharedMemoryTensorBridge(LocalTensorCopyBridge):
+    """
+    Same-node shared-memory transport with zero-copy import semantics.
+
+    Publishing creates a shared-memory snapshot of model state. Importing that
+    manifest returns tensor aliases to the shared storage instead of cloning.
+    This proves the bridge lifecycle can expose a complete version through
+    shared memory, while keeping the CUDA IPC transport as a separate follow-up.
+    """
+
+    transport = "shared-memory"
+
+    def __init__(self, *, source_worker: str = "local-training", source_rank: int = 0):
+        super().__init__(source_worker=source_worker, source_rank=source_rank)
+        self._shared_memory_segments: dict[str, dict[str, shared_memory.SharedMemory]] = {}
+        self._owned_shared_memory_update_ids: set[str] = set()
+
+    def publish(
+        self,
+        model: torch.nn.Module,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest:
+        user_metadata = _validated_manifest_metadata(metadata)
+        if _BRIDGE_METADATA_KEY in user_metadata:
+            raise WeightManifestValidationError(
+                f"metadata key {_BRIDGE_METADATA_KEY!r} is reserved for bridge internals"
+            )
+
+        version = int(weight_version)
+        if version <= self._latest_published_weight_version:
+            raise WeightManifestValidationError(
+                "weight_version must increase monotonically "
+                f"(got {version}, latest {self._latest_published_weight_version})"
+            )
+
+        update_id = str(uuid.uuid4())
+        tensors, segments, shared_metadata = self._snapshot_to_shared_memory(model)
+        if not tensors:
+            for segment in segments.values():
+                segment.close()
+                segment.unlink()
+            raise WeightManifestValidationError("model state_dict produced no tensors")
+
+        descriptors = {
+            name: TensorDescriptor.from_tensor(name, tensor) for name, tensor in tensors.items()
+        }
+        manifest = WeightUpdateManifest(
+            update_id=update_id,
+            source_worker=self.source_worker,
+            source_rank=self.source_rank,
+            weight_version=version,
+            transport=self.transport,
+            tensors=descriptors,
+            created_at=time.perf_counter(),
+            metadata={**user_metadata, _BRIDGE_METADATA_KEY: shared_metadata},
+        )
+        self._updates[manifest.update_id] = _LocalUpdateRecord(
+            manifest=manifest,
+            tensors=tensors,
+        )
+        self._shared_memory_segments[manifest.update_id] = segments
+        self._owned_shared_memory_update_ids.add(manifest.update_id)
+        self._latest_published_weight_version = version
+        logger.info(
+            "Published shared-memory weight update %s version=%s tensors=%s bytes=%s",
+            manifest.update_id,
+            manifest.weight_version,
+            manifest.tensor_count,
+            manifest.total_nbytes,
+        )
+        return manifest
+
+    def _snapshot_to_shared_memory(
+        self,
+        model: torch.nn.Module,
+    ) -> tuple[
+        dict[str, torch.Tensor],
+        dict[str, shared_memory.SharedMemory],
+        dict[str, Any],
+    ]:
+        shared_tensors: dict[str, torch.Tensor] = {}
+        segments: dict[str, shared_memory.SharedMemory] = {}
+        tensor_metadata: dict[str, dict[str, Any]] = {}
+        try:
+            for name, tensor in model.state_dict().items():
+                if not isinstance(tensor, torch.Tensor):
+                    continue
+                if tensor.device.type != "cpu":
+                    raise WeightBridgeUnavailableError(
+                        "SharedMemoryTensorBridge currently supports CPU tensors only. "
+                        f"Tensor {name} is on {tensor.device}."
+                    )
+                snapshot = tensor.detach().clone(memory_format=torch.preserve_format)
+                storage_offset = int(snapshot.storage_offset())
+                shape = tuple(int(dim) for dim in snapshot.shape)
+                stride = tuple(int(item) for item in snapshot.stride())
+                storage_numel = _required_storage_numel(shape, stride, storage_offset)
+                storage_nbytes = storage_numel * snapshot.element_size()
+                if storage_numel == 0:
+                    shared_view = torch.empty_strided(
+                        shape,
+                        stride,
+                        dtype=snapshot.dtype,
+                    )
+                    shared_tensors[name] = shared_view
+                    tensor_metadata[name] = {
+                        "name": None,
+                        "size": 0,
+                        "storage_numel": 0,
+                        "storage_nbytes": 0,
+                        "storage_offset": 0,
+                    }
+                    continue
+
+                segment = _create_shared_memory(max(storage_nbytes, 1))
+                try:
+                    base = torch.frombuffer(
+                        segment.buf,
+                        dtype=snapshot.dtype,
+                        count=storage_numel,
+                    )
+                    shared_view = base.as_strided(shape, stride, storage_offset)
+                    shared_view.copy_(snapshot)
+                except Exception:
+                    segment.close()
+                    segment.unlink()
+                    raise
+
+                shared_tensors[name] = shared_view
+                segments[name] = segment
+                tensor_metadata[name] = {
+                    "name": segment.name,
+                    "size": int(segment.size),
+                    "storage_numel": storage_numel,
+                    "storage_nbytes": storage_nbytes,
+                    "storage_offset": storage_offset,
+                }
+        except Exception:
+            for segment in segments.values():
+                try:
+                    segment.close()
+                finally:
+                    segment.unlink()
+            raise
+
+        return (
+            shared_tensors,
+            segments,
+            {
+                "format": _SHARED_MEMORY_FORMAT,
+                "tensors": tensor_metadata,
+            },
+        )
+
+    def import_update(self, manifest: WeightUpdateManifest) -> Mapping[str, torch.Tensor]:
+        record = self._updates.get(manifest.update_id)
+        if record is None:
+            record = self._attach_shared_memory_manifest(manifest)
+        if record.state == "rejected":
+            raise WeightUpdateRejectedError(
+                f"weight update {manifest.update_id} was rejected: {record.rejection_reason}"
+            )
+        if record.state == "released":
+            raise WeightUpdateRejectedError(f"weight update {manifest.update_id} was released")
+
+        self._validate_manifest(record, manifest)
+        record.import_count += 1
+        if record.state == "published":
+            record.state = "imported"
+        return dict(record.tensors)
+
+    def release(self, update_id: str) -> None:
+        super().release(update_id)
+        segments = self._shared_memory_segments.pop(update_id, {})
+        should_unlink = update_id in self._owned_shared_memory_update_ids
+        self._owned_shared_memory_update_ids.discard(update_id)
+        for segment in segments.values():
+            try:
+                segment.close()
+            finally:
+                if should_unlink:
+                    try:
+                        segment.unlink()
+                    except FileNotFoundError:
+                        pass
+
+    def _attach_shared_memory_manifest(self, manifest: WeightUpdateManifest) -> _LocalUpdateRecord:
+        if manifest.transport != self.transport:
+            raise WeightManifestValidationError(
+                f"transport mismatch: expected {self.transport}, got {manifest.transport}"
+            )
+        bridge_metadata = manifest.metadata.get(_BRIDGE_METADATA_KEY)
+        if not isinstance(bridge_metadata, Mapping):
+            raise WeightManifestValidationError("shared-memory manifest is missing bridge metadata")
+        if bridge_metadata.get("format") != _SHARED_MEMORY_FORMAT:
+            raise WeightManifestValidationError(
+                "shared-memory manifest has unsupported metadata format: "
+                f"{bridge_metadata.get('format')}"
+            )
+        entries = bridge_metadata.get("tensors")
+        if not isinstance(entries, Mapping):
+            raise WeightManifestValidationError("shared-memory manifest has no tensor handles")
+        if set(entries) != set(manifest.tensors):
+            missing = sorted(set(manifest.tensors) - set(entries))
+            extra = sorted(set(entries) - set(manifest.tensors))
+            raise WeightManifestValidationError(
+                f"shared-memory manifest handle mismatch: missing={missing}, extra={extra}"
+            )
+
+        tensors: dict[str, torch.Tensor] = {}
+        segments: dict[str, shared_memory.SharedMemory] = {}
+        try:
+            for name, descriptor in manifest.tensors.items():
+                entry = entries.get(name)
+                if not isinstance(entry, Mapping):
+                    raise WeightManifestValidationError(
+                        f"shared-memory manifest is missing handle for tensor {name}"
+                    )
+                if descriptor.device != "cpu":
+                    raise WeightManifestValidationError(
+                        f"shared-memory manifest tensor {name} is on {descriptor.device}"
+                    )
+                dtype = _dtype_from_name(descriptor.dtype)
+                try:
+                    storage_numel = int(entry["storage_numel"])
+                    storage_offset = int(entry["storage_offset"])
+                    expected_size = int(entry["size"])
+                    storage_nbytes = int(entry["storage_nbytes"])
+                except (KeyError, TypeError, ValueError) as exc:
+                    raise WeightManifestValidationError(
+                        f"shared-memory manifest has invalid handle metadata for tensor {name}"
+                    ) from exc
+
+                required_storage_numel = _required_storage_numel(
+                    descriptor.shape,
+                    descriptor.stride,
+                    storage_offset,
+                )
+                if storage_numel < required_storage_numel:
+                    raise WeightManifestValidationError(
+                        f"shared-memory tensor {name} storage is smaller than descriptor"
+                    )
+                if storage_nbytes != storage_numel * torch.empty((), dtype=dtype).element_size():
+                    raise WeightManifestValidationError(
+                        f"shared-memory tensor {name} storage byte count does not match dtype"
+                    )
+                if storage_numel == 0:
+                    tensor = torch.empty_strided(descriptor.shape, descriptor.stride, dtype=dtype)
+                    actual_descriptor = TensorDescriptor.from_tensor(name, tensor)
+                    if actual_descriptor != descriptor:
+                        raise WeightManifestValidationError(
+                            f"tensor descriptor mismatch for {name}: "
+                            f"expected {descriptor}, got {actual_descriptor}"
+                        )
+                    tensors[name] = tensor
+                    continue
+
+                segment = _attach_shared_memory(str(entry["name"]))
+                if expected_size > segment.size or storage_nbytes > segment.size:
+                    segment.close()
+                    raise WeightManifestValidationError(
+                        f"shared-memory segment for tensor {name} is smaller than manifest"
+                    )
+                base = torch.frombuffer(segment.buf, dtype=dtype, count=storage_numel)
+                tensor = base.as_strided(descriptor.shape, descriptor.stride, storage_offset)
+                actual_descriptor = TensorDescriptor.from_tensor(name, tensor)
+                if actual_descriptor != descriptor:
+                    segment.close()
+                    if actual_descriptor.sha256 != descriptor.sha256:
+                        raise WeightManifestValidationError(
+                            f"tensor checksum mismatch for {name}: "
+                            f"expected {descriptor.sha256}, got {actual_descriptor.sha256}"
+                        )
+                    raise WeightManifestValidationError(
+                        f"tensor descriptor mismatch for {name}: "
+                        f"expected {descriptor}, got {actual_descriptor}"
+                    )
+                tensors[name] = tensor
+                segments[name] = segment
+        except Exception:
+            for segment in segments.values():
+                segment.close()
+            raise
+
+        record = _LocalUpdateRecord(
+            manifest=manifest,
+            tensors=tensors,
+            state="published",
+            import_count=0,
+        )
+        self._updates[manifest.update_id] = record
+        self._shared_memory_segments[manifest.update_id] = segments
+        return record
+
+
+class CUDAVMMTensorBridge(LocalTensorCopyBridge):
+    """
+    Same-node CUDA VMM transport with POSIX-fd zero-copy import semantics.
+
+    This is the modern CUDA IPC path for WSL2/native Linux runtimes where legacy
+    `cudaIpcOpenMemHandle` is unavailable. Publishing packs a complete CUDA
+    model-state snapshot into one exportable CUDA VMM allocation. Consumers
+    connect to the publisher broker, receive the allocation fd over SCM_RIGHTS,
+    map it into their process, and build PyTorch tensors that alias the mapped
+    GPU memory through DLPack.
+    """
+
+    transport = "cuda-vmm"
+
+    def __init__(
+        self,
+        *,
+        source_worker: str = "cuda-training",
+        source_rank: int = 0,
+        device_index: int = 0,
+        backend_factory: Optional[Callable[[], Any]] = None,
+    ):
+        super().__init__(source_worker=source_worker, source_rank=source_rank)
+        self.device_index = int(device_index)
+        self._backend_factory = backend_factory
+        self._backend: Optional[Any] = None
+        self._cuda_vmm_allocations: dict[str, _CUDAVMMAllocationRecord] = {}
+        self._cuda_vmm_imports: dict[str, _CUDAVMMImportRecord] = {}
+        self._owned_cuda_vmm_update_ids: set[str] = set()
+
+    def publish(
+        self,
+        model: torch.nn.Module,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest:
+        user_metadata = _validated_manifest_metadata(metadata)
+        if _BRIDGE_METADATA_KEY in user_metadata:
+            raise WeightManifestValidationError(
+                f"metadata key {_BRIDGE_METADATA_KEY!r} is reserved for bridge internals"
+            )
+        version = int(weight_version)
+        if version <= self._latest_published_weight_version:
+            raise WeightManifestValidationError(
+                "weight_version must increase monotonically "
+                f"(got {version}, latest {self._latest_published_weight_version})"
+            )
+
+        state_tensors, entries, requested_nbytes = _pack_tensors_for_cuda_vmm(model.state_dict())
+        if not state_tensors:
+            raise WeightManifestValidationError("model state_dict produced no CUDA tensors")
+
+        backend = self._get_backend()
+        if not backend.supports_posix_fd_vmm():
+            raise WeightBridgeUnavailableError(
+                "CUDA VMM POSIX-fd export is not supported by this device/runtime."
+            )
+        handle, address, mapped_nbytes, exported_fd = backend.create_allocation(requested_nbytes)
+        try:
+            tensors: dict[str, torch.Tensor] = {}
+            for name, tensor in state_tensors.items():
+                entry = entries[name]
+                destination = address + int(entry["offset"])
+                backend.copy_tensor_to_address(destination, tensor)
+                tensors[name] = self._tensor_from_address(
+                    destination,
+                    tuple(int(dim) for dim in tensor.shape),
+                    tuple(int(item) for item in tensor.stride()),
+                    tensor.dtype,
+                )
+            backend.synchronize()
+
+            descriptors = {
+                name: TensorDescriptor.from_tensor(name, tensor) for name, tensor in tensors.items()
+            }
+            update_id = str(uuid.uuid4())
+            socket_path, thread, stop_event = self._start_fd_broker(update_id, exported_fd)
+            manifest = WeightUpdateManifest(
+                update_id=update_id,
+                source_worker=self.source_worker,
+                source_rank=self.source_rank,
+                weight_version=version,
+                transport=self.transport,
+                tensors=descriptors,
+                created_at=time.perf_counter(),
+                metadata={
+                    **user_metadata,
+                    _BRIDGE_METADATA_KEY: {
+                        "format": _CUDA_VMM_FORMAT,
+                        "socket_path": socket_path,
+                        "mapped_nbytes": mapped_nbytes,
+                        "requested_nbytes": requested_nbytes,
+                        "device_index": self.device_index,
+                        "tensors": entries,
+                    },
+                },
+            )
+            self._updates[manifest.update_id] = _LocalUpdateRecord(
+                manifest=manifest,
+                tensors=tensors,
+            )
+            self._cuda_vmm_allocations[manifest.update_id] = _CUDAVMMAllocationRecord(
+                handle=handle,
+                address=address,
+                mapped_nbytes=mapped_nbytes,
+                exported_fd=exported_fd,
+                socket_path=socket_path,
+                thread=thread,
+                stop_event=stop_event,
+            )
+            self._owned_cuda_vmm_update_ids.add(manifest.update_id)
+            self._latest_published_weight_version = version
+            logger.info(
+                "Published CUDA VMM weight update %s version=%s tensors=%s bytes=%s",
+                manifest.update_id,
+                manifest.weight_version,
+                manifest.tensor_count,
+                manifest.total_nbytes,
+            )
+            return manifest
+        except Exception:
+            backend.release_allocation(handle, address, mapped_nbytes, exported_fd)
+            raise
+
+    def import_update(self, manifest: WeightUpdateManifest) -> Mapping[str, torch.Tensor]:
+        record = self._updates.get(manifest.update_id)
+        if record is None:
+            record = self._attach_cuda_vmm_manifest(manifest)
+        if record.state == "rejected":
+            raise WeightUpdateRejectedError(
+                f"weight update {manifest.update_id} was rejected: {record.rejection_reason}"
+            )
+        if record.state == "released":
+            raise WeightUpdateRejectedError(f"weight update {manifest.update_id} was released")
+
+        self._validate_manifest(record, manifest)
+        record.import_count += 1
+        if record.state == "published":
+            record.state = "imported"
+        return dict(record.tensors)
+
+    def release(self, update_id: str) -> None:
+        record = self._updates.pop(update_id, None)
+        released_tensors = list(record.tensors.values()) if record is not None else []
+        if record is not None:
+            record.tensors.clear()
+            record.state = "released"
+        if self.active_update_id == update_id:
+            self.active_update_id = None
+        allocation = self._cuda_vmm_allocations.pop(update_id, None)
+        if allocation is not None:
+            allocation.stop_event.set()
+            try:
+                with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                    sock.settimeout(0.1)
+                    sock.connect(allocation.socket_path)
+            except OSError:
+                pass
+            allocation.thread.join(timeout=1)
+            try:
+                os.unlink(allocation.socket_path)
+            except FileNotFoundError:
+                pass
+            self._get_backend().release_allocation(
+                allocation.handle,
+                allocation.address,
+                allocation.mapped_nbytes,
+                allocation.exported_fd,
+            )
+        imported = self._cuda_vmm_imports.pop(update_id, None)
+        if imported is not None:
+            imported.dlpack_owners.clear()
+            self._get_backend().release_import(
+                imported.allocation_handle,
+                imported.address,
+                imported.mapped_nbytes,
+            )
+            try:
+                os.close(imported.posix_fd)
+            except OSError:
+                pass
+            try:
+                os.close(imported.socket_fd)
+            except OSError:
+                pass
+        released_tensors.clear()
+
+    def _get_backend(self) -> Any:
+        if self._backend is None:
+            if self._backend_factory is not None:
+                self._backend = self._backend_factory()
+            else:
+                self._backend = _CUDAVMMDriverBackend(device_index=self.device_index)
+        return self._backend
+
+    def _tensor_from_address(
+        self,
+        address: int,
+        shape: tuple[int, ...],
+        stride: tuple[int, ...],
+        dtype: torch.dtype,
+        owners: Optional[list[Any]] = None,
+    ) -> torch.Tensor:
+        owner = _DLPackOwner(
+            address=address,
+            shape=shape,
+            stride=stride,
+            dtype=dtype,
+            device_index=self.device_index,
+        )
+        tensor = owner.to_tensor()
+        try:
+            tensor._kernel_align_dlpack_owner = owner
+        except AttributeError:
+            pass
+        if owners is not None:
+            owners.append(owner)
+        else:
+            weakref.finalize(tensor, lambda held_owner: None, owner)
+        return tensor
+
+    def _start_fd_broker(self, update_id: str, exported_fd: int):
+        import threading
+
+        socket_path = f"/tmp/kernel-align-cuda-vmm-{os.getpid()}-{update_id}.sock"
+        try:
+            os.unlink(socket_path)
+        except FileNotFoundError:
+            pass
+        stop_event = threading.Event()
+
+        def broker() -> None:
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                server.bind(socket_path)
+                server.listen(16)
+                server.settimeout(0.1)
+                while not stop_event.is_set():
+                    try:
+                        connection, _ = server.accept()
+                    except TimeoutError:
+                        continue
+                    except OSError:
+                        break
+                    with connection:
+                        try:
+                            _send_fd(connection, exported_fd)
+                        except BrokenPipeError:
+                            if not stop_event.is_set():
+                                logger.debug(
+                                    "CUDA VMM fd broker client disconnected before fd send"
+                                )
+            finally:
+                server.close()
+
+        thread = threading.Thread(target=broker, name=f"cuda-vmm-fd-{update_id}", daemon=True)
+        thread.start()
+        return socket_path, thread, stop_event
+
+    def _attach_cuda_vmm_manifest(self, manifest: WeightUpdateManifest) -> _LocalUpdateRecord:
+        if manifest.transport != self.transport:
+            raise WeightManifestValidationError(
+                f"transport mismatch: expected {self.transport}, got {manifest.transport}"
+            )
+        bridge_metadata = manifest.metadata.get(_BRIDGE_METADATA_KEY)
+        if not isinstance(bridge_metadata, Mapping):
+            raise WeightManifestValidationError("CUDA VMM manifest is missing bridge metadata")
+        if bridge_metadata.get("format") != _CUDA_VMM_FORMAT:
+            raise WeightManifestValidationError(
+                "CUDA VMM manifest has unsupported metadata format: "
+                f"{bridge_metadata.get('format')}"
+            )
+        entries = bridge_metadata.get("tensors")
+        if not isinstance(entries, Mapping) or set(entries) != set(manifest.tensors):
+            raise WeightManifestValidationError("CUDA VMM manifest handle mismatch")
+
+        socket_path = str(bridge_metadata.get("socket_path"))
+        mapped_nbytes = int(bridge_metadata.get("mapped_nbytes", 0))
+        if not socket_path or mapped_nbytes <= 0:
+            raise WeightManifestValidationError("CUDA VMM manifest has invalid fd metadata")
+
+        backend = self._get_backend()
+        socket_fd = -1
+        posix_fd = -1
+        allocation_handle = None
+        address = 0
+        owners: list[Any] = []
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            socket_fd = int(sock.fileno())
+            sock.connect(socket_path)
+            posix_fd = _recv_fd(sock)
+            allocation_handle, address = backend.import_allocation(posix_fd, mapped_nbytes)
+            tensors: dict[str, torch.Tensor] = {}
+            for name, descriptor in manifest.tensors.items():
+                entry = entries[name]
+                offset = int(entry["offset"])
+                dtype = _dtype_from_name(descriptor.dtype)
+                tensor = self._tensor_from_address(
+                    address + offset,
+                    descriptor.shape,
+                    descriptor.stride,
+                    dtype,
+                    owners,
+                )
+                actual_descriptor = TensorDescriptor.from_tensor(name, tensor)
+                if actual_descriptor != descriptor:
+                    if actual_descriptor.sha256 != descriptor.sha256:
+                        raise WeightManifestValidationError(
+                            f"tensor checksum mismatch for {name}: "
+                            f"expected {descriptor.sha256}, got {actual_descriptor.sha256}"
+                        )
+                    raise WeightManifestValidationError(
+                        f"tensor descriptor mismatch for {name}: "
+                        f"expected {descriptor}, got {actual_descriptor}"
+                    )
+                tensors[name] = tensor
+            record = _LocalUpdateRecord(
+                manifest=manifest,
+                tensors=tensors,
+                state="published",
+                import_count=0,
+            )
+            self._updates[manifest.update_id] = record
+            self._cuda_vmm_imports[manifest.update_id] = _CUDAVMMImportRecord(
+                allocation_handle=allocation_handle,
+                address=address,
+                mapped_nbytes=mapped_nbytes,
+                socket_fd=socket_fd,
+                posix_fd=posix_fd,
+                dlpack_owners=owners,
+            )
+            sock.detach()
+            return record
+        except Exception:
+            owners.clear()
+            if allocation_handle is not None or address:
+                backend.release_import(allocation_handle, address, mapped_nbytes)
+            for fd in (posix_fd, socket_fd):
+                if fd >= 0:
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+            raise
 
 
 class IPCWeightBridge:
     """
-    This implementation bridges the memory sharing between training and inference processes.
-    It leverages the CUDA IPC mechanism to achieve zero-copy weight synchronization,
-    significantly reducing communication overhead.
-       - Training process: Exports IPC handles for model weights.
-       - Inference process: Reconstructs Tensors based on these handles,
-       directly accessing the training process's memory.
-    Suitable for RL inference scenarios such as vLLM that require frequent weight updates,
-    ensuring efficient collaboration between training and inference.
+    Guarded placeholder for the legacy CUDA IPC transport.
+
+    Legacy `cudaIpcOpenMemHandle`/PyTorch `reduce_tensor` handle reconstruction
+    fails on the current WSL2 driver path. Use `CUDAVMMTensorBridge` for the
+    validated same-node CUDA zero-copy path based on VMM POSIX-fd export.
     """
 
-    def __init__(self):
-        # Mapping of storage parameter names to IPC handles
-        self.handle_registry: Dict[str, Any] = {}
+    transport = "cuda-ipc"
 
-    def export_model_handles(self, model: torch.nn.Module) -> Dict[str, Any]:
-        """
-        The training process calls:
-        Iterates through the model parameters and generates a cross-process
-        readable IPC handle for each Tensor.
-        """
-        logger.info("Exporting model weights via CUDA IPC...")
-        ipc_handles = {}
+    def __init__(self, *, source_worker: str = "cuda-training", source_rank: int = 0):
+        del source_worker, source_rank
+        self.handle_registry: dict[str, Any] = {}
 
-        for name, param in model.named_parameters():
-            data = param.data.detach()
-            # Calling PyTorch's shared memory interface
-            shared_storage = data.storage()._share_cuda_()
-            ipc_handles[name] = {
-                "handle": shared_storage,
-                "shape": data.shape,
-                "dtype": data.dtype,
-                "stride": data.stride(),
-            }
+    def publish(
+        self,
+        model: torch.nn.Module,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest:
+        del model, weight_version, metadata
+        raise self._unavailable()
 
-        self.handle_registry = ipc_handles
-        return ipc_handles
+    def import_update(self, manifest: WeightUpdateManifest) -> Mapping[str, torch.Tensor]:
+        del manifest
+        raise self._unavailable()
 
-    def import_model_weights(self, ipc_handles: Dict[str, Any]) -> Dict[str, torch.Tensor]:
-        """
-        The inference process calls:
-        Reconstructs Tensors based on the received handles,
-        directly accessing the training process's memory.
-        """
-        logger.info("Importing model weights from IPC handles...")
-        remote_weights = {}
+    def export_model_handles(self, model: torch.nn.Module) -> Mapping[str, Any]:
+        del model
+        raise self._unavailable()
 
-        for name, info in ipc_handles.items():
-            storage = torch.cuda.FloatTensor._new_shared_cuda(info["handle"])
-            tensor = torch.cuda.FloatTensor(storage).view(info["shape"])
-            remote_weights[name] = tensor
+    def import_model_weights(self, ipc_handles: Mapping[str, Any]) -> Mapping[str, torch.Tensor]:
+        del ipc_handles
+        raise self._unavailable()
 
-        return remote_weights
+    def release(self, update_id: str) -> None:
+        del update_id
+
+    def _unavailable(self) -> WeightBridgeUnavailableError:
+        if torch.cuda.is_available() and torch.cuda.current_device() < 0:
+            return WeightBridgeUnavailableError(
+                "CUDA IPC weight bridge is unavailable because no active CUDA device "
+                "context can be selected."
+            )
+        if torch.cuda.is_available() and torch.version.cuda and torch.cuda.device_count() > 0:
+            platform_note = (
+                "Legacy CUDA IPC producer/consumer handle reconstruction has not "
+                "passed on this platform. Use CUDAVMMTensorBridge (`cuda-vmm`) for "
+                "the validated same-node CUDA zero-copy transport."
+            )
+        else:
+            platform_note = ""
+        if not torch.cuda.is_available():
+            return WeightBridgeUnavailableError(
+                "CUDA IPC weight bridge is unavailable because CUDA is not available. "
+                "Use LocalTensorCopyBridge for protocol validation."
+            )
+        return WeightBridgeUnavailableError(
+            "Legacy CUDA IPC weight bridge is not production-ready yet. "
+            f"{platform_note} Use SharedMemoryTensorBridge or LocalTensorCopyBridge "
+            "when CUDA VMM is unavailable."
+        )
+
+
+def make_weight_bridge(
+    transport: str = "local-clone",
+    *,
+    source_worker: str = "local-training",
+    source_rank: int = 0,
+) -> WeightPublisher:
+    if transport in {"local", "local-clone"}:
+        return LocalTensorCopyBridge(
+            source_worker=source_worker,
+            source_rank=source_rank,
+        )
+    if transport in {"shared-memory", "shm"}:
+        return SharedMemoryTensorBridge(
+            source_worker=source_worker,
+            source_rank=source_rank,
+        )
+    if transport in {"cuda-vmm", "cuda-vmm-fd"}:
+        return CUDAVMMTensorBridge(
+            source_worker=source_worker,
+            source_rank=source_rank,
+        )
+    if transport in {"cuda-ipc", "ipc"}:
+        return IPCWeightBridge()
+    if transport in {"multi-node", "rdma", "nccl-rdma"}:
+        raise WeightBridgeUnavailableError(
+            "multi-node/RDMA weight transport is not implemented. Use local-clone "
+            "or shared-memory on one node, or add a production RDMA/NCCL transport."
+        )
+    raise WeightBridgeUnavailableError(f"unknown weight bridge transport: {transport}")
+
+
+__all__ = [
+    "CUDAVMMTensorBridge",
+    "IPCWeightBridge",
+    "LocalTensorCopyBridge",
+    "SharedMemoryTensorBridge",
+    "TensorDescriptor",
+    "VLLMCUDAVMMExternalStorageAdapter",
+    "VLLMCheckpointWeightReloadAdapter",
+    "VLLMInProcessWeightReloadAdapter",
+    "VLLMIPCWeightUpdateRequestBuilder",
+    "VLLMWeightInstallAdapter",
+    "WeightBridgeError",
+    "WeightBridgeUnavailableError",
+    "WeightConsumer",
+    "WeightInstallAdapter",
+    "WeightLayout",
+    "WeightManifestValidationError",
+    "WeightPublisher",
+    "WeightUpdateManifest",
+    "WeightUpdateRejectedError",
+    "make_weight_bridge",
+]

--- a/rl_engine/executors/deepspeed_trainer.py
+++ b/rl_engine/executors/deepspeed_trainer.py
@@ -10,6 +10,12 @@ from typing import Any, Mapping, Optional
 
 import torch
 
+from rl_engine.executors.bridge import (
+    WeightBridgeUnavailableError,
+    WeightPublisher,
+    WeightUpdateManifest,
+    make_weight_bridge,
+)
 from rl_engine.executors.training_contract import (
     RolloutBatchMixin,
     RolloutStageResult,
@@ -51,11 +57,23 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
 
     config: DeepSpeedTrainingConfig
 
-    def __init__(self, config: Optional[DeepSpeedTrainingConfig] = None):
+    def __init__(
+        self,
+        config: Optional[DeepSpeedTrainingConfig] = None,
+        *,
+        weight_bridge: Optional[WeightPublisher] = None,
+        weight_transport: str = "local-clone",
+    ):
         self.config = config or DeepSpeedTrainingConfig()
         self.device = torch.device(self.config.device)
         if self.device.type == "cuda" and not torch.cuda.is_available():
             raise RuntimeError("CUDA training requested but torch.cuda.is_available() is false")
+        self.weight_bridge = weight_bridge or make_weight_bridge(
+            weight_transport,
+            source_worker="deepspeed-training",
+            source_rank=0,
+        )
+        self._latest_published_weight_version = -1
 
         deepspeed = _load_deepspeed()
         torch.manual_seed(self.config.seed)
@@ -108,7 +126,7 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
         self.engine.step()
 
         finished_at = time.perf_counter()
-        published = rollout.weight_version + 1
+        published = self._next_published_weight_version(rollout.weight_version)
         return TrainingStageResult(
             iteration=rollout.iteration,
             consumed_weight_version=rollout.weight_version,
@@ -126,6 +144,51 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
             started_at=started_at,
             finished_at=finished_at,
         )
+
+    def publish_weights(
+        self,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest:
+        """
+        Publish the current DeepSpeed model state as a complete weight manifest.
+
+        ZeRO-3 partitions parameters across ranks, so a production publication
+        must all-gather a full state first. Until that path exists, the worker
+        fails explicitly instead of publishing an incomplete shard.
+        """
+        if self.config.zero_stage >= 3:
+            raise WeightBridgeUnavailableError(
+                "DeepSpeed ZeRO-3 publish requires a real all-gather/full-state "
+                "export before rollout workers can consume the weight manifest."
+            )
+
+        manifest_metadata = dict(metadata or {})
+        layout = {
+            "kind": "full-state",
+            "zero_stage": self.config.zero_stage,
+            "world_size": 1,
+            "rank": 0,
+        }
+        layout.update(dict(manifest_metadata.get("layout", {})))
+        manifest_metadata["layout"] = layout
+        return self.weight_bridge.publish(
+            self.model,
+            weight_version=weight_version,
+            metadata=manifest_metadata,
+        )
+
+    def release_weights(self, update_id: str) -> None:
+        self.weight_bridge.release(update_id)
+
+    def _next_published_weight_version(self, consumed_weight_version: int) -> int:
+        published = max(
+            int(consumed_weight_version) + 1,
+            self._latest_published_weight_version + 1,
+        )
+        self._latest_published_weight_version = published
+        return published
 
     def _resolved_deepspeed_config(self) -> dict[str, Any]:
         batch_size = max(1, self.config.num_prompts * self.config.samples_per_prompt)

--- a/rl_engine/executors/ray_actor_manager.py
+++ b/rl_engine/executors/ray_actor_manager.py
@@ -7,6 +7,8 @@ import importlib
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional, Sequence
 
+from rl_engine.executors.bridge import WeightUpdateManifest
+
 
 class RayUnavailableError(RuntimeError):
     """Raised when the optional Ray runtime cannot be imported."""
@@ -143,6 +145,12 @@ class RayRolloutWorkerHandle:
     def rollout(self, spec: Any) -> Any:
         return self._ray.get(self.actor.rollout.remote(spec))
 
+    def update_weights(self, manifest: WeightUpdateManifest) -> Any:
+        return self._ray.get(self.actor.update_weights.remote(manifest))
+
+    def release_weights(self) -> Any:
+        return self._ray.get(self.actor.release_weights.remote())
+
 
 class RayTrainingWorkerHandle:
     """Synchronous `TrainingWorker` protocol adapter for a Ray actor."""
@@ -153,6 +161,22 @@ class RayTrainingWorkerHandle:
 
     def train(self, rollout: Any) -> Any:
         return self._ray.get(self.actor.train.remote(rollout))
+
+    def publish_weights(
+        self,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest:
+        return self._ray.get(
+            self.actor.publish_weights.remote(
+                weight_version=weight_version,
+                metadata=metadata,
+            )
+        )
+
+    def release_weights(self, update_id: str) -> Any:
+        return self._ray.get(self.actor.release_weights.remote(update_id))
 
 
 class _RayWorkerActor:
@@ -171,6 +195,25 @@ class _RayWorkerActor:
 
     def train(self, rollout: Any) -> Any:
         return self.worker.train(rollout)
+
+    def update_weights(self, manifest: WeightUpdateManifest) -> Any:
+        return self.worker.update_weights(manifest)
+
+    def publish_weights(
+        self,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest:
+        return self.worker.publish_weights(
+            weight_version=weight_version,
+            metadata=metadata,
+        )
+
+    def release_weights(self, update_id: Optional[str] = None) -> Any:
+        if update_id is None:
+            return self.worker.release_weights()
+        return self.worker.release_weights(update_id)
 
     def health_check(self) -> Mapping[str, Any]:
         return {

--- a/rl_engine/executors/rollout.py
+++ b/rl_engine/executors/rollout.py
@@ -1,11 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
 
+from __future__ import annotations
+
 import torch
-from typing import Optional, Dict, Any, Mapping, Sequence
-from rl_engine.kernels.registry import kernel_registry
-from rl_engine.executors.bridge import IPCWeightBridge
+from typing import Any, Mapping, Optional, Sequence
+
+from rl_engine.executors.bridge import (
+    WeightBridgeUnavailableError,
+    WeightConsumer,
+    WeightInstallAdapter,
+    WeightUpdateManifest,
+    make_weight_bridge,
+)
 from rl_engine.executors.vllm_sampler import VLLMSamplerConfig, VLLMSharedPrefixSampler
+from rl_engine.kernels.registry import kernel_registry
 from rl_engine.utils.logger import logger
 
 
@@ -15,26 +24,98 @@ class RolloutExecutor:
     Manages shared weights and dispatches hardware-specific kernels for large-scale sampling.
     """
 
-    def __init__(self, model_config: Optional[dict] = None):
+    def __init__(
+        self,
+        model_config: Optional[dict] = None,
+        *,
+        weight_bridge: Optional[WeightConsumer] = None,
+        weight_transport: Optional[str] = None,
+        weight_install_adapter: Optional[WeightInstallAdapter] = None,
+    ):
         self.config = model_config or {}
-        self.bridge = IPCWeightBridge()  # Integrates Zero-Copy bridge.
-        self.shared_weights: Dict[str, torch.Tensor] = {}
+        transport = weight_transport or str(self.config.get("weight_transport", "cuda-vmm"))
+        self.bridge = weight_bridge or make_weight_bridge(transport)
+        self.shared_weights: dict[str, torch.Tensor] = {}
+        self.weight_install_adapter = weight_install_adapter
+        self.active_weight_version: Optional[int] = None
+        self.active_weight_update_id: Optional[str] = None
         self.logp_op = None
         self.attn_op = None
         self.sampler_config: Optional[VLLMSamplerConfig] = None
         self.sampler: Optional[VLLMSharedPrefixSampler] = None
 
-        logger.info("Initializing Zero-Copy enabled RolloutExecutor...")
+        logger.info("Initializing RolloutExecutor with weight transport %s", transport)
 
-    def update_weights_via_ipc(self, ipc_handles: Dict[str, Any]):
+    def update_weights(self, manifest: WeightUpdateManifest) -> Mapping[str, torch.Tensor]:
         """
-        Sync weights from training process via IPC handles.
-        Enables Zero-Copy by directly mapping training VRAM to the inference process.
+        Import a complete published weight manifest and switch active version.
+
+        The underlying bridge owns transport-specific semantics. Same-node CPU
+        shared-memory imports return aliases to the published shared segment;
+        CUDA VMM imports return aliases to the published GPU allocation. Legacy
+        CUDA IPC remains capability-gated until its lifecycle is validated.
         """
-        logger.info("Syncing weights from Training process (Zero-Copy)...")
-        self.shared_weights = self.bridge.import_model_weights(ipc_handles)
-        # Weights can be further loaded into vLLM sampler.
-        logger.info(f"Successfully mapped {len(self.shared_weights)} parameters via IPC.")
+        logger.info(
+            "Importing weight update %s version=%s transport=%s",
+            manifest.update_id,
+            manifest.weight_version,
+            manifest.transport,
+        )
+        previous_update_id = self.active_weight_update_id
+        try:
+            imported = dict(self.bridge.import_update(manifest))
+            if self.weight_install_adapter is not None:
+                self.weight_install_adapter.install(manifest, imported)
+            self.bridge.acknowledge(manifest.update_id)
+        except Exception as exc:
+            try:
+                self.bridge.reject(manifest.update_id, f"rollout weight install failed: {exc}")
+            except Exception:
+                logger.exception("Failed to reject weight update %s", manifest.update_id)
+            raise
+        self.shared_weights = imported
+        self.active_weight_version = manifest.weight_version
+        self.active_weight_update_id = manifest.update_id
+        if previous_update_id is not None and previous_update_id != manifest.update_id:
+            self.release_weight_update(previous_update_id)
+        logger.info("Activated %s imported weight tensors.", len(self.shared_weights))
+        return self.shared_weights
+
+    def release_weights(self) -> None:
+        """Release the active weight update held by this rollout worker."""
+        if self.active_weight_update_id is None:
+            return
+        update_id = self.active_weight_update_id
+        if self.weight_install_adapter is not None:
+            self.weight_install_adapter.release(update_id)
+        self.bridge.release(update_id)
+        self.shared_weights = {}
+        self.active_weight_update_id = None
+
+    def release_weight_update(self, update_id: str) -> None:
+        """Release a specific manifest update, active or already superseded."""
+        if self.weight_install_adapter is not None:
+            self.weight_install_adapter.release(update_id)
+        self.bridge.release(update_id)
+        if self.active_weight_update_id == update_id:
+            self.shared_weights = {}
+            self.active_weight_update_id = None
+
+    def update_weights_via_ipc(self, ipc_handles: Mapping[str, Any]) -> Mapping[str, torch.Tensor]:
+        """
+        Backward-compatible IPC entry point.
+
+        Raw CUDA IPC handle imports are intentionally unavailable until issue
+        #13 validates CUDA IPC snapshot visibility and handle lifetime in a real
+        target runtime. New callers should pass a `WeightUpdateManifest` to
+        `update_weights(...)` instead.
+        """
+        del ipc_handles
+        raise WeightBridgeUnavailableError(
+            "Raw CUDA IPC handle imports are not production-ready. Publish a "
+            "WeightUpdateManifest and call update_weights(...) so the bridge can "
+            "validate version, tensor metadata, acknowledgement, and release lifecycle."
+        )
 
     def _prepare_kernels(self):
         """
@@ -76,7 +157,7 @@ class RolloutExecutor:
         *,
         num_generations: Optional[int] = None,
         sampling_params: Optional[Mapping[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Generate GRPO rollout candidates through vLLM with shared prefix caching.
         """

--- a/tests/test_deepspeed_training_worker.py
+++ b/tests/test_deepspeed_training_worker.py
@@ -10,6 +10,10 @@ import time
 
 import pytest
 
+from rl_engine.executors.bridge import (
+    LocalTensorCopyBridge,
+    WeightBridgeUnavailableError,
+)
 from rl_engine.executors.training_contract import RolloutStageResult
 
 
@@ -178,3 +182,80 @@ def test_deepspeed_training_worker_synthetic_fallback(monkeypatch):
     assert result.published_weight_version == 5
     assert result.metrics["training_backend"] == "deepspeed"
     assert result.metrics["training_data_source"] == "synthetic_fallback"
+
+
+def test_deepspeed_worker_publishes_full_state_manifest(monkeypatch):
+    _install_fake_deepspeed(monkeypatch)
+    from rl_engine.executors.deepspeed_trainer import (
+        DeepSpeedTrainingConfig,
+        DeepSpeedTrainingWorker,
+    )
+
+    bridge = LocalTensorCopyBridge(source_worker="training", source_rank=0)
+    worker = DeepSpeedTrainingWorker(
+        DeepSpeedTrainingConfig(
+            vocab_size=16,
+            hidden_dim=8,
+            zero_stage=2,
+            seed=17,
+        ),
+        weight_bridge=bridge,
+    )
+
+    manifest = worker.publish_weights(
+        weight_version=21,
+        metadata={"iteration": 4},
+    )
+    imported = bridge.import_update(manifest)
+
+    assert manifest.source_worker == "training"
+    assert manifest.weight_version == 21
+    assert manifest.metadata["iteration"] == 4
+    assert manifest.metadata["layout"]["kind"] == "full-state"
+    assert manifest.metadata["layout"]["zero_stage"] == 2
+    assert manifest.metadata["layout"]["world_size"] == 1
+    assert manifest.metadata["layout"]["rank"] == 0
+    assert set(imported) == set(worker.model.state_dict())
+
+    bridge.release(manifest.update_id)
+
+
+def test_deepspeed_zero3_publish_requires_all_gather(monkeypatch):
+    _install_fake_deepspeed(monkeypatch)
+    from rl_engine.executors.deepspeed_trainer import (
+        DeepSpeedTrainingConfig,
+        DeepSpeedTrainingWorker,
+    )
+
+    worker = DeepSpeedTrainingWorker(
+        DeepSpeedTrainingConfig(
+            vocab_size=16,
+            hidden_dim=8,
+            zero_stage=3,
+        )
+    )
+
+    with pytest.raises(WeightBridgeUnavailableError, match="ZeRO-3"):
+        worker.publish_weights(weight_version=1)
+
+
+def test_deepspeed_published_versions_are_monotonic(monkeypatch):
+    _install_fake_deepspeed(monkeypatch)
+    from rl_engine.executors.deepspeed_trainer import (
+        DeepSpeedTrainingConfig,
+        DeepSpeedTrainingWorker,
+    )
+
+    worker = DeepSpeedTrainingWorker(
+        DeepSpeedTrainingConfig(
+            vocab_size=16,
+            hidden_dim=8,
+            seed=23,
+        )
+    )
+
+    first = worker.train(_rollout(iteration=0, weight_version=5))
+    second = worker.train(_rollout(iteration=1, weight_version=5))
+
+    assert first.published_weight_version == 6
+    assert second.published_weight_version == 7

--- a/tests/test_ray_actor_manager.py
+++ b/tests/test_ray_actor_manager.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass
 from typing import Any, Sequence
 
 import pytest
+import torch
 
+from rl_engine.executors.bridge import SharedMemoryTensorBridge
 from rl_engine.executors.training_contract import (
     RolloutStageResult,
     TrainingStageResult,
@@ -128,6 +130,53 @@ class FakeTrainingWorker:
             started_at=started,
             finished_at=time.perf_counter(),
         )
+
+
+class FakeWeightPublishingWorker:
+    def __init__(self):
+        self.model = torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.LayerNorm(2))
+        with torch.no_grad():
+            for index, tensor in enumerate(self.model.parameters()):
+                tensor.fill_(index + 1)
+        self.bridge = SharedMemoryTensorBridge(source_worker="ray-training", source_rank=0)
+        self.released_updates = []
+
+    def publish_weights(self, *, weight_version, metadata=None):
+        return self.bridge.publish(
+            self.model,
+            weight_version=weight_version,
+            metadata=metadata,
+        )
+
+    def release_weights(self, update_id):
+        self.released_updates.append(update_id)
+        self.bridge.release(update_id)
+
+
+class FakeWeightConsumingWorker:
+    def __init__(self):
+        self.bridge = SharedMemoryTensorBridge(source_worker="ray-rollout", source_rank=1)
+        self.active_manifest_id = None
+        self.active_weight_names = []
+        self.released = False
+
+    def update_weights(self, manifest):
+        tensors = self.bridge.import_update(manifest)
+        self.bridge.acknowledge(manifest.update_id)
+        self.active_manifest_id = manifest.update_id
+        self.active_weight_names = sorted(tensors)
+        return {
+            "active_weight_version": self.bridge.active_weight_version,
+            "update_id": manifest.update_id,
+            "tensor_count": len(tensors),
+            "weight_names": self.active_weight_names,
+        }
+
+    def release_weights(self):
+        if self.active_manifest_id is not None:
+            self.bridge.release(self.active_manifest_id)
+        self.released = True
+        return {"released": True, "update_id": self.active_manifest_id}
 
 
 def test_importing_module_does_not_import_ray(monkeypatch):
@@ -259,3 +308,42 @@ def test_ray_actor_handles_support_direct_rollout_training_handoff():
 
     manager.shutdown()
     assert [actor for actor, _ in fake_ray.kill_calls] == list(reversed(fake_ray.actors))
+
+
+def test_ray_actor_handles_forward_weight_manifest_between_workers():
+    from rl_engine.executors.ray_actor_manager import (
+        RayActorManager,
+        RayRuntimeConfig,
+        RayWorkerSpec,
+    )
+
+    fake_ray = FakeRayModule()
+    manager = RayActorManager(
+        RayRuntimeConfig(auto_init=True),
+        ray_module=fake_ray,
+    )
+    training = manager.create_training_worker(RayWorkerSpec(FakeWeightPublishingWorker))
+    rollout = manager.create_rollout_worker(RayWorkerSpec(FakeWeightConsumingWorker))
+
+    manifest = training.publish_weights(
+        weight_version=11,
+        metadata={"iteration": 3},
+    )
+    update_result = rollout.update_weights(manifest)
+    release_result = rollout.release_weights()
+    training.release_weights(manifest.update_id)
+
+    assert manifest.source_worker == "ray-training"
+    assert manifest.weight_version == 11
+    assert manifest.metadata["iteration"] == 3
+    assert update_result == {
+        "active_weight_version": 11,
+        "update_id": manifest.update_id,
+        "tensor_count": manifest.tensor_count,
+        "weight_names": sorted(manifest.tensors),
+    }
+    assert release_result == {"released": True, "update_id": manifest.update_id}
+    assert len(fake_ray.actors) == 2
+    assert len(fake_ray.get_calls) == 4
+
+    manager.shutdown()

--- a/tests/test_vllm_rollout_sampler.py
+++ b/tests/test_vllm_rollout_sampler.py
@@ -4,7 +4,14 @@
 import importlib
 
 import pytest
+import torch
 
+from rl_engine.executors.bridge import (
+    CUDAVMMTensorBridge,
+    SharedMemoryTensorBridge,
+    VLLMWeightInstallAdapter,
+    WeightBridgeUnavailableError,
+)
 from rl_engine.executors.rollout import RolloutExecutor
 from rl_engine.executors.vllm_sampler import (
     VLLMSamplerConfig,
@@ -278,3 +285,99 @@ def test_rollout_executor_defers_vllm_sampler_config_validation():
     assert executor.sampler_config is None
     with pytest.raises(ValueError, match="Unsupported rollout sampler backend"):
         executor.generate_candidates(["prompt-a"])
+
+
+def test_rollout_executor_defaults_to_cuda_vmm_manifest_bridge():
+    executor = RolloutExecutor()
+
+    assert isinstance(executor.bridge, CUDAVMMTensorBridge)
+
+
+def test_rollout_executor_updates_weights_from_manifest():
+    model = torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.LayerNorm(2))
+    with torch.no_grad():
+        for index, tensor in enumerate(model.parameters()):
+            tensor.fill_(index + 1)
+
+    publisher = SharedMemoryTensorBridge(source_worker="trainer", source_rank=0)
+    manifest = publisher.publish(model, weight_version=3)
+    rollout_bridge = SharedMemoryTensorBridge(source_worker="rollout", source_rank=1)
+    executor = RolloutExecutor(weight_bridge=rollout_bridge)
+
+    weights = executor.update_weights(manifest)
+
+    assert executor.active_weight_version == 3
+    assert executor.active_weight_update_id == manifest.update_id
+    assert set(weights) == set(model.state_dict())
+    assert rollout_bridge.update_status(manifest.update_id) == "acknowledged"
+    for name, tensor in model.state_dict().items():
+        assert torch.equal(weights[name], tensor)
+
+    executor.release_weights()
+    assert executor.shared_weights == {}
+    assert executor.active_weight_update_id is None
+
+    publisher.release(manifest.update_id)
+
+
+def test_rollout_executor_installs_weights_before_acknowledging():
+    model = torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.LayerNorm(2))
+    publisher = SharedMemoryTensorBridge(source_worker="trainer", source_rank=0)
+    manifest = publisher.publish(model, weight_version=4)
+    rollout_bridge = SharedMemoryTensorBridge(source_worker="rollout", source_rank=1)
+    install_calls = []
+    adapter = VLLMWeightInstallAdapter(
+        object(),
+        install_callable=lambda incoming_manifest, incoming_tensors: install_calls.append(
+            (incoming_manifest.update_id, set(incoming_tensors))
+        ),
+    )
+    executor = RolloutExecutor(
+        weight_bridge=rollout_bridge,
+        weight_install_adapter=adapter,
+    )
+
+    executor.update_weights(manifest)
+
+    assert install_calls == [(manifest.update_id, set(manifest.tensors))]
+    assert adapter.active_weight_version == 4
+    assert rollout_bridge.update_status(manifest.update_id) == "acknowledged"
+
+    executor.release_weights()
+    publisher.release(manifest.update_id)
+
+
+def test_rollout_executor_rejects_update_when_weight_install_fails():
+    model = torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.LayerNorm(2))
+    publisher = SharedMemoryTensorBridge(source_worker="trainer", source_rank=0)
+    first = publisher.publish(model, weight_version=1)
+    second = publisher.publish(model, weight_version=2)
+    rollout_bridge = SharedMemoryTensorBridge(source_worker="rollout", source_rank=1)
+    executor = RolloutExecutor(weight_bridge=rollout_bridge)
+    executor.update_weights(first)
+
+    adapter = VLLMWeightInstallAdapter(
+        object(),
+        install_callable=lambda _manifest, _tensors: (_ for _ in ()).throw(
+            RuntimeError("install failed")
+        ),
+    )
+    executor.weight_install_adapter = adapter
+
+    with pytest.raises(RuntimeError, match="install failed"):
+        executor.update_weights(second)
+
+    assert executor.active_weight_version == 1
+    assert executor.active_weight_update_id == first.update_id
+    assert rollout_bridge.update_status(second.update_id) == "rejected"
+
+    executor.release_weights()
+    publisher.release(first.update_id)
+    publisher.release(second.update_id)
+
+
+def test_rollout_executor_legacy_ipc_entry_is_explicitly_blocked():
+    executor = RolloutExecutor({"weight_transport": "shared-memory"})
+
+    with pytest.raises(WeightBridgeUnavailableError, match="WeightUpdateManifest"):
+        executor.update_weights_via_ipc({"weight": object()})

--- a/tests/test_weight_sync_bridge.py
+++ b/tests/test_weight_sync_bridge.py
@@ -1,0 +1,947 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import replace
+import multiprocessing as mp
+from queue import Empty
+
+import pytest
+import torch
+
+import rl_engine.executors.bridge as bridge_module
+from rl_engine.executors.bridge import (
+    CUDAVMMTensorBridge,
+    IPCWeightBridge,
+    LocalTensorCopyBridge,
+    SharedMemoryTensorBridge,
+    TensorDescriptor,
+    VLLMCUDAVMMExternalStorageAdapter,
+    VLLMCheckpointWeightReloadAdapter,
+    VLLMInProcessWeightReloadAdapter,
+    VLLMIPCWeightUpdateRequestBuilder,
+    VLLMWeightInstallAdapter,
+    WeightBridgeUnavailableError,
+    WeightManifestValidationError,
+    WeightUpdateRejectedError,
+    make_weight_bridge,
+)
+
+
+def _model() -> torch.nn.Module:
+    model = torch.nn.Sequential(
+        torch.nn.Linear(3, 4),
+        torch.nn.LayerNorm(4),
+        torch.nn.Linear(4, 2, bias=False),
+    )
+    with torch.no_grad():
+        for index, parameter in enumerate(model.parameters()):
+            parameter.fill_(index + 1)
+    return model
+
+
+def _model_with_empty_buffer() -> torch.nn.Module:
+    model = _model()
+    model.register_buffer("empty_buffer", torch.empty(0, 3))
+    return model
+
+
+class _FakeCudaDevice:
+    type = "cuda"
+
+    def __str__(self):
+        return "cuda:0"
+
+
+class _FakeCudaTensor:
+    device = _FakeCudaDevice()
+    dtype = torch.float32
+
+    def __init__(self, shape):
+        self.shape = torch.Size(shape)
+
+    def detach(self):
+        return self
+
+    def contiguous(self):
+        return self
+
+    def numel(self):
+        total = 1
+        for dim in self.shape:
+            total *= int(dim)
+        return total
+
+
+def _fake_cuda_tensors_for_manifest(manifest):
+    return {
+        name: _FakeCudaTensor(descriptor.shape) for name, descriptor in manifest.tensors.items()
+    }
+
+
+def test_local_bridge_publishes_manifest_with_tensor_metadata():
+    model = _model()
+    bridge = LocalTensorCopyBridge(source_worker="trainer-0", source_rank=0)
+
+    manifest = bridge.publish(model, weight_version=7, metadata={"step": 3})
+
+    assert manifest.source_worker == "trainer-0"
+    assert manifest.source_rank == 0
+    assert manifest.weight_version == 7
+    assert manifest.transport == "local-clone"
+    assert manifest.metadata["step"] == 3
+    assert manifest.metadata["layout"] == {
+        "kind": "full-state",
+        "world_size": 1,
+        "rank": 0,
+        "tensor_parallel_size": 1,
+        "data_parallel_size": 1,
+        "zero_stage": 0,
+        "node_count": 1,
+        "rdma_enabled": False,
+    }
+    assert manifest.tensor_count == len(model.state_dict())
+    assert manifest.total_nbytes > 0
+    assert set(manifest.tensors) == set(model.state_dict())
+
+    for name, tensor in model.state_dict().items():
+        descriptor = manifest.tensors[name]
+        assert descriptor == TensorDescriptor.from_tensor(name, tensor)
+        assert len(descriptor.sha256) == 64
+
+
+def test_local_bridge_import_acknowledge_and_release_lifecycle():
+    model = _model()
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(model, weight_version=1)
+
+    imported = bridge.import_update(manifest)
+
+    assert bridge.update_status(manifest.update_id) == "imported"
+    assert set(imported) == set(model.state_dict())
+    for name, original in model.state_dict().items():
+        assert torch.equal(imported[name], original)
+        assert imported[name].data_ptr() != original.data_ptr()
+
+    bridge.acknowledge(manifest.update_id)
+    assert bridge.active_weight_version == 1
+    assert bridge.active_update_id == manifest.update_id
+    assert bridge.update_status(manifest.update_id) == "acknowledged"
+
+    bridge.release(manifest.update_id)
+    bridge.release(manifest.update_id)
+    assert bridge.update_status(manifest.update_id) == "released"
+    assert bridge.active_update_id is None
+    assert bridge.active_weight_version == 1
+
+
+def test_reject_path_does_not_advance_active_version():
+    bridge = LocalTensorCopyBridge()
+    first = bridge.publish(_model(), weight_version=1)
+    bridge.import_update(first)
+    bridge.acknowledge(first.update_id)
+
+    second = bridge.publish(_model(), weight_version=2)
+    bridge.reject(second.update_id, "consumer validation failed")
+
+    assert bridge.update_status(second.update_id) == "rejected"
+    assert bridge.active_weight_version == 1
+    assert bridge.active_update_id == first.update_id
+    with pytest.raises(WeightUpdateRejectedError, match="rejected"):
+        bridge.import_update(second)
+
+
+def test_acknowledge_requires_successful_import():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=1)
+
+    with pytest.raises(WeightUpdateRejectedError, match="before import_update"):
+        bridge.acknowledge(manifest.update_id)
+
+
+def test_acknowledge_revalidates_imported_content_before_switching_active_version():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=1)
+    imported = bridge.import_update(manifest)
+    assert imported
+    name = next(iter(manifest.tensors))
+    bridge._updates[manifest.update_id].tensors[name].add_(1)  # noqa: SLF001
+
+    with pytest.raises(WeightManifestValidationError, match="checksum mismatch"):
+        bridge.acknowledge(manifest.update_id)
+
+    assert bridge.active_weight_version is None
+    assert bridge.active_update_id is None
+
+
+def test_metadata_mismatch_rejects_import_without_advancing_active_version():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=1)
+    name, descriptor = next(iter(manifest.tensors.items()))
+    mutated_descriptor = replace(descriptor, shape=(999,))
+    mutated_manifest = replace(
+        manifest,
+        tensors={**dict(manifest.tensors), name: mutated_descriptor},
+    )
+
+    with pytest.raises(WeightManifestValidationError, match="descriptor mismatch"):
+        bridge.import_update(mutated_manifest)
+
+    assert bridge.active_weight_version is None
+    assert bridge.update_status(manifest.update_id) == "published"
+
+
+def test_content_checksum_mismatch_rejects_import_without_advancing_active_version():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=1)
+    source_ptrs = bridge.debug_tensor_data_ptrs(manifest.update_id)
+    assert source_ptrs
+    name = next(iter(manifest.tensors))
+    bridge._updates[manifest.update_id].tensors[name].add_(1)  # noqa: SLF001
+
+    with pytest.raises(WeightManifestValidationError, match="checksum mismatch"):
+        bridge.import_update(manifest)
+
+    assert bridge.active_weight_version is None
+    assert bridge.update_status(manifest.update_id) == "published"
+
+
+def test_publish_requires_monotonic_weight_versions():
+    bridge = LocalTensorCopyBridge()
+    bridge.publish(_model(), weight_version=3)
+
+    with pytest.raises(WeightManifestValidationError, match="monotonically"):
+        bridge.publish(_model(), weight_version=3)
+
+
+def test_publish_rejects_unsupported_weight_layouts():
+    bridge = LocalTensorCopyBridge()
+
+    with pytest.raises(WeightBridgeUnavailableError, match="weight layout"):
+        bridge.publish(
+            _model(),
+            weight_version=1,
+            metadata={"layout": {"kind": "zero-shard"}},
+        )
+
+    with pytest.raises(WeightBridgeUnavailableError, match="ZeRO-3"):
+        bridge.publish(
+            _model(),
+            weight_version=1,
+            metadata={"layout": {"zero_stage": 3}},
+        )
+
+    with pytest.raises(WeightBridgeUnavailableError, match="tensor-parallel"):
+        bridge.publish(
+            _model(),
+            weight_version=1,
+            metadata={"layout": {"tensor_parallel_size": 2}},
+        )
+
+    with pytest.raises(WeightBridgeUnavailableError, match="multi-node/RDMA"):
+        bridge.publish(
+            _model(),
+            weight_version=1,
+            metadata={"layout": {"node_count": 2}},
+        )
+
+
+def test_factory_and_cuda_ipc_unavailable_path_are_explicit():
+    local = make_weight_bridge("local-clone")
+    assert isinstance(local, LocalTensorCopyBridge)
+    shared = make_weight_bridge("shared-memory")
+    assert isinstance(shared, SharedMemoryTensorBridge)
+    cuda_vmm = make_weight_bridge("cuda-vmm")
+    assert isinstance(cuda_vmm, CUDAVMMTensorBridge)
+
+    ipc = make_weight_bridge("cuda-ipc")
+    assert isinstance(ipc, IPCWeightBridge)
+    with pytest.raises(WeightBridgeUnavailableError, match="CUDA IPC"):
+        ipc.export_model_handles(_model())
+
+    with pytest.raises(WeightBridgeUnavailableError, match="multi-node/RDMA"):
+        make_weight_bridge("rdma")
+
+
+def test_shared_memory_bridge_imports_without_second_copy():
+    model = _model()
+    bridge = SharedMemoryTensorBridge()
+    manifest = bridge.publish(model, weight_version=1)
+    source_ptrs = bridge.debug_tensor_data_ptrs(manifest.update_id)
+
+    imported = bridge.import_update(manifest)
+
+    shared_metadata = manifest.metadata["weight_bridge"]
+    assert shared_metadata["format"] == "python-multiprocessing-shared-memory-v1"
+    assert set(shared_metadata["tensors"]) == set(manifest.tensors)
+    for name, tensor in imported.items():
+        assert tensor.data_ptr() == source_ptrs[name]
+
+    first_name = next(iter(imported))
+    imported[first_name].add_(10)
+    with pytest.raises(WeightManifestValidationError, match="checksum mismatch"):
+        bridge.import_update(manifest)
+
+    bridge.release(manifest.update_id)
+
+
+def _shared_memory_tensor_pickle_child(imported, queue):
+    first_name = next(iter(imported))
+    imported[first_name].add_(5)
+    queue.put(float(imported[first_name].flatten()[0].item()))
+
+
+def _shared_memory_manifest_child(manifest, queue):
+    consumer = SharedMemoryTensorBridge(source_worker="rollout-worker", source_rank=1)
+    imported = dict(consumer.import_update(manifest))
+    try:
+        consumer.acknowledge(manifest.update_id)
+        first_name = next(iter(imported))
+        value_before = float(imported[first_name].flatten()[0].item())
+        queue.put(
+            {
+                "value_before": value_before,
+                "active_weight_version": consumer.active_weight_version,
+                "tensor_count": len(imported),
+            }
+        )
+    finally:
+        consumer.release(manifest.update_id)
+
+
+def test_shared_memory_bridge_tensor_alias_is_visible_across_processes():
+    bridge = SharedMemoryTensorBridge()
+    manifest = bridge.publish(_model(), weight_version=1)
+    imported = dict(bridge.import_update(manifest))
+    first_name = next(iter(imported))
+    before = float(imported[first_name].flatten()[0].item())
+
+    context = mp.get_context("spawn")
+    queue = context.Queue()
+    process = context.Process(target=_shared_memory_tensor_pickle_child, args=(imported, queue))
+    process.start()
+    process.join(timeout=10)
+
+    assert process.exitcode == 0
+    child_value = queue.get(timeout=1)
+    assert child_value == before + 5
+    assert float(imported[first_name].flatten()[0].item()) == before + 5
+
+    bridge.release(manifest.update_id)
+
+
+def test_shared_memory_manifest_import_works_from_fresh_process():
+    bridge = SharedMemoryTensorBridge()
+    manifest = bridge.publish(_model(), weight_version=42)
+    imported = dict(bridge.import_update(manifest))
+    first_name = next(iter(imported))
+    before = float(imported[first_name].flatten()[0].item())
+
+    context = mp.get_context("spawn")
+    queue = context.Queue()
+    process = context.Process(target=_shared_memory_manifest_child, args=(manifest, queue))
+    process.start()
+    process.join(timeout=10)
+
+    assert process.exitcode == 0
+    try:
+        child_result = queue.get(timeout=1)
+    except Empty as exc:
+        raise AssertionError("child did not report shared-memory import result") from exc
+
+    assert child_result["value_before"] == before
+    assert child_result["active_weight_version"] == 42
+    assert child_result["tensor_count"] == manifest.tensor_count
+    assert float(imported[first_name].flatten()[0].item()) == before
+
+    bridge.release(manifest.update_id)
+    consumer_after_release = SharedMemoryTensorBridge()
+    with pytest.raises(FileNotFoundError):
+        consumer_after_release.import_update(manifest)
+
+
+def _shared_memory_manifest_tamper_child(manifest, queue):
+    consumer = SharedMemoryTensorBridge(source_worker="rollout-worker", source_rank=1)
+    imported = dict(consumer.import_update(manifest))
+    first_name = next(iter(imported))
+    imported[first_name].add_(11)
+    try:
+        consumer.import_update(manifest)
+    except WeightManifestValidationError as exc:
+        queue.put(
+            {
+                "error": str(exc),
+                "status": consumer.update_status(manifest.update_id),
+                "active_weight_version": consumer.active_weight_version,
+            }
+        )
+    finally:
+        consumer.release(manifest.update_id)
+
+
+def test_shared_memory_manifest_checksum_rejects_cross_process_tamper():
+    bridge = SharedMemoryTensorBridge()
+    manifest = bridge.publish(_model(), weight_version=42)
+    imported = dict(bridge.import_update(manifest))
+    first_name = next(iter(imported))
+    before = float(imported[first_name].flatten()[0].item())
+
+    context = mp.get_context("spawn")
+    queue = context.Queue()
+    process = context.Process(target=_shared_memory_manifest_tamper_child, args=(manifest, queue))
+    process.start()
+    process.join(timeout=10)
+
+    assert process.exitcode == 0
+    child_result = queue.get(timeout=1)
+
+    assert "checksum mismatch" in child_result["error"]
+    assert child_result["status"] == "imported"
+    assert child_result["active_weight_version"] is None
+    assert float(imported[first_name].flatten()[0].item()) == before + 11
+
+    with pytest.raises(WeightManifestValidationError, match="checksum mismatch"):
+        bridge.import_update(manifest)
+
+    bridge.release(manifest.update_id)
+
+
+def test_shared_memory_publish_rejects_reserved_metadata_key():
+    bridge = SharedMemoryTensorBridge()
+
+    with pytest.raises(WeightManifestValidationError, match="reserved"):
+        bridge.publish(_model(), weight_version=1, metadata={"weight_bridge": {}})
+
+
+def test_shared_memory_manifest_rejects_handle_mismatch():
+    bridge = SharedMemoryTensorBridge()
+    manifest = bridge.publish(_model(), weight_version=1)
+    shared_metadata = manifest.metadata["weight_bridge"]
+    mutated_manifest = replace(
+        manifest,
+        metadata={
+            **manifest.metadata,
+            "weight_bridge": {
+                **shared_metadata,
+                "tensors": {
+                    **shared_metadata["tensors"],
+                    "unexpected.weight": {
+                        "name": None,
+                        "size": 0,
+                        "storage_numel": 0,
+                        "storage_nbytes": 0,
+                        "storage_offset": 0,
+                    },
+                },
+            },
+        },
+    )
+
+    consumer = SharedMemoryTensorBridge()
+    with pytest.raises(WeightManifestValidationError, match="handle mismatch"):
+        consumer.import_update(mutated_manifest)
+
+    bridge.release(manifest.update_id)
+
+
+def test_shared_memory_manifest_handles_empty_tensors():
+    bridge = SharedMemoryTensorBridge()
+    manifest = bridge.publish(_model_with_empty_buffer(), weight_version=1)
+
+    consumer = SharedMemoryTensorBridge()
+    imported = consumer.import_update(manifest)
+
+    assert tuple(imported["empty_buffer"].shape) == (0, 3)
+    assert imported["empty_buffer"].numel() == 0
+    assert imported["empty_buffer"].device.type == "cpu"
+
+    consumer.release(manifest.update_id)
+    bridge.release(manifest.update_id)
+
+
+def test_cuda_ipc_bridge_remains_blocked_until_snapshot_semantics_are_validated():
+    bridge = IPCWeightBridge()
+    model = _model().to("cuda") if torch.cuda.is_available() else _model()
+
+    with pytest.raises(WeightBridgeUnavailableError, match="not production-ready|unavailable"):
+        bridge.publish(model, weight_version=1)
+
+
+def test_cuda_vmm_bridge_requires_cuda_tensors_before_loading_backend():
+    backend_calls = []
+    bridge = CUDAVMMTensorBridge(backend_factory=lambda: backend_calls.append("loaded"))
+
+    with pytest.raises(WeightBridgeUnavailableError, match="requires CUDA tensors"):
+        bridge.publish(_model(), weight_version=1)
+
+    assert backend_calls == []
+
+
+def test_cuda_vmm_bridge_rejects_reserved_metadata_key():
+    bridge = CUDAVMMTensorBridge(backend_factory=lambda: object())
+
+    with pytest.raises(WeightManifestValidationError, match="reserved"):
+        bridge.publish(_model(), weight_version=1, metadata={"weight_bridge": {}})
+
+
+def test_vllm_weight_install_adapter_uses_explicit_capability():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=5)
+    tensors = bridge.import_update(manifest)
+    calls = []
+
+    adapter = VLLMWeightInstallAdapter(
+        object(),
+        install_callable=lambda incoming_manifest, incoming_tensors: calls.append(
+            (incoming_manifest.weight_version, set(incoming_tensors))
+        ),
+    )
+
+    adapter.install(manifest, tensors)
+
+    assert adapter.active_weight_version == 5
+    assert adapter.active_update_id == manifest.update_id
+    assert calls == [(5, set(manifest.tensors))]
+
+
+def test_vllm_weight_install_adapter_requires_verified_capability():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=5)
+    tensors = bridge.import_update(manifest)
+    adapter = VLLMWeightInstallAdapter(object())
+
+    with pytest.raises(WeightBridgeUnavailableError, match="vLLM weight install"):
+        adapter.install(manifest, tensors)
+
+
+def test_vllm_weight_install_adapter_uses_public_update_weights_request_builder():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=6)
+    tensors = bridge.import_update(manifest)
+    calls = []
+
+    class FakeVLLMEngine:
+        def update_weights(self, request):
+            calls.append(request)
+
+    adapter = VLLMWeightInstallAdapter(
+        FakeVLLMEngine(),
+        request_builder=lambda incoming_manifest, incoming_tensors: {
+            "update_id": incoming_manifest.update_id,
+            "weight_version": incoming_manifest.weight_version,
+            "tensor_count": len(incoming_tensors),
+        },
+    )
+
+    adapter.install(manifest, tensors)
+
+    assert adapter.active_weight_version == 6
+    assert calls == [
+        {
+            "update_id": manifest.update_id,
+            "weight_version": 6,
+            "tensor_count": manifest.tensor_count,
+        }
+    ]
+
+
+def test_vllm_update_weights_api_requires_explicit_request_builder():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=6)
+    tensors = bridge.import_update(manifest)
+
+    class FakeVLLMEngine:
+        def update_weights(self, request):
+            del request
+
+    adapter = VLLMWeightInstallAdapter(FakeVLLMEngine())
+
+    with pytest.raises(WeightBridgeUnavailableError, match="request_builder"):
+        adapter.install(manifest, tensors)
+
+
+def test_vllm_ipc_request_builder_creates_public_update_request_for_cuda_tensors():
+    manifest = LocalTensorCopyBridge().publish(_model(), weight_version=1)
+    cuda_tensors = _fake_cuda_tensors_for_manifest(manifest)
+    fake_handles = []
+
+    def fake_reduce_tensor(tensor):
+        fake_handles.append((tuple(tensor.shape), str(tensor.dtype), str(tensor.device)))
+        return ("rebuild_cuda_tensor", (tensor.numel(),))
+
+    builder = VLLMIPCWeightUpdateRequestBuilder(
+        reduce_tensor_fn=fake_reduce_tensor,
+        gpu_uuid="GPU-test",
+    )
+
+    request = builder(manifest, cuda_tensors)
+
+    update_info = request["update_info"]
+    assert update_info["names"] == list(manifest.tensors)
+    assert update_info["dtype_names"] == ["float32"] * manifest.tensor_count
+    assert update_info["shapes"] == [
+        list(descriptor.shape) for descriptor in manifest.tensors.values()
+    ]
+    assert update_info["ipc_handles"] == [
+        {"GPU-test": ("rebuild_cuda_tensor", (descriptor.numel,))}
+        for descriptor in manifest.tensors.values()
+    ]
+    assert update_info["is_checkpoint_format"] is True
+    assert len(fake_handles) == manifest.tensor_count
+
+    builder.release(manifest.update_id)
+    assert builder._keepalive == {}  # noqa: SLF001
+
+
+def test_vllm_ipc_request_builder_requires_cuda_tensors():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=1)
+    tensors = bridge.import_update(manifest)
+    builder = VLLMIPCWeightUpdateRequestBuilder(
+        reduce_tensor_fn=lambda tensor: ("unused", ()),
+        gpu_uuid="GPU-test",
+    )
+
+    with pytest.raises(WeightBridgeUnavailableError, match="requires CUDA tensors"):
+        builder(manifest, tensors)
+
+
+def test_vllm_install_adapter_releases_ipc_request_builder_keepalive():
+    manifest = LocalTensorCopyBridge().publish(_model(), weight_version=1)
+    cuda_tensors = _fake_cuda_tensors_for_manifest(manifest)
+    builder = VLLMIPCWeightUpdateRequestBuilder(
+        reduce_tensor_fn=lambda tensor: ("rebuild_cuda_tensor", (tensor.numel(),)),
+        gpu_uuid="GPU-test",
+    )
+    calls = []
+
+    class FakeVLLMEngine:
+        def update_weights(self, request):
+            calls.append(request)
+
+    adapter = VLLMWeightInstallAdapter(FakeVLLMEngine(), request_builder=builder)
+    adapter.install(manifest, cuda_tensors)
+
+    assert manifest.update_id in builder._keepalive  # noqa: SLF001
+    adapter.release(manifest.update_id)
+
+    assert calls
+    assert builder._keepalive == {}  # noqa: SLF001
+    assert adapter.active_update_id is None
+
+
+def test_vllm_install_adapter_releases_ipc_keepalive_when_update_fails():
+    manifest = LocalTensorCopyBridge().publish(_model(), weight_version=1)
+    builder = VLLMIPCWeightUpdateRequestBuilder(
+        reduce_tensor_fn=lambda tensor: ("rebuild_cuda_tensor", (tensor.numel(),)),
+        gpu_uuid="GPU-test",
+    )
+
+    class FailingVLLMEngine:
+        def update_weights(self, request):
+            assert request["update_info"]["ipc_handles"]
+            raise RuntimeError("vLLM update failed")
+
+    adapter = VLLMWeightInstallAdapter(FailingVLLMEngine(), request_builder=builder)
+
+    with pytest.raises(RuntimeError, match="vLLM update failed"):
+        adapter.install(manifest, _fake_cuda_tensors_for_manifest(manifest))
+
+    assert builder._keepalive == {}  # noqa: SLF001
+    assert adapter.active_update_id is None
+
+
+def test_vllm_in_process_reload_adapter_uses_collective_rpc_reload_weights():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=8)
+    tensors = bridge.import_update(manifest)
+    calls = []
+
+    class FakeLLMEngine:
+        def collective_rpc(self, method, kwargs):
+            calls.append((method, kwargs))
+
+    class FakeLLM:
+        llm_engine = FakeLLMEngine()
+
+    adapter = VLLMInProcessWeightReloadAdapter(
+        FakeLLM(),
+        target_dtype=torch.float16,
+        synchronize_cuda=False,
+    )
+
+    adapter.install(manifest, tensors)
+
+    assert adapter.active_weight_version == 8
+    assert adapter.active_update_id == manifest.update_id
+    assert len(calls) == 1
+    method, kwargs = calls[0]
+    assert method == "reload_weights"
+    assert kwargs["is_checkpoint_format"] is True
+    weights = kwargs["weights_iterator"]
+    assert [name for name, _ in weights] == list(manifest.tensors)
+    assert all(tensor.dtype == torch.float16 for _, tensor in weights)
+    assert all(tensor.is_contiguous() for _, tensor in weights)
+
+    adapter.release(manifest.update_id)
+    assert adapter.active_update_id is None
+
+
+def test_vllm_in_process_reload_adapter_uses_direct_reload_weights_capability():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=9)
+    tensors = bridge.import_update(manifest)
+    calls = []
+
+    class FakeReloadEngine:
+        def reload_weights(self, *, weights_iterator, is_checkpoint_format):
+            calls.append((weights_iterator, is_checkpoint_format))
+
+    adapter = VLLMInProcessWeightReloadAdapter(
+        FakeReloadEngine(),
+        target_device="cpu",
+        is_checkpoint_format=False,
+        synchronize_cuda=False,
+    )
+
+    adapter.install(manifest, tensors)
+
+    assert adapter.active_weight_version == 9
+    assert len(calls) == 1
+    weights, is_checkpoint_format = calls[0]
+    assert is_checkpoint_format is False
+    assert [name for name, _ in weights] == list(manifest.tensors)
+    assert all(tensor.device.type == "cpu" for _, tensor in weights)
+
+
+def test_vllm_in_process_reload_adapter_requires_complete_manifest():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=10)
+    tensors = dict(bridge.import_update(manifest))
+    tensors.pop(next(iter(tensors)))
+    adapter = VLLMInProcessWeightReloadAdapter(object(), synchronize_cuda=False)
+
+    with pytest.raises(WeightManifestValidationError, match="tensor set mismatch"):
+        adapter.install(manifest, tensors)
+
+
+def test_vllm_in_process_reload_adapter_does_not_activate_failed_reload():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=11)
+    tensors = bridge.import_update(manifest)
+
+    class FailingReloadEngine:
+        def reload_weights(self, *, weights_iterator, is_checkpoint_format):
+            assert weights_iterator
+            assert is_checkpoint_format is True
+            raise RuntimeError("reload failed")
+
+    adapter = VLLMInProcessWeightReloadAdapter(
+        FailingReloadEngine(),
+        synchronize_cuda=False,
+    )
+
+    with pytest.raises(RuntimeError, match="reload failed"):
+        adapter.install(manifest, tensors)
+
+    assert adapter.active_weight_version is None
+    assert adapter.active_update_id is None
+
+
+def test_vllm_checkpoint_reload_adapter_uses_manifest_weights_path():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(
+        _model(),
+        weight_version=12,
+        metadata={"vllm_weights_path": "/models/checkpoint-v12"},
+    )
+    tensors = bridge.import_update(manifest)
+    calls = []
+
+    class FakeLLMEngine:
+        def collective_rpc(self, method, kwargs):
+            calls.append((method, kwargs))
+
+    class FakeLLM:
+        llm_engine = FakeLLMEngine()
+
+    adapter = VLLMCheckpointWeightReloadAdapter(
+        FakeLLM(),
+        synchronize_cuda=False,
+    )
+
+    adapter.install(manifest, tensors)
+
+    assert adapter.active_weight_version == 12
+    assert adapter.active_update_id == manifest.update_id
+    assert calls == [
+        (
+            "reload_weights",
+            {
+                "weights_path": "/models/checkpoint-v12",
+                "is_checkpoint_format": True,
+            },
+        )
+    ]
+
+
+def test_vllm_checkpoint_reload_adapter_uses_resolver():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=13)
+    tensors = bridge.import_update(manifest)
+    calls = []
+
+    class FakeReloadEngine:
+        def reload_weights(self, *, weights_path, is_checkpoint_format):
+            calls.append((weights_path, is_checkpoint_format))
+
+    adapter = VLLMCheckpointWeightReloadAdapter(
+        FakeReloadEngine(),
+        weights_path_resolver=lambda incoming_manifest, incoming_tensors: (
+            f"/models/v{incoming_manifest.weight_version}-{len(incoming_tensors)}"
+        ),
+        is_checkpoint_format=False,
+        synchronize_cuda=False,
+    )
+
+    adapter.install(manifest, tensors)
+
+    assert calls == [("/models/v13-5", False)]
+    adapter.release(manifest.update_id)
+    assert adapter.active_update_id is None
+
+
+def test_vllm_checkpoint_reload_adapter_requires_weights_path():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=14)
+    tensors = bridge.import_update(manifest)
+    adapter = VLLMCheckpointWeightReloadAdapter(object(), synchronize_cuda=False)
+
+    with pytest.raises(WeightBridgeUnavailableError, match="weights_path"):
+        adapter.install(manifest, tensors)
+
+
+def test_vllm_cuda_vmm_external_storage_adapter_requires_cuda_vmm_manifest():
+    bridge = LocalTensorCopyBridge()
+    manifest = bridge.publish(_model(), weight_version=15)
+    adapter = VLLMCUDAVMMExternalStorageAdapter(object(), synchronize_cuda=False)
+
+    with pytest.raises(WeightBridgeUnavailableError, match="cuda-vmm"):
+        adapter.install(manifest, bridge.import_update(manifest))
+
+
+def test_vllm_cuda_vmm_external_storage_adapter_rebinds_matching_parameters(monkeypatch):
+    model = torch.nn.Sequential(torch.nn.Linear(3, 4), torch.nn.LayerNorm(4))
+    replacement = _model()
+    bridge = LocalTensorCopyBridge(source_worker="trainer", source_rank=0)
+    local_manifest = bridge.publish(replacement, weight_version=16)
+    tensors = bridge.import_update(local_manifest)
+    manifest = replace(local_manifest, transport="cuda-vmm")
+    calls = []
+
+    class FakeCUDAVMMTensorBridge:
+        transport = "cuda-vmm"
+
+        def __init__(self, **kwargs):
+            calls.append(("init", kwargs))
+
+        def import_update(self, incoming_manifest):
+            calls.append(("import", incoming_manifest.update_id))
+            return tensors
+
+        def acknowledge(self, update_id):
+            calls.append(("ack", update_id))
+
+        def release(self, update_id):
+            calls.append(("release", update_id))
+
+    monkeypatch.setattr(bridge_module, "CUDAVMMTensorBridge", FakeCUDAVMMTensorBridge)
+
+    class FakeLLMEngine:
+        def apply_model(self, func):
+            return [func(model)]
+
+    adapter = VLLMCUDAVMMExternalStorageAdapter(
+        FakeLLMEngine(),
+        require_all_parameters=False,
+        synchronize_cuda=False,
+    )
+
+    adapter.install(manifest, {})
+
+    assert adapter.active_weight_version == 16
+    assert adapter.last_result[0]["zero_copy"] is True
+    rebound = set(adapter.last_result[0]["rebound"])
+    for name in rebound:
+        assert model.get_parameter(name).data_ptr() == tensors[name].data_ptr()
+
+    adapter.release(manifest.update_id)
+
+    assert ("ack", manifest.update_id) in calls
+    assert ("release", manifest.update_id) in calls
+    assert adapter.active_update_id is None
+
+
+def test_vllm_cuda_vmm_external_storage_adapter_rolls_back_partial_rebind(monkeypatch):
+    model = torch.nn.Sequential(torch.nn.Linear(3, 4), torch.nn.LayerNorm(4))
+    bridge = LocalTensorCopyBridge(source_worker="trainer", source_rank=0)
+    local_manifest = bridge.publish(model, weight_version=17)
+    tensors = dict(bridge.import_update(local_manifest))
+    manifest = replace(local_manifest, transport="cuda-vmm")
+    original_ptrs = {name: parameter.data_ptr() for name, parameter in model.named_parameters()}
+    calls = []
+
+    bad_tensors = dict(tensors)
+    bad_tensors["1.weight"] = torch.ones(5)
+
+    class FakeCUDAVMMTensorBridge:
+        transport = "cuda-vmm"
+
+        def __init__(self, **kwargs):
+            calls.append(("init", kwargs))
+
+        def import_update(self, incoming_manifest):
+            calls.append(("import", incoming_manifest.update_id))
+            return bad_tensors
+
+        def acknowledge(self, update_id):
+            calls.append(("ack", update_id))
+
+        def release(self, update_id):
+            calls.append(("release", update_id))
+
+    monkeypatch.setattr(bridge_module, "CUDAVMMTensorBridge", FakeCUDAVMMTensorBridge)
+
+    class FakeLLMEngine:
+        def apply_model(self, func):
+            return [func(model)]
+
+    adapter = VLLMCUDAVMMExternalStorageAdapter(FakeLLMEngine(), synchronize_cuda=False)
+
+    with pytest.raises(WeightManifestValidationError, match="shape mismatch"):
+        adapter.install(manifest, {})
+
+    assert {
+        name: parameter.data_ptr() for name, parameter in model.named_parameters()
+    } == original_ptrs
+    assert ("release", manifest.update_id) in calls
+    assert ("ack", manifest.update_id) not in calls
+    assert not hasattr(model, "_kernel_align_cuda_vmm_bridge")
+
+
+def test_cuda_vmm_driver_backend_prefers_env_libcuda(monkeypatch):
+    calls = []
+
+    def fake_cdll(path):
+        calls.append(path)
+        if path == "/custom/libcuda.so.1":
+            return object()
+        raise OSError(f"missing {path}")
+
+    monkeypatch.setenv("KERNEL_ALIGN_LIBCUDA_PATH", "/custom/libcuda.so.1")
+    monkeypatch.setattr(ctypes, "CDLL", fake_cdll)
+
+    assert bridge_module._CUDAVMMDriverBackend._find_libcuda(None) == "/custom/libcuda.so.1"
+    assert calls == ["/custom/libcuda.so.1"]


### PR DESCRIPTION
## Summary
- Add the issue 13 versioned weight-sync manifest contract with tensor descriptors, layout validation, ack/reject/release lifecycle, and local/shared-memory/CUDA VMM transports.
- Wire rollout weight updates, guarded vLLM install adapters, DeepSpeed full-state publication, and Ray actor publish/update/release forwarding.
- Add production-aligned bridge, rollout, DeepSpeed, Ray, vLLM adapter tests plus a benchmark smoke runner. No task-workspace docs are included in this PR.

## Validation
- PASS: py -3.13 -m pytest tests/test_weight_sync_bridge.py tests/test_vllm_rollout_sampler.py tests/test_deepspeed_training_worker.py tests/test_ray_actor_manager.py rl_engine/tests/test_dispatch.py -q (68 passed)
- PASS: py -3.13 -m compileall rl_engine tests benchmarks
- PASS: pre-commit run --files rl_engine/executors/bridge.py rl_engine/executors/rollout.py rl_engine/executors/deepspeed_trainer.py rl_engine/executors/ray_actor_manager.py benchmarks/benchmark_weight_sync_bridge.py tests/test_weight_sync_bridge.py tests/test_vllm_rollout_sampler.py tests/test_deepspeed_training_worker.py tests/test_ray_actor_manager.py
- NOTE: py -3.13 -m pytest tests -q currently reports 85 passed, 1 skipped, 3 failed in existing CUDA fused-logp tests because NativeLogpOp lacks indexed_out/online_out/online_indexed_out fallback methods. Those files were not changed in this PR.

## Remaining Limitations
- Multi-node/RDMA and NCCL multi-rank weight transport are still explicit blockers.
- ZeRO-3 publish still requires a real all-gather/full-state export before rollout workers can safely consume weights.
- Tensor-parallel multi-shard layouts are blocked until a layout-aware adapter exists.
- Legacy CUDA IPC remains guarded; same-node GPU zero-copy is implemented through CUDA VMM POSIX-fd export/import.