### PR TITLE
feat: add overlapping rollout training pipeline

### DIFF
--- a/benchmarks/benchmark_overlap_pipeline.py
+++ b/benchmarks/benchmark_overlap_pipeline.py
@@ -1,0 +1,514 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from rl_engine.executors.overlap_pipeline import (  # noqa: E402
+    IterationSpec,
+    ManifestWeightHandoff,
+    OverlapPipeline,
+    PipelineConfig,
+    RolloutExecutorWorker,
+    RolloutStageResult,
+    TorchRLTrainingConfig,
+    TorchRLTrainingWorker,
+    TrainingStageResult,
+    timeline_summary_to_dict,
+)
+from rl_engine.executors.rollout import RolloutExecutor  # noqa: E402
+
+ISSUE_DIR = REPO_ROOT / "task-workspace" / "issues" / "issue_18"
+CSV_COLUMNS = [
+    "timestamp",
+    "candidate",
+    "mode",
+    "stage",
+    "num_iterations",
+    "max_prefetch",
+    "rollout_avg_ms",
+    "training_avg_ms",
+    "sequential_estimate_ms",
+    "overlapped_elapsed_ms",
+    "overlap_ms",
+    "overlap_ratio",
+    "max_queue_depth",
+    "final_weight_version",
+    "training_data_source",
+    "environment",
+    "weight_versions",
+    "status",
+    "notes",
+]
+
+
+class SyntheticRolloutWorker:
+    def __init__(self, delay_seconds: float):
+        self.delay_seconds = delay_seconds
+
+    def rollout(self, spec: IterationSpec) -> RolloutStageResult:
+        started_at = time.perf_counter()
+        if self.delay_seconds:
+            time.sleep(self.delay_seconds)
+        finished_at = time.perf_counter()
+        return RolloutStageResult(
+            iteration=spec.iteration,
+            weight_version=int(spec.weight_version),
+            payload={"prompts": list(spec.prompts), "mode": "synthetic"},
+            started_at=started_at,
+            finished_at=finished_at,
+            metrics={"backend": "synthetic", "delay_seconds": self.delay_seconds},
+        )
+
+
+class SyntheticTrainingWorker:
+    def __init__(self, delay_seconds: float):
+        self.delay_seconds = delay_seconds
+
+    def train(self, rollout: RolloutStageResult) -> TrainingStageResult:
+        started_at = time.perf_counter()
+        if self.delay_seconds:
+            time.sleep(self.delay_seconds)
+        finished_at = time.perf_counter()
+        return TrainingStageResult(
+            iteration=rollout.iteration,
+            consumed_weight_version=rollout.weight_version,
+            published_weight_version=rollout.weight_version + 1,
+            metrics={
+                "backend": "synthetic",
+                "delay_seconds": self.delay_seconds,
+                "training_data_source": "synthetic_timing_worker",
+            },
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+
+class ManifestInstallSyntheticRolloutWorker(SyntheticRolloutWorker):
+    def __init__(self, delay_seconds: float):
+        super().__init__(delay_seconds)
+        self.installed_versions: list[int] = []
+        self.installed_transports: list[str] = []
+        self.released_update_ids: list[str] = []
+
+    def rollout(self, spec: IterationSpec) -> RolloutStageResult:
+        started_at = time.perf_counter()
+        if self.delay_seconds:
+            time.sleep(self.delay_seconds)
+        token_base = int(spec.iteration) + 1
+        payload = {
+            "normalized_outputs": [
+                [
+                    {"token_ids": [token_base, token_base + 1]},
+                    {"token_ids": [token_base + 2, token_base + 3]},
+                ]
+            ],
+            "mode": "manifest-handoff",
+        }
+        finished_at = time.perf_counter()
+        return RolloutStageResult(
+            iteration=spec.iteration,
+            weight_version=int(spec.weight_version),
+            payload=payload,
+            started_at=started_at,
+            finished_at=finished_at,
+            metrics={
+                "backend": "synthetic-manifest-rollout",
+                "delay_seconds": self.delay_seconds,
+                "installed_weight_version": (
+                    self.installed_versions[-1] if self.installed_versions else None
+                ),
+            },
+        )
+
+    def install_weight_manifest(self, manifest) -> None:
+        self.installed_versions.append(manifest.weight_version)
+        self.installed_transports.append(manifest.transport)
+
+    def release_weight_manifest(self, update_id: str) -> None:
+        self.released_update_ids.append(update_id)
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _write_csv_row(row: Mapping[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    exists = output.exists() and output.stat().st_size > 0
+    if exists:
+        first_line = output.read_text(encoding="utf-8").splitlines()[0]
+        if first_line.split(",") != CSV_COLUMNS:
+            exists = False
+    with output.open("a" if exists else "w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS)
+        if not exists:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def _write_timeline(summary: Mapping[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _row_from_summary(
+    *,
+    mode: str,
+    status: str,
+    notes: str,
+    summary: Mapping[str, Any],
+    num_iterations: int,
+    max_prefetch: int,
+) -> dict[str, Any]:
+    rollouts = summary["rollout_results"]
+    trainings = summary["training_results"]
+    rollout_avg = (
+        sum(item["duration_seconds"] for item in rollouts) / len(rollouts) * 1000.0
+        if rollouts
+        else 0.0
+    )
+    training_avg = (
+        sum(item["duration_seconds"] for item in trainings) / len(trainings) * 1000.0
+        if trainings
+        else 0.0
+    )
+    weight_versions = [
+        f"{item['consumed_weight_version']}->{item['published_weight_version']}"
+        for item in trainings
+    ]
+    data_sources = sorted(
+        {str(item.get("metrics", {}).get("training_data_source", "unknown")) for item in trainings}
+    )
+    return {
+        "timestamp": _timestamp(),
+        "candidate": "issue-18-candidate-1",
+        "mode": mode,
+        "stage": "evaluation",
+        "num_iterations": num_iterations,
+        "max_prefetch": max_prefetch,
+        "rollout_avg_ms": f"{rollout_avg:.4f}",
+        "training_avg_ms": f"{training_avg:.4f}",
+        "sequential_estimate_ms": f"{summary['sequential_estimate_seconds'] * 1000.0:.4f}",
+        "overlapped_elapsed_ms": f"{summary['elapsed_seconds'] * 1000.0:.4f}",
+        "overlap_ms": f"{summary['overlap_seconds'] * 1000.0:.4f}",
+        "overlap_ratio": f"{summary['overlap_ratio']:.6f}",
+        "max_queue_depth": summary["max_queue_depth"],
+        "final_weight_version": summary.get("final_published_weight_version", ""),
+        "training_data_source": ";".join(data_sources),
+        "environment": _environment_summary(),
+        "weight_versions": ";".join(weight_versions),
+        "status": status,
+        "notes": notes,
+    }
+
+
+def _blocked_row(
+    *,
+    mode: str,
+    notes: str,
+    num_iterations: int,
+    max_prefetch: int,
+) -> dict[str, Any]:
+    return {
+        "timestamp": _timestamp(),
+        "candidate": "issue-18-candidate-1",
+        "mode": mode,
+        "stage": "evaluation",
+        "num_iterations": num_iterations,
+        "max_prefetch": max_prefetch,
+        "rollout_avg_ms": "",
+        "training_avg_ms": "",
+        "sequential_estimate_ms": "",
+        "overlapped_elapsed_ms": "",
+        "overlap_ms": "",
+        "overlap_ratio": "",
+        "max_queue_depth": "",
+        "final_weight_version": "",
+        "training_data_source": "",
+        "environment": _environment_summary(),
+        "weight_versions": "",
+        "status": "blocked",
+        "notes": notes,
+    }
+
+
+def _run_pipeline(
+    *,
+    rollout_worker,
+    training_worker,
+    num_iterations: int,
+    max_prefetch: int,
+    prompt_prefix: str,
+    token_prompts: bool = False,
+    weight_handoff: Optional[ManifestWeightHandoff] = None,
+) -> tuple[list[TrainingStageResult], dict[str, Any]]:
+    def prompts_for(index: int) -> list[Any]:
+        if token_prompts:
+            base = [4, 5, 6, 7, 8, 9, 2, index + 10]
+            return [
+                {"prompt_token_ids": list(base)},
+                {"prompt_token_ids": list(base) + [12]},
+            ]
+        return [f"{prompt_prefix}-{index}-a", f"{prompt_prefix}-{index}-b"]
+
+    specs = [
+        IterationSpec(
+            iteration=index,
+            weight_version=None,
+            prompts=prompts_for(index),
+        )
+        for index in range(num_iterations)
+    ]
+    pipeline = OverlapPipeline(
+        rollout_worker,
+        training_worker,
+        PipelineConfig(max_prefetch=max_prefetch),
+        weight_handoff=weight_handoff,
+    )
+    results = pipeline.run(specs)
+    summary = timeline_summary_to_dict(pipeline.timeline_summary())
+    return results, summary
+
+
+def run_synthetic(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
+    _, summary = _run_pipeline(
+        rollout_worker=SyntheticRolloutWorker(args.synthetic_rollout_delay_ms / 1000.0),
+        training_worker=SyntheticTrainingWorker(args.synthetic_training_delay_ms / 1000.0),
+        num_iterations=args.num_iterations,
+        max_prefetch=args.max_prefetch,
+        prompt_prefix="synthetic",
+    )
+    row = _row_from_summary(
+        mode="synthetic",
+        status="pass",
+        notes="deterministic synthetic fallback; validates scheduler timing only",
+        summary=summary,
+        num_iterations=args.num_iterations,
+        max_prefetch=args.max_prefetch,
+    )
+    return row, summary
+
+
+def run_manifest_handoff(args: argparse.Namespace) -> tuple[dict[str, Any], dict[str, Any]]:
+    rollout_worker = ManifestInstallSyntheticRolloutWorker(args.synthetic_rollout_delay_ms / 1000.0)
+    training_device = args.training_device
+    if training_device == "cuda" and not torch.cuda.is_available():
+        training_device = "cpu"
+    training_worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=args.num_generations,
+            prompt_len=2,
+            completion_len=min(args.max_tokens, 4),
+            vocab_size=64,
+            hidden_dim=32,
+            valid_density=1.0,
+            device=training_device,
+            seed=args.seed,
+        )
+    )
+    _, summary = _run_pipeline(
+        rollout_worker=rollout_worker,
+        training_worker=training_worker,
+        num_iterations=args.num_iterations,
+        max_prefetch=args.max_prefetch,
+        prompt_prefix="manifest-handoff",
+        weight_handoff=ManifestWeightHandoff(),
+    )
+    row = _row_from_summary(
+        mode="manifest-handoff",
+        status="pass",
+        notes=(
+            "local production-semantics manifest handoff; "
+            f"installed_versions={rollout_worker.installed_versions}; "
+            f"transports={rollout_worker.installed_transports}; "
+            f"released={len(rollout_worker.released_update_ids)}"
+        ),
+        summary=summary,
+        num_iterations=args.num_iterations,
+        max_prefetch=args.max_prefetch,
+    )
+    return row, summary
+
+
+def run_realistic(args: argparse.Namespace) -> tuple[dict[str, Any], Optional[dict[str, Any]]]:
+    training_device = args.training_device
+    if training_device == "cuda" and not torch.cuda.is_available():
+        training_device = "cpu"
+
+    training_worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=args.num_generations,
+            prompt_len=4,
+            completion_len=args.max_tokens,
+            vocab_size=64,
+            hidden_dim=32,
+            valid_density=0.75,
+            device=training_device,
+            seed=args.seed,
+        )
+    )
+    rollout_worker = _build_realistic_rollout_worker(args)
+    warmup_seconds = _warm_realistic_rollout_worker(rollout_worker, args)
+    _, summary = _run_pipeline(
+        rollout_worker=rollout_worker,
+        training_worker=training_worker,
+        num_iterations=args.num_iterations,
+        max_prefetch=args.max_prefetch,
+        prompt_prefix="realistic",
+        token_prompts=args.skip_tokenizer_init,
+    )
+    notes = (
+        "production-facing adapters: RolloutExecutor.generate_candidates plus "
+        f"TorchRLTrainingWorker(device={training_device}); "
+        f"token_prompts={args.skip_tokenizer_init}; "
+        f"warmup_rollouts={args.realistic_warmup_rollouts}; "
+        f"warmup_seconds={warmup_seconds:.4f}"
+    )
+    row = _row_from_summary(
+        mode="realistic",
+        status="pass",
+        notes=notes,
+        summary=summary,
+        num_iterations=args.num_iterations,
+        max_prefetch=args.max_prefetch,
+    )
+    return row, summary
+
+
+def _build_realistic_rollout_worker(args: argparse.Namespace) -> RolloutExecutorWorker:
+    if not args.model:
+        raise RuntimeError(
+            "realistic rollout requires --model for vLLM; pass a local model path/name "
+            "or record this as the environment blocker"
+        )
+    config = {
+        "model": args.model,
+        "num_generations": args.num_generations,
+        "sampling_params": {"max_tokens": args.max_tokens},
+        "engine_kwargs": {
+            "gpu_memory_utilization": args.gpu_memory_utilization,
+            "max_model_len": args.max_model_len,
+            "trust_remote_code": False,
+            "enforce_eager": args.enforce_eager,
+        },
+    }
+    if args.skip_tokenizer_init:
+        config["engine_kwargs"]["skip_tokenizer_init"] = True
+    executor = RolloutExecutor(config)
+    return RolloutExecutorWorker(
+        executor,
+        num_generations=args.num_generations,
+        sampling_params={"max_tokens": args.max_tokens},
+    )
+
+
+def _warm_realistic_rollout_worker(
+    worker: RolloutExecutorWorker,
+    args: argparse.Namespace,
+) -> float:
+    if args.realistic_warmup_rollouts <= 0:
+        return 0.0
+    start = time.perf_counter()
+    for index in range(args.realistic_warmup_rollouts):
+        prompts = (
+            [{"prompt_token_ids": [4, 5, 6, 7, 8, 9, 2, 10 + index]}]
+            if args.skip_tokenizer_init
+            else [f"warmup-{index}"]
+        )
+        worker.rollout(IterationSpec(iteration=-1 - index, weight_version=0, prompts=prompts))
+    return time.perf_counter() - start
+
+
+def _environment_summary() -> str:
+    cuda = torch.version.cuda or ""
+    if torch.cuda.is_available():
+        device = torch.cuda.get_device_name(0)
+        memory_gb = torch.cuda.get_device_properties(0).total_memory / (1024**3)
+        return f"torch={torch.__version__};cuda={cuda};gpu={device};gpu_mem_gb={memory_gb:.2f}"
+    return f"torch={torch.__version__};cuda={cuda};gpu=none"
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Overlapping rollout/training pipeline benchmark")
+    parser.add_argument(
+        "--mode",
+        choices=["realistic", "synthetic", "manifest-handoff"],
+        default="synthetic",
+    )
+    parser.add_argument("--smoke", action="store_true", help="Use small issue #18 smoke settings")
+    parser.add_argument("--num-iterations", type=int, default=3)
+    parser.add_argument("--max-prefetch", type=int, default=1)
+    parser.add_argument("--model", default=None, help="vLLM model path/name for realistic mode")
+    parser.add_argument("--num-generations", type=int, default=2)
+    parser.add_argument("--max-tokens", type=int, default=8)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.45)
+    parser.add_argument("--max-model-len", type=int, default=512)
+    parser.add_argument("--enforce-eager", action="store_true", default=True)
+    parser.add_argument("--training-device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--skip-tokenizer-init", action="store_true")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--realistic-warmup-rollouts", type=int, default=1)
+    parser.add_argument("--synthetic-rollout-delay-ms", type=float, default=30.0)
+    parser.add_argument("--synthetic-training-delay-ms", type=float, default=60.0)
+    parser.add_argument("--output", type=Path, default=ISSUE_DIR / "benchmark.csv")
+    parser.add_argument("--timeline-output", type=Path, default=None)
+    return parser
+
+
+def main() -> None:
+    args = build_arg_parser().parse_args()
+    if args.smoke:
+        args.num_iterations = min(args.num_iterations, 3)
+        args.max_prefetch = max(1, args.max_prefetch)
+        args.num_generations = min(args.num_generations, 2)
+        args.max_tokens = min(args.max_tokens, 8)
+        args.max_model_len = min(args.max_model_len, 64)
+
+    timeline_output = args.timeline_output or (
+        ISSUE_DIR / "outputs" / f"overlap-{args.mode}-{int(time.time())}.json"
+    )
+
+    summary: Optional[dict[str, Any]] = None
+    try:
+        if args.mode == "synthetic":
+            row, summary = run_synthetic(args)
+        elif args.mode == "manifest-handoff":
+            row, summary = run_manifest_handoff(args)
+        else:
+            row, summary = run_realistic(args)
+    except Exception as exc:
+        row = _blocked_row(
+            mode=args.mode,
+            notes=f"{type(exc).__name__}: {str(exc).splitlines()[0]}",
+            num_iterations=args.num_iterations,
+            max_prefetch=args.max_prefetch,
+        )
+
+    _write_csv_row(row, args.output)
+    if summary is not None:
+        _write_timeline(summary, timeline_output)
+
+    writer = csv.DictWriter(sys.stdout, fieldnames=CSV_COLUMNS)
+    writer.writeheader()
+    writer.writerow(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/rl_engine/executors/overlap_pipeline.py
+++ b/rl_engine/executors/overlap_pipeline.py
@@ -1,0 +1,660 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import asdict, dataclass, field, replace
+from typing import Any, Mapping, Optional, Protocol, Sequence, cast
+
+import torch
+
+from rl_engine.executors.bridge import WeightPublisher, WeightUpdateManifest, make_weight_bridge
+from rl_engine.executors.rollout import RolloutExecutor
+from rl_engine.executors.training_contract import (
+    RolloutBatchMixin,
+    RolloutStageResult,
+    TorchRLTrainingConfig,
+    TrainingStageResult,
+    extract_rollout_token_groups,
+)
+from rl_engine.testing import (
+    compute_policy_ratio,
+    compute_reference_kl,
+    masked_mean,
+    selected_logprobs_reference,
+)
+
+
+@dataclass(frozen=True)
+class PipelineConfig:
+    """Local overlap scheduler configuration."""
+
+    max_prefetch: int = 1
+    stop_on_error: bool = True
+    rollout_workers: int = 1
+    training_workers: int = 1
+    initial_weight_version: int = 0
+    weight_version_policy: str = "published"
+
+    def __post_init__(self) -> None:
+        if self.max_prefetch < 1:
+            raise ValueError("max_prefetch must be >= 1")
+        if self.rollout_workers < 1:
+            raise ValueError("rollout_workers must be >= 1")
+        if self.training_workers < 1:
+            raise ValueError("training_workers must be >= 1")
+        if self.weight_version_policy not in {"published", "spec"}:
+            raise ValueError("weight_version_policy must be 'published' or 'spec'")
+
+
+@dataclass(frozen=True)
+class IterationSpec:
+    """One scheduled rollout/training iteration."""
+
+    iteration: int
+    weight_version: Optional[int] = None
+    prompts: Sequence[Any] = field(default_factory=list)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WeightHandoffRecord:
+    """One published and installed weight manifest handoff."""
+
+    iteration: int
+    weight_version: int
+    update_id: str
+    transport: str
+    tensor_count: int
+    total_nbytes: int
+    published_at: float
+    installed_at: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class PipelineTimelineSummary:
+    """Serializable summary of one pipeline run."""
+
+    started_at: float
+    finished_at: float
+    elapsed_seconds: float
+    sequential_estimate_seconds: float
+    overlap_seconds: float
+    overlap_ratio: float
+    max_queue_depth: int
+    rollout_results: list[Mapping[str, Any]]
+    training_results: list[Mapping[str, Any]]
+    weight_handoffs: list[Mapping[str, Any]]
+    final_published_weight_version: int
+
+
+class RolloutWorker(Protocol):
+    def rollout(self, spec: IterationSpec) -> RolloutStageResult: ...
+
+
+class TrainingWorker(Protocol):
+    def train(self, rollout: RolloutStageResult) -> TrainingStageResult: ...
+
+
+class PipelineExecutionError(RuntimeError):
+    """Raised when a rollout, training, or weight handoff stage fails."""
+
+    def __init__(self, stage: str, iteration: int, cause: BaseException):
+        super().__init__(f"{stage} failed for iteration {iteration}: {cause}")
+        self.stage = stage
+        self.iteration = iteration
+        self.cause = cause
+
+
+class ManifestWeightHandoff:
+    """
+    Publish training weights and install them on rollout workers at safe boundaries.
+
+    Publication happens only after a complete training step. Installation is
+    deferred until no rollout future is active, so a rollout engine is not
+    hot-updated while it may still be generating with the previous version.
+    """
+
+    def __init__(self, *, release_on_shutdown: bool = True):
+        self.release_on_shutdown = bool(release_on_shutdown)
+        self.records: list[WeightHandoffRecord] = []
+        self._pending: list[tuple[WeightUpdateManifest, WeightHandoffRecord]] = []
+        self._installed_update_ids: list[str] = []
+
+    def publish(
+        self,
+        training_worker: TrainingWorker,
+        result: TrainingStageResult,
+    ) -> Optional[WeightHandoffRecord]:
+        if result.published_weight_version is None:
+            return None
+        self._release_pending(training_worker)
+        publish_weights = getattr(training_worker, "publish_weights", None)
+        if not callable(publish_weights):
+            raise RuntimeError(
+                "manifest weight handoff requires the training worker to expose "
+                "publish_weights(weight_version=..., metadata=...)"
+            )
+
+        manifest = publish_weights(
+            weight_version=result.published_weight_version,
+            metadata={
+                "issue": "18",
+                "pipeline_iteration": result.iteration,
+                "consumed_weight_version": result.consumed_weight_version,
+            },
+        )
+        record = WeightHandoffRecord(
+            iteration=result.iteration,
+            weight_version=manifest.weight_version,
+            update_id=manifest.update_id,
+            transport=manifest.transport,
+            tensor_count=manifest.tensor_count,
+            total_nbytes=manifest.total_nbytes,
+            published_at=time.perf_counter(),
+        )
+        self._pending.append((manifest, record))
+        return record
+
+    def pending_iteration(self) -> int:
+        if not self._pending:
+            return -1
+        return int(self._pending[-1][1].iteration)
+
+    def install_latest(
+        self,
+        rollout_worker: RolloutWorker,
+        training_worker: Optional[TrainingWorker] = None,
+    ) -> Optional[WeightHandoffRecord]:
+        del training_worker
+        if not self._pending:
+            return None
+
+        install = _resolve_manifest_install(rollout_worker)
+        latest_manifest, latest_record = self._pending[-1]
+        installed_at = time.perf_counter()
+        install(latest_manifest)
+        installed_record = replace(latest_record, installed_at=installed_at)
+        self.records.append(installed_record)
+        self._installed_update_ids.append(latest_manifest.update_id)
+        self._pending.clear()
+        return installed_record
+
+    def release_all(
+        self,
+        training_worker: TrainingWorker,
+        rollout_worker: RolloutWorker,
+    ) -> None:
+        if not self.release_on_shutdown:
+            return
+
+        release_rollout = getattr(rollout_worker, "release_weight_manifest", None)
+        if callable(release_rollout):
+            for update_id in reversed(self._installed_update_ids):
+                release_rollout(update_id)
+
+        release_training = getattr(training_worker, "release_weights", None)
+        if callable(release_training):
+            update_ids = [record.update_id for record in self.records]
+            update_ids.extend(manifest.update_id for manifest, _record in self._pending)
+            for update_id in reversed(update_ids):
+                release_training(update_id)
+
+        self._pending.clear()
+        self._installed_update_ids.clear()
+
+    def _release_pending(self, training_worker: TrainingWorker) -> None:
+        if not self._pending:
+            return
+        release_training = getattr(training_worker, "release_weights", None)
+        if callable(release_training):
+            for manifest, _record in self._pending:
+                release_training(manifest.update_id)
+        self._pending.clear()
+
+
+class OverlapPipeline:
+    """Coordinate rollout and training stages with bounded prefetch overlap."""
+
+    def __init__(
+        self,
+        rollout_worker: RolloutWorker,
+        training_worker: TrainingWorker,
+        config: Optional[PipelineConfig] = None,
+        *,
+        weight_handoff: Optional[ManifestWeightHandoff] = None,
+    ):
+        self.rollout_worker = rollout_worker
+        self.training_worker = training_worker
+        self.config = config or PipelineConfig()
+        self.weight_handoff = weight_handoff
+        self.rollout_results: list[RolloutStageResult] = []
+        self.training_results: list[TrainingStageResult] = []
+        self.weight_handoffs: list[WeightHandoffRecord] = []
+        self.max_queue_depth = 0
+        self.started_at = 0.0
+        self.finished_at = 0.0
+        self.final_published_weight_version = self.config.initial_weight_version
+
+    def run(self, iterations: Sequence[IterationSpec]) -> list[TrainingStageResult]:
+        specs = list(iterations)
+        if not specs:
+            return []
+
+        self.rollout_results = []
+        self.training_results = []
+        self.weight_handoffs = []
+        self.max_queue_depth = 0
+        self.started_at = time.perf_counter()
+        self.finished_at = self.started_at
+        self.final_published_weight_version = self.config.initial_weight_version
+
+        rollout_futures: dict[Future[RolloutStageResult], int] = {}
+        training_futures: dict[Future[TrainingStageResult], int] = {}
+        buffered_rollouts: dict[int, RolloutStageResult] = {}
+        submitted_specs: dict[int, IterationSpec] = {}
+        next_rollout_index = 0
+        next_training_index = 0
+        current_published_weight_version = self.config.initial_weight_version
+        current_rollout_weight_version = self.config.initial_weight_version
+
+        def rollout_backlog() -> int:
+            return len(rollout_futures) + len(buffered_rollouts)
+
+        def rollout_spec_for(index: int) -> IterationSpec:
+            base_spec = specs[index]
+            if self.config.weight_version_policy == "spec":
+                if base_spec.weight_version is None:
+                    raise ValueError("IterationSpec.weight_version is required for spec policy")
+                return base_spec
+            visible_version = (
+                current_rollout_weight_version
+                if self.weight_handoff is not None
+                else current_published_weight_version
+            )
+            return replace(base_spec, weight_version=visible_version)
+
+        def install_pending_weights_if_idle() -> None:
+            nonlocal current_rollout_weight_version
+            if self.weight_handoff is None or rollout_futures:
+                return
+            try:
+                installed = self.weight_handoff.install_latest(
+                    self.rollout_worker,
+                    self.training_worker,
+                )
+            except BaseException as exc:
+                raise PipelineExecutionError(
+                    "weight_handoff",
+                    self.weight_handoff.pending_iteration(),
+                    exc,
+                ) from exc
+            if installed is None:
+                return
+            current_rollout_weight_version = installed.weight_version
+            self.weight_handoffs.append(installed)
+
+        def submit_rollouts(executor: ThreadPoolExecutor) -> None:
+            nonlocal next_rollout_index
+            while next_rollout_index < len(specs) and rollout_backlog() < self.config.max_prefetch:
+                index = next_rollout_index
+                rollout_spec = rollout_spec_for(index)
+                submitted_specs[index] = rollout_spec
+                future = executor.submit(self.rollout_worker.rollout, rollout_spec)
+                rollout_futures[future] = index
+                next_rollout_index += 1
+            self.max_queue_depth = max(self.max_queue_depth, rollout_backlog())
+
+        def submit_training(executor: ThreadPoolExecutor) -> None:
+            nonlocal next_training_index
+            while (
+                next_training_index < len(specs)
+                and next_training_index in buffered_rollouts
+                and len(training_futures) < self.config.training_workers
+            ):
+                rollout = buffered_rollouts.pop(next_training_index)
+                future = executor.submit(self.training_worker.train, rollout)
+                training_futures[future] = next_training_index
+                next_training_index += 1
+            self.max_queue_depth = max(self.max_queue_depth, rollout_backlog())
+
+        try:
+            with (
+                ThreadPoolExecutor(
+                    max_workers=self.config.rollout_workers,
+                    thread_name_prefix="rl-kernel-rollout",
+                ) as rollout_executor,
+                ThreadPoolExecutor(
+                    max_workers=self.config.training_workers,
+                    thread_name_prefix="rl-kernel-training",
+                ) as training_executor,
+            ):
+                submit_rollouts(rollout_executor)
+
+                while len(self.training_results) < len(specs):
+                    install_pending_weights_if_idle()
+                    submit_training(training_executor)
+                    submit_rollouts(rollout_executor)
+
+                    active_futures: set[Future[Any]] = set(rollout_futures) | set(training_futures)
+                    if not active_futures:
+                        break
+
+                    done, _ = wait(active_futures, return_when=FIRST_COMPLETED)
+                    for future in done:
+                        if future in rollout_futures:
+                            index = rollout_futures.pop(future)
+                            rollout_spec = submitted_specs[index]
+                            try:
+                                result = future.result()
+                            except BaseException as exc:
+                                self._cancel_pending(rollout_futures, training_futures)
+                                raise PipelineExecutionError(
+                                    "rollout", rollout_spec.iteration, exc
+                                ) from exc
+                            self._validate_rollout_result(rollout_spec, result)
+                            buffered_rollouts[index] = result
+                            self.rollout_results.append(result)
+                            self.max_queue_depth = max(self.max_queue_depth, rollout_backlog())
+                        elif future in training_futures:
+                            index = training_futures.pop(future)
+                            rollout_spec = submitted_specs[index]
+                            try:
+                                result = future.result()
+                            except BaseException as exc:
+                                self._cancel_pending(rollout_futures, training_futures)
+                                raise PipelineExecutionError(
+                                    "training", rollout_spec.iteration, exc
+                                ) from exc
+                            try:
+                                self._validate_training_result(rollout_spec, result)
+                                if result.published_weight_version is not None:
+                                    if self.weight_handoff is not None:
+                                        self.weight_handoff.publish(self.training_worker, result)
+                                    current_published_weight_version = max(
+                                        current_published_weight_version,
+                                        result.published_weight_version,
+                                    )
+                                self.training_results.append(result)
+                            except BaseException as exc:
+                                self._cancel_pending(rollout_futures, training_futures)
+                                raise PipelineExecutionError(
+                                    "weight_handoff", rollout_spec.iteration, exc
+                                ) from exc
+
+                return list(self.training_results)
+        finally:
+            try:
+                install_pending_weights_if_idle()
+            finally:
+                if self.weight_handoff is not None:
+                    self.weight_handoff.release_all(self.training_worker, self.rollout_worker)
+            self.final_published_weight_version = current_published_weight_version
+            self.finished_at = time.perf_counter()
+
+    def timeline_summary(self) -> PipelineTimelineSummary:
+        finished_at = self.finished_at or time.perf_counter()
+        rollout_rows: list[Mapping[str, Any]] = [
+            _stage_to_dict(result) for result in self.rollout_results
+        ]
+        training_rows: list[Mapping[str, Any]] = [
+            _stage_to_dict(result) for result in self.training_results
+        ]
+        sequential = sum(result.duration_seconds for result in self.rollout_results) + sum(
+            result.duration_seconds for result in self.training_results
+        )
+        overlap = compute_stage_overlap_seconds(self.rollout_results, self.training_results)
+        rollout_total = sum(result.duration_seconds for result in self.rollout_results)
+        denominator = max(rollout_total, 1e-12)
+        return PipelineTimelineSummary(
+            started_at=self.started_at,
+            finished_at=finished_at,
+            elapsed_seconds=finished_at - self.started_at,
+            sequential_estimate_seconds=sequential,
+            overlap_seconds=overlap,
+            overlap_ratio=overlap / denominator,
+            max_queue_depth=self.max_queue_depth,
+            rollout_results=rollout_rows,
+            training_results=training_rows,
+            weight_handoffs=[asdict(record) for record in self.weight_handoffs],
+            final_published_weight_version=self.final_published_weight_version,
+        )
+
+    @staticmethod
+    def _cancel_pending(
+        rollout_futures: Mapping[Future[RolloutStageResult], int],
+        training_futures: Mapping[Future[TrainingStageResult], int],
+    ) -> None:
+        for future in list(rollout_futures) + list(training_futures):
+            future.cancel()
+
+    @staticmethod
+    def _validate_rollout_result(spec: IterationSpec, result: RolloutStageResult) -> None:
+        if result.iteration != spec.iteration:
+            raise ValueError(
+                f"rollout result iteration {result.iteration} does not match spec "
+                f"{spec.iteration}"
+            )
+        if result.weight_version != spec.weight_version:
+            raise ValueError(
+                f"rollout result weight_version {result.weight_version} does not match spec "
+                f"{spec.weight_version}"
+            )
+
+    @staticmethod
+    def _validate_training_result(spec: IterationSpec, result: TrainingStageResult) -> None:
+        if result.iteration != spec.iteration:
+            raise ValueError(
+                f"training result iteration {result.iteration} does not match spec "
+                f"{spec.iteration}"
+            )
+
+
+class RolloutExecutorWorker:
+    """Production-facing rollout adapter over RolloutExecutor.generate_candidates."""
+
+    def __init__(
+        self,
+        executor: RolloutExecutor,
+        *,
+        num_generations: Optional[int] = None,
+        sampling_params: Optional[Mapping[str, Any]] = None,
+    ):
+        self.executor = executor
+        self.num_generations = num_generations
+        self.sampling_params = dict(sampling_params or {})
+
+    def rollout(self, spec: IterationSpec) -> RolloutStageResult:
+        if spec.weight_version is None:
+            raise ValueError("IterationSpec.weight_version must be resolved before rollout")
+        started_at = time.perf_counter()
+        payload = self.executor.generate_candidates(
+            spec.prompts,
+            num_generations=self.num_generations,
+            sampling_params=self.sampling_params,
+        )
+        finished_at = time.perf_counter()
+        return RolloutStageResult(
+            iteration=spec.iteration,
+            weight_version=int(cast(int, spec.weight_version)),
+            payload=payload,
+            started_at=started_at,
+            finished_at=finished_at,
+            metrics={
+                "num_prompts": len(spec.prompts),
+                "backend": payload.get("backend") if isinstance(payload, Mapping) else None,
+            },
+        )
+
+    def install_weight_manifest(self, manifest: WeightUpdateManifest) -> Mapping[str, torch.Tensor]:
+        return self.executor.update_weights(manifest)
+
+    def release_weight_manifest(self, update_id: str) -> None:
+        release_update = getattr(self.executor, "release_weight_update", None)
+        if callable(release_update):
+            release_update(update_id)
+        elif getattr(self.executor, "active_weight_update_id", None) == update_id:
+            self.executor.release_weights()
+
+
+class TorchRLTrainingWorker(RolloutBatchMixin):
+    """DeepSpeed-style local training adapter using a real PyTorch optimizer step."""
+
+    config: TorchRLTrainingConfig
+
+    def __init__(
+        self,
+        config: Optional[TorchRLTrainingConfig] = None,
+        *,
+        weight_bridge: Optional[WeightPublisher] = None,
+        weight_transport: str = "local-clone",
+    ):
+        self.config = config or TorchRLTrainingConfig()
+        self.weight_bridge = weight_bridge or make_weight_bridge(
+            weight_transport,
+            source_worker="torch-training",
+            source_rank=0,
+        )
+        self.device = torch.device(self.config.device)
+        if self.device.type == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("CUDA training requested but torch.cuda.is_available() is false")
+
+        torch.manual_seed(self.config.seed)
+        self.model = torch.nn.Sequential(
+            torch.nn.Embedding(self.config.vocab_size, self.config.hidden_dim),
+            torch.nn.Linear(self.config.hidden_dim, self.config.vocab_size),
+        ).to(device=self.device)
+        self.optimizer = torch.optim.AdamW(self.model.parameters(), lr=self.config.lr)
+        self._latest_published_weight_version = -1
+
+    def train(self, rollout: RolloutStageResult) -> TrainingStageResult:
+        started_at = time.perf_counter()
+        batch, payload_metrics = self._batch_from_rollout_or_synthetic(rollout)
+
+        logits = self.model(batch.token_ids.long())
+        current_logps = selected_logprobs_reference(
+            logits,
+            batch.token_ids,
+            mask=batch.completion_mask,
+            output_dtype=torch.float32,
+        )
+        old_logps = current_logps.detach() - 0.01
+        ref_logps = current_logps.detach() - 0.02
+        ratio = compute_policy_ratio(current_logps, old_logps, batch.completion_mask)
+        unclipped = ratio * batch.advantages.float()
+        clipped = torch.clamp(ratio, 0.8, 1.2) * batch.advantages.float()
+        policy_loss = -torch.minimum(unclipped, clipped)
+        kl = compute_reference_kl(current_logps, ref_logps, batch.completion_mask)
+        loss = masked_mean(policy_loss + 0.01 * kl, batch.completion_mask)
+
+        self.optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        self.optimizer.step()
+
+        finished_at = time.perf_counter()
+        published = self._next_published_weight_version(rollout.weight_version)
+        return TrainingStageResult(
+            iteration=rollout.iteration,
+            consumed_weight_version=rollout.weight_version,
+            published_weight_version=published,
+            metrics={
+                "loss": float(loss.detach().cpu().item()),
+                "active_tokens": int(batch.completion_mask.sum().item()),
+                "payload_type": type(rollout.payload).__name__,
+                "training_backend": "torch",
+                **payload_metrics,
+            },
+            started_at=started_at,
+            finished_at=finished_at,
+        )
+
+    def publish_weights(
+        self,
+        *,
+        weight_version: int,
+        metadata: Optional[Mapping[str, Any]] = None,
+    ) -> WeightUpdateManifest:
+        return self.weight_bridge.publish(
+            self.model,
+            weight_version=weight_version,
+            metadata=metadata,
+        )
+
+    def release_weights(self, update_id: str) -> None:
+        self.weight_bridge.release(update_id)
+
+    def _next_published_weight_version(self, consumed_weight_version: int) -> int:
+        published = max(
+            self._latest_published_weight_version + 1,
+            int(consumed_weight_version) + 1,
+        )
+        self._latest_published_weight_version = published
+        return published
+
+
+def compute_stage_overlap_seconds(
+    rollouts: Sequence[RolloutStageResult],
+    trainings: Sequence[TrainingStageResult],
+) -> float:
+    """Compute pairwise rollout/training interval overlap in seconds."""
+
+    overlap = 0.0
+    for rollout in rollouts:
+        for training in trainings:
+            if rollout.iteration == training.iteration:
+                continue
+            start = max(rollout.started_at, training.started_at)
+            end = min(rollout.finished_at, training.finished_at)
+            overlap += max(0.0, end - start)
+    return overlap
+
+
+def timeline_summary_to_dict(summary: PipelineTimelineSummary) -> dict[str, Any]:
+    return asdict(summary)
+
+
+def _resolve_manifest_install(rollout_worker: RolloutWorker):
+    install = getattr(rollout_worker, "install_weight_manifest", None)
+    if callable(install):
+        return install
+    update_weights = getattr(rollout_worker, "update_weights", None)
+    if callable(update_weights):
+        return update_weights
+    executor = getattr(rollout_worker, "executor", None)
+    update_weights = getattr(executor, "update_weights", None)
+    if callable(update_weights):
+        return update_weights
+    raise RuntimeError(
+        "manifest weight handoff requires the rollout worker to expose "
+        "install_weight_manifest(manifest) or update_weights(manifest)"
+    )
+
+
+def _stage_to_dict(stage: RolloutStageResult | TrainingStageResult) -> dict[str, Any]:
+    row = asdict(stage)
+    row.pop("payload", None)
+    row["duration_seconds"] = stage.duration_seconds
+    return row
+
+
+__all__ = [
+    "IterationSpec",
+    "ManifestWeightHandoff",
+    "OverlapPipeline",
+    "PipelineConfig",
+    "PipelineExecutionError",
+    "PipelineTimelineSummary",
+    "RolloutExecutorWorker",
+    "RolloutStageResult",
+    "RolloutWorker",
+    "TorchRLTrainingConfig",
+    "TorchRLTrainingWorker",
+    "TrainingStageResult",
+    "TrainingWorker",
+    "WeightHandoffRecord",
+    "compute_stage_overlap_seconds",
+    "extract_rollout_token_groups",
+    "timeline_summary_to_dict",
+]

--- a/tests/test_overlap_pipeline.py
+++ b/tests/test_overlap_pipeline.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import math
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from rl_engine.executors.overlap_pipeline import (
+    IterationSpec,
+    ManifestWeightHandoff,
+    OverlapPipeline,
+    PipelineConfig,
+    PipelineExecutionError,
+    RolloutExecutorWorker,
+    RolloutStageResult,
+    TorchRLTrainingConfig,
+    TorchRLTrainingWorker,
+    TrainingStageResult,
+    extract_rollout_token_groups,
+)
+
+
+class RecordingRolloutWorker:
+    def __init__(self, *, delay: float = 0.0, fail_iteration: int | None = None):
+        self.delay = delay
+        self.fail_iteration = fail_iteration
+        self.started: dict[int, threading.Event] = {}
+        self.finished: dict[int, threading.Event] = {}
+        self.calls: list[int] = []
+        self._lock = threading.Lock()
+        self._in_flight = 0
+        self.max_in_flight = 0
+
+    def rollout(self, spec: IterationSpec) -> RolloutStageResult:
+        with self._lock:
+            self.calls.append(spec.iteration)
+            self._in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self._in_flight)
+            started = self.started.setdefault(spec.iteration, threading.Event())
+            finished = self.finished.setdefault(spec.iteration, threading.Event())
+
+        started_at = time.perf_counter()
+        started.set()
+        try:
+            if self.fail_iteration == spec.iteration:
+                raise RuntimeError(f"rollout boom {spec.iteration}")
+            if self.delay:
+                time.sleep(self.delay)
+            return RolloutStageResult(
+                iteration=spec.iteration,
+                weight_version=int(spec.weight_version),
+                payload={"prompts": list(spec.prompts)},
+                started_at=started_at,
+                finished_at=time.perf_counter(),
+                metrics={"worker": "recording"},
+            )
+        finally:
+            finished.set()
+            with self._lock:
+                self._in_flight -= 1
+
+
+class RecordingTrainingWorker:
+    def __init__(
+        self,
+        *,
+        delay: float = 0.0,
+        block_iteration: int | None = None,
+        fail_iteration: int | None = None,
+    ):
+        self.delay = delay
+        self.block_iteration = block_iteration
+        self.fail_iteration = fail_iteration
+        self.allow_finish = threading.Event()
+        self.started: dict[int, threading.Event] = {}
+        self.finished: dict[int, threading.Event] = {}
+        self.calls: list[int] = []
+        self.consumed_versions: list[int] = []
+
+    def train(self, rollout: RolloutStageResult) -> TrainingStageResult:
+        self.calls.append(rollout.iteration)
+        self.consumed_versions.append(rollout.weight_version)
+        started = self.started.setdefault(rollout.iteration, threading.Event())
+        finished = self.finished.setdefault(rollout.iteration, threading.Event())
+        started_at = time.perf_counter()
+        started.set()
+        try:
+            if self.fail_iteration == rollout.iteration:
+                raise RuntimeError(f"training boom {rollout.iteration}")
+            if self.block_iteration == rollout.iteration:
+                assert self.allow_finish.wait(timeout=5.0)
+            if self.delay:
+                time.sleep(self.delay)
+            return TrainingStageResult(
+                iteration=rollout.iteration,
+                consumed_weight_version=rollout.weight_version,
+                published_weight_version=rollout.weight_version + 1,
+                metrics={"worker": "recording"},
+                started_at=started_at,
+                finished_at=time.perf_counter(),
+            )
+        finally:
+            finished.set()
+
+
+def _specs(count: int) -> list[IterationSpec]:
+    return [
+        IterationSpec(iteration=index, weight_version=index, prompts=[f"prompt-{index}"])
+        for index in range(count)
+    ]
+
+
+def _unversioned_specs(count: int) -> list[IterationSpec]:
+    return [IterationSpec(iteration=index, prompts=[f"prompt-{index}"]) for index in range(count)]
+
+
+def test_pipeline_overlaps_next_rollout_with_current_training():
+    rollout = RecordingRolloutWorker(delay=0.01)
+    training = RecordingTrainingWorker(block_iteration=0)
+    pipeline = OverlapPipeline(
+        rollout,
+        training,
+        PipelineConfig(max_prefetch=1, rollout_workers=1, training_workers=1),
+    )
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(pipeline.run, _specs(3))
+
+        assert training.started.setdefault(0, threading.Event()).wait(timeout=5.0)
+        assert rollout.started.setdefault(1, threading.Event()).wait(timeout=5.0)
+        assert not training.finished.setdefault(0, threading.Event()).is_set()
+
+        training.allow_finish.set()
+        results = future.result(timeout=5.0)
+
+    assert [result.iteration for result in results] == [0, 1, 2]
+    assert [result.consumed_weight_version for result in results] == [0, 0, 1]
+    assert [result.published_weight_version for result in results] == [1, 1, 2]
+
+    summary = pipeline.timeline_summary()
+    assert summary.overlap_seconds > 0.0
+    assert summary.overlap_ratio > 0.0
+
+
+def test_pipeline_backpressure_limits_rollout_prefetch():
+    rollout = RecordingRolloutWorker(delay=0.02)
+    training = RecordingTrainingWorker(delay=0.02)
+    pipeline = OverlapPipeline(
+        rollout,
+        training,
+        PipelineConfig(max_prefetch=1, rollout_workers=4, training_workers=1),
+    )
+
+    pipeline.run(_specs(4))
+
+    assert rollout.max_in_flight == 1
+    assert pipeline.max_queue_depth <= 1
+    assert training.calls == [0, 1, 2, 3]
+
+
+def test_pipeline_defaults_to_current_published_weight_version():
+    rollout = RecordingRolloutWorker(delay=0.01)
+    training = RecordingTrainingWorker(delay=0.01)
+    pipeline = OverlapPipeline(
+        rollout,
+        training,
+        PipelineConfig(max_prefetch=1, initial_weight_version=5),
+    )
+
+    results = pipeline.run(_unversioned_specs(3))
+
+    assert [result.consumed_weight_version for result in results] == [5, 5, 6]
+    assert [result.published_weight_version for result in results] == [6, 6, 7]
+    assert pipeline.timeline_summary().final_published_weight_version == 7
+
+
+def test_torch_training_worker_publishes_monotonic_versions_under_stale_rollout():
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=1,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=3,
+        )
+    )
+    rollout_a = RolloutStageResult(
+        iteration=0,
+        weight_version=5,
+        payload={"normalized_outputs": [[{"token_ids": [1, 2]}]]},
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+    rollout_b = RolloutStageResult(
+        iteration=1,
+        weight_version=5,
+        payload={"normalized_outputs": [[{"token_ids": [3, 4]}]]},
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    first = worker.train(rollout_a)
+    second = worker.train(rollout_b)
+
+    assert first.published_weight_version == 6
+    assert second.published_weight_version == 7
+
+
+class ManifestAwareRolloutWorker(RecordingRolloutWorker):
+    def __init__(self, *, delay: float = 0.0):
+        super().__init__(delay=delay)
+        self.installed_versions: list[int] = []
+        self.installed_transports: list[str] = []
+        self.released_update_ids: list[str] = []
+
+    def install_weight_manifest(self, manifest):
+        self.installed_versions.append(manifest.weight_version)
+        self.installed_transports.append(manifest.transport)
+
+    def release_weight_manifest(self, update_id):
+        self.released_update_ids.append(update_id)
+
+
+class ManifestPublishingTrainingWorker(RecordingTrainingWorker):
+    def __init__(self, *, delay: float = 0.0):
+        super().__init__(delay=delay)
+        self.published_versions: list[int] = []
+        self.released_update_ids: list[str] = []
+        self._latest_published_weight_version = -1
+        self._bridges = {}
+
+    def publish_weights(self, *, weight_version, metadata=None):
+        import torch
+
+        from rl_engine.executors.bridge import LocalTensorCopyBridge
+
+        version = max(self._latest_published_weight_version + 1, int(weight_version))
+        self._latest_published_weight_version = version
+        self.published_versions.append(version)
+        model = torch.nn.Linear(2, 2)
+        bridge = LocalTensorCopyBridge(source_worker="test-training")
+        manifest = bridge.publish(model, weight_version=version, metadata=metadata)
+        self._bridges[manifest.update_id] = bridge
+        return manifest
+
+    def release_weights(self, update_id):
+        self.released_update_ids.append(update_id)
+        self._bridges.pop(update_id).release(update_id)
+
+
+def test_pipeline_manifest_weight_handoff_installs_complete_published_updates():
+    rollout = ManifestAwareRolloutWorker(delay=0.01)
+    training = ManifestPublishingTrainingWorker(delay=0.01)
+    pipeline = OverlapPipeline(
+        rollout,
+        training,
+        PipelineConfig(max_prefetch=1, initial_weight_version=0),
+        weight_handoff=ManifestWeightHandoff(),
+    )
+
+    results = pipeline.run(_unversioned_specs(3))
+    summary = pipeline.timeline_summary()
+
+    assert [result.consumed_weight_version for result in results] == [0, 0, 1]
+    assert [result.published_weight_version for result in results] == [1, 1, 2]
+    assert training.published_versions == [1, 2, 3]
+    assert rollout.installed_versions == [1, 2, 3]
+    assert rollout.installed_transports == ["local-clone", "local-clone", "local-clone"]
+    assert len(summary.weight_handoffs) == 3
+    assert summary.weight_handoffs[-1]["weight_version"] == 3
+    assert len(rollout.released_update_ids) == 3
+    assert len(training.released_update_ids) == 3
+
+
+def test_pipeline_surfaces_rollout_failure():
+    rollout = RecordingRolloutWorker(fail_iteration=0)
+    training = RecordingTrainingWorker()
+    pipeline = OverlapPipeline(rollout, training)
+
+    with pytest.raises(PipelineExecutionError) as exc_info:
+        pipeline.run(_specs(2))
+
+    assert exc_info.value.stage == "rollout"
+    assert exc_info.value.iteration == 0
+    assert training.calls == []
+
+
+def test_pipeline_surfaces_training_failure_without_publishing_next_result():
+    rollout = RecordingRolloutWorker()
+    training = RecordingTrainingWorker(fail_iteration=0)
+    pipeline = OverlapPipeline(rollout, training)
+
+    with pytest.raises(PipelineExecutionError) as exc_info:
+        pipeline.run(_specs(2))
+
+    assert exc_info.value.stage == "training"
+    assert exc_info.value.iteration == 0
+    assert pipeline.training_results == []
+
+
+class FakeRolloutExecutor:
+    def __init__(self):
+        self.calls = []
+
+    def generate_candidates(self, prompts, *, num_generations=None, sampling_params=None):
+        self.calls.append((prompts, num_generations, sampling_params))
+        return {
+            "backend": "fake-vllm",
+            "num_prompts": len(prompts),
+            "num_generations": num_generations,
+        }
+
+
+def test_rollout_executor_worker_uses_generate_candidates():
+    executor = FakeRolloutExecutor()
+    worker = RolloutExecutorWorker(
+        executor,
+        num_generations=2,
+        sampling_params={"max_tokens": 8},
+    )
+    result = worker.rollout(IterationSpec(iteration=3, weight_version=7, prompts=["a", "b"]))
+
+    assert executor.calls == [(["a", "b"], 2, {"max_tokens": 8})]
+    assert result.iteration == 3
+    assert result.weight_version == 7
+    assert result.payload["backend"] == "fake-vllm"
+    assert result.metrics["num_prompts"] == 2
+
+
+def test_torch_rl_training_worker_runs_real_optimizer_step():
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=2,
+            completion_len=3,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=5,
+        )
+    )
+    rollout = RolloutStageResult(
+        iteration=2,
+        weight_version=9,
+        payload={
+            "normalized_outputs": [
+                [
+                    {
+                        "token_ids": [3, 4, 5],
+                        "text": "abc",
+                    }
+                ],
+                [
+                    {
+                        "token_ids": [6, 7, 8],
+                        "text": "def",
+                    }
+                ],
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    result = worker.train(rollout)
+
+    assert result.iteration == 2
+    assert result.consumed_weight_version == 9
+    assert result.published_weight_version == 10
+    assert result.metrics["training_backend"] == "torch"
+    assert result.metrics["training_data_source"] == "rollout_payload"
+    assert result.metrics["rollout_sequences"] == 2
+    assert result.metrics["rollout_tokens"] == 6
+    assert math.isfinite(result.metrics["loss"])
+    assert result.metrics["active_tokens"] == 6
+
+
+def test_extract_rollout_token_groups_from_normalized_payload():
+    payload = {
+        "normalized_outputs": [
+            [{"token_ids": [1, 2]}, {"token_ids": [3]}],
+            [{"outputs": [{"token_ids": [4, 5, 6]}]}],
+        ]
+    }
+
+    assert extract_rollout_token_groups(payload) == [[1, 2], [3], [4, 5, 6]]


### PR DESCRIPTION
## Summary
- Add a bounded local overlap scheduler that runs rollout for the next iteration while training consumes the previous complete rollout batch.
- Add production-facing rollout/training adapters: `RolloutExecutor.generate_candidates(...)` for vLLM rollout and a real PyTorch RL-style optimizer step for DeepSpeed-style local training.
- Connect issue 18 to issue 13's `WeightUpdateManifest` lifecycle through manifest publish/install/release handoff, including timeline metadata and shutdown cleanup.
- Add smoke benchmark modes for synthetic timing, manifest handoff, and realistic WSL2/vLLM rollout plus local training.

## Validation
- `pre-commit run --all-files`
- `py -3.13 -m mypy --ignore-missing-imports rl_engine`
- `py -3.13 -m pytest tests -q`
- `py -3.13 -m pytest rl_engine\tests\test_dispatch.py -v`
- `py -3.13 -m compileall rl_engine tests benchmarks`
- `py -3.13 -m mkdocs build --strict -f mkdocs.yaml`

## Runtime Smoke Results
- `py -3.13 benchmarks\benchmark_overlap_pipeline.py --smoke --mode synthetic --output $env:TEMP\issue18-synthetic.csv --timeline-output $env:TEMP\issue18-synthetic.json`: pass; bounded stale versions `0->1;0->1;1->2`.
- `py -3.13 benchmarks\benchmark_overlap_pipeline.py --smoke --mode manifest-handoff --output $env:TEMP\issue18-manifest.csv --timeline-output $env:TEMP\issue18-manifest.json`: pass; installed versions `[1, 2, 3]`; transport `local-clone`; installed manifests released.
- WSL2/vLLM realistic smoke with local tiny GPT-2 and CPU training: pass through `RolloutExecutor.generate_candidates(...)` plus `TorchRLTrainingWorker`; rollout payload tokens are consumed for training; weight versions `0->1;0->2;1->3`.

## Notes
- This is stacked on issue 13: `issue-13-zero-copy-weight-bridge-rebased`.
- No `task-workspace` issue docs, benchmark CSV artifacts, or timeline JSON artifacts are included.
- Local CI-equivalent commands were run with Python 3.13 because Python 3.10 is not installed locally; GitHub CI will run Python 3.10.