### PR TITLE
[docs]: fix root README logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./docs/assets/rl-engine-log-display.png" width="220" alt="RL-Kernel Logo">
+  <img src="docs/assets/logo.png" width="220" alt="RL-Kernel Logo">
 </p>
 
 <h1 align="center">RL-Kernel</h1>

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,9 +6,9 @@ hide:
 
 # Welcome to RL-Kernel
 
-<figure markdown="span">
-  ![](./assets/logo.png){ align="center" alt="RL-Kernel" width="38%" }
-</figure>
+<p align="center">
+  <img src="assets/logo.png" alt="RL-Kernel Logo" width="200">
+</p>
 
 <p style="text-align:center">
 <strong>High-performance kernels and runtime infrastructure for RL post-training.</strong>

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -6,8 +6,8 @@ exclude_docs: |
 
 theme:
   name: material
-  logo: assets/rl-engine-log.png
-  favicon: assets/rl-engine-log.png
+  logo: assets/logo.png
+  favicon: assets/logo.png
   palette:
     - media: "(prefers-color-scheme)"
       toggle:


### PR DESCRIPTION
Fixes the broken official logo image path in the root README as a follow-up to #59.