### PR TITLE
feat(benchmarking): add automated performance profiling suite

### DIFF
--- a/benchmarks/profiler.py
+++ b/benchmarks/profiler.py
@@ -1,0 +1,806 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from rl_engine.platforms.device import device_ctx  # noqa: E402
+from rl_engine.testing import selected_logprobs_reference  # noqa: E402
+from rl_engine.utils.logger import logger  # noqa: E402
+
+
+@dataclass(frozen=True)
+class GPUTargetInfo:
+    """Hardware target identification for cross-GPU benchmarking."""
+
+    name: str
+    architecture: str
+    total_memory_gb: float
+    driver_version: str
+    backend: str
+    compute_capability: str | None = None
+    device_index: int = 0
+
+
+@dataclass
+class BenchmarkMetrics:
+    """End-to-end performance metrics for a single benchmark run."""
+
+    # Identification
+    timestamp: str
+    benchmark_name: str
+    gpu_target: GPUTargetInfo
+
+    # Workload shape
+    batch_size: int
+    seq_len: int
+    vocab_size: int
+    total_tokens: int
+
+    # Timing
+    latency_ms: float
+    latency_std_ms: float | None = None
+    warmup_iterations: int = 0
+    repeat_iterations: int = 1
+
+    # Throughput & Compute
+    tokens_per_sec: float = 0.0
+    tflops: float = 0.0
+
+    # Memory
+    peak_vram_gb: float = 0.0
+    peak_vram_reduction_gb: float | None = None
+
+    # Status & Metadata
+    status: str = "pass"
+    notes: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        base = asdict(self)
+        base["gpu_target"] = asdict(self.gpu_target)
+        return base
+
+
+class GPUProfiler:
+    """Automatically detect and profile GPU hardware targets."""
+
+    @staticmethod
+    def get_target_info(device_index: int = 0) -> GPUTargetInfo:
+        if not torch.cuda.is_available():
+            return GPUTargetInfo(
+                name="CPU",
+                architecture="unknown",
+                total_memory_gb=0.0,
+                driver_version="N/A",
+                backend="cpu",
+                compute_capability=None,
+                device_index=-1,
+            )
+
+        if device_index is None or device_index < 0:
+            device_index = torch.cuda.current_device()
+        device = torch.device(f"cuda:{device_index}")
+        name = torch.cuda.get_device_name(device)
+        total_mem = torch.cuda.get_device_properties(device).total_memory / (1024**3)
+
+        if hasattr(torch.version, "hip") and torch.version.hip is not None:
+            backend = "rocm"
+            driver = torch.version.hip or "unknown"
+            # ROCm architecture detection from device name
+            arch = GPUProfiler._infer_amd_arch(name)
+            cc = None
+        else:
+            backend = "cuda"
+            driver = torch.version.cuda or "unknown"
+            major, minor = torch.cuda.get_device_capability(device)
+            arch = GPUProfiler._infer_nvidia_arch(name, major, minor)
+            cc = f"{major}.{minor}"
+
+        return GPUTargetInfo(
+            name=name,
+            architecture=arch,
+            total_memory_gb=round(total_mem, 2),
+            driver_version=driver,
+            backend=backend,
+            compute_capability=cc,
+            device_index=device_index,
+        )
+
+    @staticmethod
+    def _infer_nvidia_arch(name: str, major: int, minor: int) -> str:
+        mapping = {
+            (7, 0): "Volta",
+            (7, 5): "Turing",
+            (8, 0): "Ampere",
+            (8, 6): "Ampere",
+            (8, 7): "Ampere",
+            (8, 9): "Ada Lovelace",
+            (9, 0): "Hopper",
+            (10, 0): "Blackwell",
+        }
+        return mapping.get((major, minor), f"SM{major}{minor}")
+
+    @staticmethod
+    def _infer_amd_arch(name: str) -> str:
+        name_lower = name.lower()
+        if "mi300" in name_lower:
+            return "CDNA3"
+        if "mi250" in name_lower:
+            return "CDNA2"
+        if "mi100" in name_lower:
+            return "CDNA1"
+        if "rx 7900" in name_lower or "gfx1100" in name_lower:
+            return "RDNA3"
+        if "gfx90a" in name_lower:
+            return "CDNA2"
+        return "AMD-GCN/RDNA"
+
+
+class PerformanceProfiler:
+    """
+    Automated end-to-end performance profiling suite.
+
+    Measures Tokens/sec, TFLOPS, and peak VRAM across different GPU targets
+    for RL-Kernel operators and sampling pipelines.
+    """
+
+    def __init__(self, device: torch.device | None = None, warmup: int = 3, repeat: int = 10):
+        self.device = device if device is not None else device_ctx.device
+        self.warmup = warmup
+        self.repeat = repeat
+        self.gpu_info = GPUProfiler.get_target_info(
+            device_index=self.device.index if self.device.type == "cuda" else -1
+        )
+        self._metrics: list[BenchmarkMetrics] = []
+
+    def _sync(self) -> None:
+        if self.device.type == "cuda":
+            torch.cuda.synchronize(self.device)
+
+    def _reset_memory(self) -> None:
+        if self.device.type == "cuda":
+            torch.cuda.empty_cache()
+            torch.cuda.reset_peak_memory_stats(self.device)
+
+    def _peak_memory_gb(self) -> float:
+        if self.device.type != "cuda":
+            return 0.0
+        return torch.cuda.max_memory_allocated(self.device) / (1024**3)
+
+    def _time_kernel(self, fn) -> tuple[Any, float, float | None]:
+        """Run fn with warmup + repeat, return (last_result, median_ms, std_ms)."""
+        result = None
+        for _ in range(max(0, self.warmup)):
+            result = fn()
+        self._sync()
+
+        elapsed: list[float] = []
+        self._reset_memory()
+        for _ in range(max(1, self.repeat)):
+            if self.device.type == "cuda":
+                start = torch.cuda.Event(enable_timing=True)
+                end = torch.cuda.Event(enable_timing=True)
+                start.record()
+                result = fn()
+                end.record()
+                end.synchronize()
+                elapsed.append(start.elapsed_time(end))
+            else:
+                t0 = time.perf_counter()
+                result = fn()
+                self._sync()
+                elapsed.append((time.perf_counter() - t0) * 1000.0)
+
+        self._sync()
+        median_ms = statistics.median(elapsed)
+        std_ms = statistics.stdev(elapsed) if len(elapsed) > 1 else None
+        return result, median_ms, std_ms
+
+    def _measure_peak_memory_once(self, fn) -> float:
+        """Measure peak allocation for one invocation after the configured warmup."""
+        for _ in range(max(0, self.warmup)):
+            _ = fn()
+        self._sync()
+        self._reset_memory()
+        _ = fn()
+        self._sync()
+        return self._peak_memory_gb()
+
+    @staticmethod
+    def estimate_logp_tflops(batch_size: int, seq_len: int, vocab_size: int) -> float:
+        """
+        Estimate floating-point operations for a single logp forward pass.
+
+        log_softmax ~= 5 * B * S * V  FLOPs
+        (subtract max, exp, sum, divide, log)
+        gather is negligible.
+        """
+        return (5.0 * batch_size * seq_len * vocab_size) / 1e12
+
+    @staticmethod
+    def estimate_sampling_tflops(batch_size: int, vocab_size: int) -> float:
+        """
+        Estimate FLOPs for a single sampling step.
+
+        softmax ~= 5 * B * V FLOPs
+        top-k and multinomial are comparatively negligible.
+        """
+        return (5.0 * batch_size * vocab_size) / 1e12
+
+    def profile_logp(
+        self,
+        candidate_fn,
+        batch_size: int,
+        seq_len: int,
+        vocab_size: int,
+        benchmark_name: str = "logp_forward",
+        native_fn=None,
+    ) -> BenchmarkMetrics:
+        """
+        Profile a log-probability operator and compute end-to-end metrics.
+
+        Args:
+            candidate_fn: Callable that performs the fused/candidate logp computation.
+            native_fn: Optional baseline callable for VRAM reduction comparison.
+        """
+        logger.info(f"Profiling '{benchmark_name}' | shape=({batch_size},{seq_len},{vocab_size})")
+
+        total_tokens = batch_size * seq_len
+        tflops_per_call = self.estimate_logp_tflops(batch_size, seq_len, vocab_size)
+
+        try:
+            _, latency_ms, latency_std = self._time_kernel(candidate_fn)
+            peak_vram = (
+                self._measure_peak_memory_once(candidate_fn)
+                if native_fn is not None and self.device.type == "cuda"
+                else self._peak_memory_gb()
+            )
+        except torch.cuda.OutOfMemoryError as exc:
+            metrics = BenchmarkMetrics(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                benchmark_name=benchmark_name,
+                gpu_target=self.gpu_info,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                vocab_size=vocab_size,
+                total_tokens=total_tokens,
+                latency_ms=float("inf"),
+                latency_std_ms=None,
+                status="oom",
+                notes=str(exc),
+            )
+            self._metrics.append(metrics)
+            return metrics
+
+        latency_s = latency_ms / 1000.0
+        tokens_per_sec = total_tokens / latency_s if latency_s > 0 else 0.0
+        tflops = tflops_per_call / latency_s if latency_s > 0 else 0.0
+
+        vram_reduction = None
+        if native_fn is not None and self.device.type == "cuda":
+            try:
+                native_peak = self._measure_peak_memory_once(native_fn)
+                vram_reduction = max(0.0, native_peak - peak_vram)
+            except Exception as exc:
+                logger.warning(f"Native baseline failed for VRAM comparison: {exc}")
+
+        metrics = BenchmarkMetrics(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            benchmark_name=benchmark_name,
+            gpu_target=self.gpu_info,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            vocab_size=vocab_size,
+            total_tokens=total_tokens,
+            latency_ms=latency_ms,
+            latency_std_ms=latency_std,
+            warmup_iterations=self.warmup,
+            repeat_iterations=self.repeat,
+            tokens_per_sec=tokens_per_sec,
+            tflops=tflops,
+            peak_vram_gb=peak_vram,
+            peak_vram_reduction_gb=vram_reduction,
+            status="pass",
+        )
+        self._metrics.append(metrics)
+        return metrics
+
+    def profile_sampling(
+        self,
+        candidate_fn,
+        batch_size: int,
+        vocab_size: int,
+        seq_len: int = 1,
+        benchmark_name: str = "sampling_step",
+    ) -> BenchmarkMetrics:
+        """
+        Profile a sampling operator and compute end-to-end metrics.
+        """
+        logger.info(f"Profiling '{benchmark_name}' | shape=({batch_size},{vocab_size})")
+
+        total_tokens = batch_size * seq_len
+        tflops_per_call = self.estimate_sampling_tflops(batch_size, vocab_size)
+
+        try:
+            _, latency_ms, latency_std = self._time_kernel(candidate_fn)
+            peak_vram = self._peak_memory_gb()
+        except torch.cuda.OutOfMemoryError as exc:
+            metrics = BenchmarkMetrics(
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                benchmark_name=benchmark_name,
+                gpu_target=self.gpu_info,
+                batch_size=batch_size,
+                seq_len=seq_len,
+                vocab_size=vocab_size,
+                total_tokens=total_tokens,
+                latency_ms=float("inf"),
+                latency_std_ms=None,
+                status="oom",
+                notes=str(exc),
+            )
+            self._metrics.append(metrics)
+            return metrics
+
+        latency_s = latency_ms / 1000.0
+        tokens_per_sec = total_tokens / latency_s if latency_s > 0 else 0.0
+        tflops = tflops_per_call / latency_s if latency_s > 0 else 0.0
+
+        metrics = BenchmarkMetrics(
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            benchmark_name=benchmark_name,
+            gpu_target=self.gpu_info,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            vocab_size=vocab_size,
+            total_tokens=total_tokens,
+            latency_ms=latency_ms,
+            latency_std_ms=latency_std,
+            warmup_iterations=self.warmup,
+            repeat_iterations=self.repeat,
+            tokens_per_sec=tokens_per_sec,
+            tflops=tflops,
+            peak_vram_gb=peak_vram,
+            status="pass",
+        )
+        self._metrics.append(metrics)
+        return metrics
+
+    def get_metrics(self) -> list[BenchmarkMetrics]:
+        return list(self._metrics)
+
+    def clear_metrics(self) -> None:
+        self._metrics.clear()
+
+    def save_json(self, path: Path | str) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "report_version": "1.0",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "gpu_target": asdict(self.gpu_info),
+            "metrics": [m.to_dict() for m in self._metrics],
+        }
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        logger.info(f"Performance report saved to {path}")
+
+    def save_csv(self, path: Path | str) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not self._metrics:
+            logger.warning("No metrics to write to CSV.")
+            return
+
+        fieldnames = list(self._metrics[0].to_dict().keys())
+        # Flatten gpu_target nested dict into prefixed keys for CSV
+        flat_rows: list[dict[str, Any]] = []
+        for m in self._metrics:
+            row = m.to_dict()
+            gpu = row.pop("gpu_target")
+            for k, v in gpu.items():
+                row[f"gpu_{k}"] = v
+            # Flatten extra dict
+            extra = row.pop("extra", {})
+            for k, v in extra.items():
+                row[f"extra_{k}"] = v
+            flat_rows.append(row)
+
+        # Recompute fieldnames from flattened rows to ensure completeness
+        all_keys = set()
+        for r in flat_rows:
+            all_keys.update(r.keys())
+        fieldnames = sorted(all_keys)
+
+        exists = path.exists() and path.stat().st_size > 0
+        with path.open("a", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            if not exists:
+                writer.writeheader()
+            writer.writerows(flat_rows)
+        logger.info(f"CSV metrics appended to {path}")
+
+    def print_summary(self) -> None:
+        from tabulate import tabulate
+
+        if not self._metrics:
+            print("No metrics collected.")
+            return
+
+        rows = []
+        for m in self._metrics:
+            rows.append(
+                [
+                    m.benchmark_name,
+                    m.batch_size,
+                    m.seq_len,
+                    m.vocab_size,
+                    f"{m.latency_ms:.2f}",
+                    f"{m.tokens_per_sec:,.0f}",
+                    f"{m.tflops:.2f}",
+                    f"{m.peak_vram_gb:.2f}",
+                    m.status,
+                ]
+            )
+
+        headers = [
+            "Benchmark",
+            "Batch",
+            "SeqLen",
+            "Vocab",
+            "Latency(ms)",
+            "Tokens/sec",
+            "TFLOPS",
+            "Peak VRAM(GB)",
+            "Status",
+        ]
+        print("\n" + "=" * 120)
+        print(f"{'RL-KERNEL AUTOMATED PERFORMANCE PROFILING SUITE':^120}")
+        print(
+            f"GPU: {self.gpu_info.name} | Arch: {self.gpu_info.architecture} "
+            f"| Backend: {self.gpu_info.backend}"
+        )
+        print("=" * 120)
+        print(tabulate(rows, headers=headers, tablefmt="fancy_grid"))
+        print("=" * 120 + "\n")
+
+
+def _parse_int_list(value: str) -> list[int]:
+    return [int(item) for item in value.split(",") if item]
+
+
+def _parse_dtype(value: str) -> torch.dtype:
+    normalized = value.lower()
+    if normalized in {"fp16", "float16", "half"}:
+        return torch.float16
+    if normalized in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if normalized in {"fp32", "float32"}:
+        return torch.float32
+    raise ValueError(f"unsupported dtype: {value}")
+
+
+def _native_logp_fn(
+    *,
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    seed: int,
+):
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+    logits = torch.randn(
+        batch_size,
+        seq_len,
+        vocab_size,
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+    token_ids = torch.randint(
+        0,
+        vocab_size,
+        (batch_size, seq_len),
+        device=device,
+        generator=generator,
+    )
+    return lambda: selected_logprobs_reference(logits, token_ids)
+
+
+def _fused_logp_fn(
+    *,
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    seed: int,
+):
+    from rl_engine.kernels.registry import kernel_registry
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+    logits = torch.randn(
+        batch_size,
+        seq_len,
+        vocab_size,
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+    token_ids = torch.randint(
+        0,
+        vocab_size,
+        (batch_size, seq_len),
+        device=device,
+        generator=generator,
+    )
+    op = kernel_registry.get_op("logp")
+    return lambda: op.apply_fp32(logits, token_ids)
+
+
+def _sampling_fn(
+    *,
+    batch_size: int,
+    vocab_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    seed: int,
+    top_k: int,
+    top_p: float,
+):
+    from benchmarks.benchmark_sampling import native_sampling
+
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed)
+    logits = torch.randn(batch_size, vocab_size, device=device, dtype=dtype, generator=generator)
+    return lambda: native_sampling(logits.clone(), top_k=top_k, top_p=top_p)
+
+
+def _blocked_metric(
+    *,
+    profiler: PerformanceProfiler,
+    benchmark_name: str,
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+    exc: Exception,
+) -> BenchmarkMetrics:
+    metric = BenchmarkMetrics(
+        timestamp=datetime.now(timezone.utc).isoformat(),
+        benchmark_name=benchmark_name,
+        gpu_target=profiler.gpu_info,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        vocab_size=vocab_size,
+        total_tokens=batch_size * seq_len,
+        latency_ms=float("inf"),
+        warmup_iterations=profiler.warmup,
+        repeat_iterations=profiler.repeat,
+        status="blocked",
+        notes=str(exc).splitlines()[0],
+    )
+    profiler._metrics.append(metric)
+    return metric
+
+
+WorkloadRunner = Callable[
+    [PerformanceProfiler, argparse.Namespace, torch.device, torch.dtype, int, int, int],
+    BenchmarkMetrics,
+]
+
+
+def _run_logp_native_workload(
+    profiler: PerformanceProfiler,
+    args: argparse.Namespace,
+    device: torch.device,
+    dtype: torch.dtype,
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+) -> BenchmarkMetrics:
+    fn = _native_logp_fn(
+        batch_size=batch_size,
+        seq_len=seq_len,
+        vocab_size=vocab_size,
+        dtype=dtype,
+        device=device,
+        seed=args.seed,
+    )
+    return profiler.profile_logp(
+        fn,
+        batch_size=batch_size,
+        seq_len=seq_len,
+        vocab_size=vocab_size,
+        benchmark_name="logp_native",
+    )
+
+
+def _run_logp_fused_workload(
+    profiler: PerformanceProfiler,
+    args: argparse.Namespace,
+    device: torch.device,
+    dtype: torch.dtype,
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+) -> BenchmarkMetrics:
+    try:
+        if device.type != "cuda":
+            raise RuntimeError("logp-fused requires CUDA")
+        fused = _fused_logp_fn(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            vocab_size=vocab_size,
+            dtype=dtype,
+            device=device,
+            seed=args.seed + 1,
+        )
+        native = _native_logp_fn(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            vocab_size=vocab_size,
+            dtype=dtype,
+            device=device,
+            seed=args.seed + 1,
+        )
+        return profiler.profile_logp(
+            fused,
+            native_fn=native,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            vocab_size=vocab_size,
+            benchmark_name="logp_fused",
+        )
+    except Exception as exc:
+        return _blocked_metric(
+            profiler=profiler,
+            benchmark_name="logp_fused",
+            batch_size=batch_size,
+            seq_len=seq_len,
+            vocab_size=vocab_size,
+            exc=exc,
+        )
+
+
+def _run_sampling_native_workload(
+    profiler: PerformanceProfiler,
+    args: argparse.Namespace,
+    device: torch.device,
+    dtype: torch.dtype,
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+) -> BenchmarkMetrics:
+    try:
+        fn = _sampling_fn(
+            batch_size=batch_size,
+            vocab_size=vocab_size,
+            dtype=torch.float32 if device.type == "cpu" else dtype,
+            device=device,
+            seed=args.seed + 2,
+            top_k=args.top_k,
+            top_p=args.top_p,
+        )
+        return profiler.profile_sampling(
+            fn,
+            batch_size=batch_size,
+            seq_len=seq_len,
+            vocab_size=vocab_size,
+            benchmark_name="sampling_native",
+        )
+    except Exception as exc:
+        return _blocked_metric(
+            profiler=profiler,
+            benchmark_name="sampling_native",
+            batch_size=batch_size,
+            seq_len=seq_len,
+            vocab_size=vocab_size,
+            exc=exc,
+        )
+
+
+WORKLOAD_REGISTRY: dict[str, WorkloadRunner] = {
+    "logp-native": _run_logp_native_workload,
+    "logp-fused": _run_logp_fused_workload,
+    "sampling-native": _run_sampling_native_workload,
+}
+
+
+def available_workloads() -> tuple[str, ...]:
+    return tuple(WORKLOAD_REGISTRY)
+
+
+def _parse_workloads(value: str) -> list[str]:
+    workloads = [item.strip() for item in value.split(",") if item.strip()]
+    unknown = sorted(set(workloads) - set(WORKLOAD_REGISTRY))
+    if unknown:
+        supported = ", ".join(available_workloads())
+        raise ValueError(f"unsupported workloads: {', '.join(unknown)}; supported: {supported}")
+    return workloads
+
+
+def run_automated_suite(args: argparse.Namespace) -> PerformanceProfiler:
+    device = torch.device(args.device)
+    dtype = _parse_dtype(args.dtype)
+    profiler = PerformanceProfiler(device=device, warmup=args.warmup, repeat=args.repeat)
+
+    if args.smoke:
+        batch_sizes = [2]
+        seq_lens = [4]
+        vocab_sizes = [32]
+    else:
+        batch_sizes = _parse_int_list(args.batch_sizes)
+        seq_lens = _parse_int_list(args.seq_lens)
+        vocab_sizes = _parse_int_list(args.vocab_sizes)
+
+    workloads = _parse_workloads(args.workloads)
+    for batch_size in batch_sizes:
+        for seq_len in seq_lens:
+            for vocab_size in vocab_sizes:
+                for workload in workloads:
+                    runner = WORKLOAD_REGISTRY[workload]
+                    runner(profiler, args, device, dtype, batch_size, seq_len, vocab_size)
+    return profiler
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="RL-Kernel automated performance profiler")
+    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--dtype", default="float16")
+    parser.add_argument("--batch-sizes", default="8,16,32")
+    parser.add_argument("--seq-lens", default="128,512")
+    parser.add_argument("--vocab-sizes", default="4096,128256")
+    parser.add_argument(
+        "--workloads",
+        default=",".join(available_workloads()),
+        help=f"Comma-separated workloads: {', '.join(available_workloads())}",
+    )
+    parser.add_argument("--top-k", type=int, default=50)
+    parser.add_argument("--top-p", type=float, default=0.9)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--repeat", type=int, default=10)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--format", choices=["csv", "json"], default="csv")
+    parser.add_argument("--no-summary", action="store_true")
+    parser.add_argument("--smoke", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_arg_parser().parse_args()
+    if args.smoke:
+        args.dtype = "float32"
+        args.warmup = 0
+        args.repeat = 1
+    profiler = run_automated_suite(args)
+    if args.output is not None:
+        if args.format == "json":
+            profiler.save_json(args.output)
+        else:
+            profiler.save_csv(args.output)
+    if not args.no_summary:
+        profiler.print_summary()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/benchmarking/README.md
+++ b/docs/benchmarking/README.md
@@ -5,10 +5,61 @@ RL-Kernel benchmarks track operator latency, memory behavior, and dispatch overh
 Current benchmark entry points:
 
 ```bash
+python scripts/run_profile_suite.py --smoke
+python scripts/run_profile_suite.py --output reports/profile.csv
+python benchmarks/profiler.py --format json --output reports/profile.json
 python benchmarks/benchmark_sampling.py
 python benchmarks/benchmark_grpo_op.py
 python scripts/run_perf.py
 ```
 
+The automated profiler records one row per workload shape with:
+
+- `tokens_per_sec`: active tokens divided by median latency.
+- `tflops`: estimated operator FLOPs divided by median latency.
+- `peak_vram_gb`: CUDA peak allocated memory during the measured run.
+- `gpu_*`: detected device name, architecture, backend, driver, and memory.
+- `status`: `pass`, `blocked`, or `oom`.
+
+Useful presets:
+
+```bash
+# CPU-friendly validation for CI or local development.
+python scripts/run_profile_suite.py --smoke --workloads logp-native
+
+# CUDA logprob profiling with native and fused candidates.
+python scripts/run_profile_suite.py \
+  --device cuda \
+  --dtype float16 \
+  --batch-sizes 8,16,32 \
+  --seq-lens 128,512 \
+  --vocab-sizes 4096,128256 \
+  --workloads logp-native,logp-fused \
+  --output reports/logp_profile.csv
+
+# Sampling baseline profiling.
+python scripts/run_profile_suite.py \
+  --workloads sampling-native \
+  --batch-sizes 64,128,256 \
+  --vocab-sizes 128256 \
+  --top-k 50 \
+  --top-p 0.9
+```
+
 When adding a new operator, document the benchmark command on the operator page and keep
 the tested shapes close to the target RL workload.
+
+## Adding Workloads
+
+Profiler workloads are registered in `benchmarks/profiler.py` through
+`WORKLOAD_REGISTRY`. To add an operator benchmark:
+
+1. Add a small workload runner that builds deterministic inputs and calls the relevant
+   `PerformanceProfiler.profile_*` method.
+2. Register the runner under a stable CLI name in `WORKLOAD_REGISTRY`.
+3. Add a focused test in `tests/test_profiler.py` that verifies the workload can be
+   selected through `--workloads`.
+4. Document a representative command and shape preset for the operator.
+
+Workloads that require CUDA should report `status=blocked` with a clear note when the
+requested device cannot run them, so CPU smoke validation still produces useful reports.

--- a/scripts/run_profile_suite.py
+++ b/scripts/run_profile_suite.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""
+Automated Performance Profiling Suite — CLI Orchestrator.
+
+Wraps ``benchmarks.profiler.run_automated_suite()`` with contributor-friendly
+report management:
+
+    --output-dir          Directory for emitted reports
+    --json / --csv        Emit one or both formats (default: both)
+    --no-summary          Skip the terminal table
+
+Usage:
+    python scripts/run_profile_suite.py --smoke --workloads logp-native
+    python scripts/run_profile_suite.py --output-dir reports/ --csv
+    python scripts/run_profile_suite.py --device cuda --workloads logp-fused
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from benchmarks.profiler import build_arg_parser, run_automated_suite  # noqa: E402
+
+
+def build_script_parser():
+    """Extend the core profiler CLI with report-management flags."""
+    parser = build_arg_parser()
+    for action in list(parser._actions):
+        if action.dest == "format":
+            parser._remove_action(action)
+            break
+
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("reports"),
+        help="Directory to store timestamped JSON/CSV reports",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        default=True,
+        help="Emit a JSON report (default: True)",
+    )
+    parser.add_argument(
+        "--csv",
+        action="store_true",
+        default=True,
+        help="Emit a CSV report (default: True)",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_script_parser().parse_args()
+
+    if args.smoke:
+        args.dtype = "float32"
+        args.warmup = 0
+        args.repeat = 1
+
+    profiler = run_automated_suite(args)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    safe_gpu_name = profiler.gpu_info.name.replace(" ", "_").replace("/", "_")
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+
+    if args.json:
+        json_path = args.output_dir / f"perf_report_{safe_gpu_name}_{timestamp}.json"
+        profiler.save_json(json_path)
+
+    if args.csv:
+        csv_path = args.output_dir / f"perf_report_{safe_gpu_name}.csv"
+        profiler.save_csv(csv_path)
+
+    if args.output is not None:
+        if args.output.suffix.lower() == ".json":
+            profiler.save_json(args.output)
+        else:
+            profiler.save_csv(args.output)
+
+    if not args.no_summary:
+        profiler.print_summary()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+import torch
+
+from benchmarks.profiler import (
+    GPUProfiler,
+    PerformanceProfiler,
+    available_workloads,
+    build_arg_parser,
+    run_automated_suite,
+)
+
+
+def test_gpu_profiler_cpu_fallback(monkeypatch):
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+
+    info = GPUProfiler.get_target_info()
+
+    assert info.name == "CPU"
+    assert info.backend == "cpu"
+    assert info.device_index == -1
+
+
+def test_logp_tflops_estimate_scales_with_shape():
+    small = PerformanceProfiler.estimate_logp_tflops(2, 4, 8)
+    large = PerformanceProfiler.estimate_logp_tflops(4, 4, 8)
+
+    assert small == pytest.approx(2 * 4 * 8 * 5 / 1e12)
+    assert large == pytest.approx(small * 2)
+
+
+def test_time_kernel_resets_peak_memory_once(monkeypatch):
+    profiler = PerformanceProfiler(device=torch.device("cpu"), warmup=1, repeat=3)
+    reset_calls = 0
+    run_calls = 0
+
+    def reset_memory():
+        nonlocal reset_calls
+        reset_calls += 1
+
+    def workload():
+        nonlocal run_calls
+        run_calls += 1
+        return run_calls
+
+    monkeypatch.setattr(profiler, "_reset_memory", reset_memory)
+
+    result, latency_ms, latency_std = profiler._time_kernel(workload)
+
+    assert result == 4
+    assert latency_ms >= 0.0
+    assert latency_std is not None
+    assert reset_calls == 1
+
+
+def test_cpu_smoke_suite_collects_metrics():
+    args = argparse.Namespace(
+        device="cpu",
+        dtype="float32",
+        batch_sizes="2",
+        seq_lens="4",
+        vocab_sizes="32",
+        workloads="logp-native,logp-fused",
+        top_k=4,
+        top_p=0.9,
+        seed=0,
+        warmup=0,
+        repeat=1,
+        smoke=True,
+    )
+
+    profiler = run_automated_suite(args)
+    metrics = profiler.get_metrics()
+
+    assert len(metrics) == 2
+    assert metrics[0].benchmark_name == "logp_native"
+    assert metrics[0].status == "pass"
+    assert metrics[0].tokens_per_sec > 0
+    assert metrics[1].benchmark_name == "logp_fused"
+    assert metrics[1].status == "blocked"
+
+
+def test_profiler_report_writers(tmp_path):
+    args = argparse.Namespace(
+        device="cpu",
+        dtype="float32",
+        batch_sizes="2",
+        seq_lens="4",
+        vocab_sizes="32",
+        workloads="logp-native",
+        top_k=4,
+        top_p=0.9,
+        seed=0,
+        warmup=0,
+        repeat=1,
+        smoke=True,
+    )
+    profiler = run_automated_suite(args)
+
+    csv_path = tmp_path / "profile.csv"
+    json_path = tmp_path / "profile.json"
+    profiler.save_csv(csv_path)
+    profiler.save_json(json_path)
+
+    assert "tokens_per_sec" in csv_path.read_text(encoding="utf-8")
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["report_version"] == "1.0"
+    assert payload["metrics"][0]["benchmark_name"] == "logp_native"
+
+
+def test_sampling_native_cpu_smoke():
+    args = argparse.Namespace(
+        device="cpu",
+        dtype="float32",
+        batch_sizes="2",
+        seq_lens="4",
+        vocab_sizes="32",
+        workloads="sampling-native",
+        top_k=4,
+        top_p=0.9,
+        seed=0,
+        warmup=0,
+        repeat=1,
+        smoke=True,
+    )
+
+    profiler = run_automated_suite(args)
+    metrics = profiler.get_metrics()
+
+    assert len(metrics) == 1
+    assert metrics[0].benchmark_name == "sampling_native"
+    assert metrics[0].status == "pass"
+    assert metrics[0].tokens_per_sec > 0
+
+
+def test_workload_registry_drives_cli_defaults():
+    assert available_workloads() == ("logp-native", "logp-fused", "sampling-native")
+
+    args = build_arg_parser().parse_args([])
+
+    assert args.workloads == ",".join(available_workloads())
+
+
+def test_unknown_workload_is_rejected():
+    args = argparse.Namespace(
+        device="cpu",
+        dtype="float32",
+        batch_sizes="2",
+        seq_lens="4",
+        vocab_sizes="32",
+        workloads="logp-native,missing-op",
+        top_k=4,
+        top_p=0.9,
+        seed=0,
+        warmup=0,
+        repeat=1,
+        smoke=True,
+    )
+
+    with pytest.raises(ValueError, match="unsupported workloads: missing-op"):
+        run_automated_suite(args)
+
+
+def test_measure_peak_memory_once(monkeypatch):
+    profiler = PerformanceProfiler(device=torch.device("cpu"), warmup=2, repeat=3)
+
+    sync_calls = 0
+    reset_calls = 0
+    peak_calls = 0
+    fn_calls = 0
+
+    def fake_sync():
+        nonlocal sync_calls
+        sync_calls += 1
+
+    def fake_reset():
+        nonlocal reset_calls
+        reset_calls += 1
+
+    def fake_peak():
+        nonlocal peak_calls
+        peak_calls += 1
+        return 1.23
+
+    def fake_fn():
+        nonlocal fn_calls
+        fn_calls += 1
+
+    monkeypatch.setattr(profiler, "_sync", fake_sync)
+    monkeypatch.setattr(profiler, "_reset_memory", fake_reset)
+    monkeypatch.setattr(profiler, "_peak_memory_gb", fake_peak)
+
+    result = profiler._measure_peak_memory_once(fake_fn)
+
+    assert result == 1.23
+    assert fn_calls == 3  # 2 warmup + 1 measured
+    assert sync_calls == 2  # after warmup + after measured
+    assert reset_calls == 1  # before measured run
+    assert peak_calls == 1


### PR DESCRIPTION
## Summary

Adds an automated profiling suite for RL-Kernel workloads to measure end-to-end performance across hardware targets, with CUDA validation and CPU fallback coverage. The suite reports Tokens/sec, TFLOPS, peak VRAM, workload status, and GPU metadata, with CLI entry points, report writers, documentation, tests, and a workload registry for future operator benchmarks.

## Changes

- Added `benchmarks/profiler.py`
  - GPU target detection with CUDA/ROCm metadata support and CPU fallback.
  - End-to-end profiling for logp and sampling workloads.
  - Metrics collection for latency, Tokens/sec, TFLOPS, peak VRAM, and status.
  - JSON/CSV report writers and terminal summary output.
  - Workload registry so future operator benchmarks can be added by registering a new workload runner.
- Added `scripts/run_profile_suite.py`
  - Contributor-friendly CLI wrapper.
  - Smoke mode support.
  - Timestamped report generation.
  - Explicit `--output` support for writing requested CSV/JSON paths.
- Added `tests/test_profiler.py`
  - CPU fallback tests.
  - TFLOPS estimation tests.
  - Smoke suite tests.
  - Report writer tests.
  - Peak memory measurement tests.
  - Workload registry and unknown workload validation tests.
- Updated `docs/benchmarking/README.md`
  - Profiler usage examples.
  - Guidance for adding new benchmark workloads.

## Issue

Closes #19

## Validation

- `python -m ruff check benchmarks/profiler.py scripts/run_profile_suite.py tests/test_profiler.py`
- `python -m py_compile benchmarks/profiler.py scripts/run_profile_suite.py tests/test_profiler.py`
- `python -m pytest -q tests/test_profiler.py`
  - `9 passed`
- `python scripts/run_profile_suite.py --smoke --workloads logp-native,logp-fused,sampling-native`
  - `logp_native`: pass
  - `logp_fused`: pass
  - `sampling_native`: pass

GPU profiling:

```bash
python scripts/run_profile_suite.py \
  --device cuda \
  --dtype float16 \
  --batch-sizes 2,4 \
  --seq-lens 16,64 \
  --vocab-sizes 1024,4096 \
  --workloads logp-native,logp-fused,sampling-native \
  --output reports/profile_gpu.csv
```

- `logp_native`: pass
- `logp_fused`: pass
- `sampling_native`: pass
- `tokens_per_sec > 0`
- `tflops > 0`
- `peak_vram_gb` populated
- GPU metadata populated:
  - `gpu_backend=cuda`
  - `gpu_name=NVIDIA A100-SXM4-40GB`
  - `gpu_total_memory_gb=39.49`
  - `gpu_architecture=Ampere`
  - `gpu_compute_capability=8.0`

Regression tests:

- `python -m pytest -q tests/test_rl_kernel_loss_step.py tests/test_op_accuracy.py tests/test_reference_ops.py`
  - `17 passed`
- `python benchmarks/benchmark_rl_kernels.py --smoke --device cuda --candidate apply`
  - pass
- `python benchmarks/benchmark_rl_kernels.py --smoke --device cuda --candidate fp32`
  - pass
- `python benchmarks/benchmark_rl_kernels.py --smoke --device cuda --candidate online_fp32`
  - pass

Existing checks:

- `python -m pytest rl_engine/tests/test_dispatch.py -v`
  - `3 passed`
- `mkdocs build --strict -f mkdocs.yaml`
  - pass
- `pre-commit run --all-files`
  - pass