### PR TITLE
feat: add production GRPO objective inputs and reductions

### DIFF
--- a/benchmarks/benchmark_grpo_objective.py
+++ b/benchmarks/benchmark_grpo_objective.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from rl_engine.alignment.grpo import GRPOConfig, compute_grpo_loss  # noqa: E402
+from rl_engine.testing import (  # noqa: E402
+    make_synthetic_rl_kernel_batch,
+    selected_logprobs_reference,
+    summarize_kernel_drift,
+)
+
+CSV_COLUMNS = [
+    "timestamp",
+    "candidate",
+    "mode",
+    "stage",
+    "num_prompts",
+    "samples_per_prompt",
+    "completion_len",
+    "vocab_size",
+    "device",
+    "dtype",
+    "advantage_max_abs_error",
+    "loss_max_abs_error",
+    "active_tokens",
+    "status",
+    "notes",
+]
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _environment() -> str:
+    parts = [f"torch={torch.__version__}", f"cuda_available={torch.cuda.is_available()}"]
+    if torch.cuda.is_available():
+        parts.append(f"cuda={torch.version.cuda}")
+        parts.append(f"gpu={torch.cuda.get_device_name(0)}")
+    return ";".join(parts)
+
+
+def _append_row(path: Path, row: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    exists = path.exists()
+    with path.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS)
+        if not exists:
+            writer.writeheader()
+        writer.writerow({column: row.get(column, "") for column in CSV_COLUMNS})
+
+
+def _write_json(path: Path | None, payload: dict[str, Any]) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _make_inputs(args: argparse.Namespace, *, device: torch.device, dtype: torch.dtype):
+    batch = make_synthetic_rl_kernel_batch(
+        num_prompts=args.num_prompts,
+        samples_per_prompt=args.samples_per_prompt,
+        prompt_len=args.prompt_len,
+        completion_len=args.completion_len,
+        vocab_size=args.vocab_size,
+        valid_density=args.valid_density,
+        dtype=dtype,
+        device=device,
+        seed=args.seed,
+    )
+    generator = torch.Generator(device=device)
+    generator.manual_seed(args.seed + 1009)
+    logits = torch.randn(
+        batch.batch_size,
+        batch.completion_len,
+        args.vocab_size,
+        device=device,
+        dtype=dtype,
+        generator=generator,
+    )
+    current_logps = selected_logprobs_reference(
+        logits,
+        batch.token_ids,
+        mask=batch.completion_mask,
+        output_dtype=torch.float32,
+    )
+    old_logps = current_logps.detach() - 0.01
+    ref_logps = current_logps.detach() - 0.02
+    return batch, logits, current_logps, old_logps, ref_logps
+
+
+def _run_reference(args: argparse.Namespace) -> dict[str, Any]:
+    device = torch.device(args.device)
+    dtype = getattr(torch, args.dtype)
+    batch, _logits, current_logps, old_logps, ref_logps = _make_inputs(
+        args,
+        device=device,
+        dtype=dtype,
+    )
+    config = GRPOConfig(
+        clip_epsilon=args.clip_epsilon,
+        kl_beta=args.kl_beta,
+        advantage_eps=args.advantage_eps,
+        loss_reduction=args.loss_reduction,
+    )
+
+    started = time.perf_counter()
+    result = compute_grpo_loss(
+        current_logps,
+        old_logps,
+        ref_logps,
+        batch.rewards,
+        batch.completion_mask,
+        num_groups=args.num_prompts,
+        config=config,
+    )
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+
+    return {
+        "timestamp": _timestamp(),
+        "candidate": args.candidate,
+        "mode": "reference",
+        "stage": "evaluation",
+        "num_prompts": args.num_prompts,
+        "samples_per_prompt": args.samples_per_prompt,
+        "completion_len": args.completion_len,
+        "vocab_size": args.vocab_size,
+        "device": str(device),
+        "dtype": str(dtype).replace("torch.", ""),
+        "advantage_max_abs_error": "0.000000",
+        "loss_max_abs_error": "0.000000",
+        "active_tokens": int(result.metrics["active_tokens"]),
+        "status": "pass",
+        "notes": (
+            f"elapsed_ms={elapsed_ms:.4f};loss={result.metrics['loss']:.8f};"
+            f"kl_mean={result.metrics['kl_mean']:.8f};"
+            f"clip_fraction={result.metrics['clip_fraction']:.8f};"
+            f"loss_reduction={result.metrics['loss_reduction']};{_environment()}"
+        ),
+    }
+
+
+def _run_fused_logp(args: argparse.Namespace) -> dict[str, Any]:
+    if not torch.cuda.is_available():
+        return _blocked_row(args, "fused-logp", "CUDA is not available")
+
+    from rl_engine.kernels.registry import kernel_registry
+
+    device = torch.device("cuda")
+    dtype = getattr(torch, args.cuda_dtype)
+    batch, logits, reference_logps, old_logps, ref_logps = _make_inputs(
+        args,
+        device=device,
+        dtype=dtype,
+    )
+    op = kernel_registry.get_op("logp")
+    if op.__class__.__name__ != "FusedLogpGenericOp":
+        return _blocked_row(
+            args,
+            "fused-logp",
+            f"fused logp backend is unavailable, got {op.__class__.__name__}",
+        )
+
+    config = GRPOConfig(
+        clip_epsilon=args.clip_epsilon,
+        kl_beta=args.kl_beta,
+        advantage_eps=args.advantage_eps,
+        loss_reduction=args.loss_reduction,
+    )
+    started = time.perf_counter()
+    candidate_logps = op(logits, batch.token_ids).float()
+    candidate_logps = candidate_logps.masked_fill(~batch.completion_mask, 0.0)
+    reference_result = compute_grpo_loss(
+        reference_logps,
+        old_logps,
+        ref_logps,
+        batch.rewards,
+        batch.completion_mask,
+        num_groups=args.num_prompts,
+        config=config,
+    )
+    candidate_result = compute_grpo_loss(
+        candidate_logps,
+        old_logps,
+        ref_logps,
+        batch.rewards,
+        batch.completion_mask,
+        num_groups=args.num_prompts,
+        config=config,
+    )
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+
+    logp_drift = summarize_kernel_drift(
+        candidate_logps,
+        reference_logps,
+        batch.completion_mask,
+    )
+    loss_drift = abs(
+        float(candidate_result.loss.detach().cpu().item())
+        - float(reference_result.loss.detach().cpu().item())
+    )
+    advantage_drift = summarize_kernel_drift(
+        candidate_result.advantages,
+        reference_result.advantages,
+        batch.completion_mask,
+    )
+
+    return {
+        "timestamp": _timestamp(),
+        "candidate": args.candidate,
+        "mode": "fused-logp",
+        "stage": "evaluation",
+        "num_prompts": args.num_prompts,
+        "samples_per_prompt": args.samples_per_prompt,
+        "completion_len": args.completion_len,
+        "vocab_size": args.vocab_size,
+        "device": str(device),
+        "dtype": str(dtype).replace("torch.", ""),
+        "advantage_max_abs_error": f"{advantage_drift['max_abs_error']:.8f}",
+        "loss_max_abs_error": f"{loss_drift:.8f}",
+        "active_tokens": int(candidate_result.metrics["active_tokens"]),
+        "status": "pass",
+        "notes": (
+            f"elapsed_ms={elapsed_ms:.4f};"
+            f"logp_max_abs_error={logp_drift['max_abs_error']:.8f};"
+            f"loss={candidate_result.metrics['loss']:.8f};"
+            f"loss_reduction={candidate_result.metrics['loss_reduction']};{_environment()}"
+        ),
+    }
+
+
+def _blocked_row(args: argparse.Namespace, mode: str, reason: str) -> dict[str, Any]:
+    return {
+        "timestamp": _timestamp(),
+        "candidate": args.candidate,
+        "mode": mode,
+        "stage": "evaluation",
+        "num_prompts": args.num_prompts,
+        "samples_per_prompt": args.samples_per_prompt,
+        "completion_len": args.completion_len,
+        "vocab_size": args.vocab_size,
+        "device": args.device,
+        "dtype": args.dtype,
+        "status": "blocked",
+        "notes": f"{reason};{_environment()}",
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="GRPO objective benchmark")
+    parser.add_argument("--mode", choices=["reference", "fused-logp"], default="reference")
+    parser.add_argument("--smoke", action="store_true")
+    parser.add_argument("--num-prompts", type=int, default=4)
+    parser.add_argument("--samples-per-prompt", type=int, default=4)
+    parser.add_argument("--prompt-len", type=int, default=8)
+    parser.add_argument("--completion-len", type=int, default=16)
+    parser.add_argument("--vocab-size", type=int, default=1024)
+    parser.add_argument("--valid-density", type=float, default=0.85)
+    parser.add_argument("--clip-epsilon", type=float, default=0.2)
+    parser.add_argument("--kl-beta", type=float, default=0.01)
+    parser.add_argument("--advantage-eps", type=float, default=1e-8)
+    parser.add_argument(
+        "--loss-reduction",
+        choices=["global_token_mean", "sequence_mean"],
+        default="global_token_mean",
+    )
+    parser.add_argument("--seed", type=int, default=16)
+    parser.add_argument("--candidate", default="issue-16-candidate-1")
+    parser.add_argument("--device", default="cpu")
+    parser.add_argument("--dtype", default="float32")
+    parser.add_argument("--cuda-dtype", default="float16")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=REPO_ROOT / "task-workspace/issues/issue_16/benchmark.csv",
+    )
+    parser.add_argument("--json-output", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.smoke:
+        args.num_prompts = min(args.num_prompts, 2)
+        args.samples_per_prompt = min(args.samples_per_prompt, 3)
+        args.prompt_len = min(args.prompt_len, 4)
+        args.completion_len = min(args.completion_len, 8)
+        args.vocab_size = min(args.vocab_size, 128)
+    return args
+
+
+def main() -> None:
+    args = parse_args()
+    if args.mode == "reference":
+        row = _run_reference(args)
+    else:
+        row = _run_fused_logp(args)
+    _append_row(args.output, row)
+    _write_json(args.json_output, row)
+    print(json.dumps(row, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/rl_engine/alignment/__init__.py
+++ b/rl_engine/alignment/__init__.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from rl_engine.alignment.grpo import (
+    GRPOConfig,
+    GRPOResult,
+    broadcast_sequence_advantages,
+    compute_group_relative_advantages,
+    compute_grpo_loss,
+)
+
+__all__ = [
+    "GRPOConfig",
+    "GRPOResult",
+    "broadcast_sequence_advantages",
+    "compute_grpo_loss",
+    "compute_group_relative_advantages",
+]

--- a/rl_engine/alignment/grpo.py
+++ b/rl_engine/alignment/grpo.py
@@ -1,0 +1,303 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+import torch
+
+
+@dataclass(frozen=True)
+class GRPOConfig:
+    """Configuration for the reference GRPO objective.
+
+    ``global_token_mean`` matches the original issue #16 behavior and averages
+    over all active completion tokens. ``sequence_mean`` first averages each
+    active completion independently, then averages those per-sequence losses so
+    long completions do not receive more weight than short completions.
+    """
+
+    clip_epsilon: float = 0.2
+    kl_beta: float = 0.01
+    advantage_eps: float = 1e-8
+    loss_reduction: str = "global_token_mean"
+
+    def __post_init__(self) -> None:
+        if self.clip_epsilon < 0.0:
+            raise ValueError("clip_epsilon must be non-negative")
+        if self.kl_beta < 0.0:
+            raise ValueError("kl_beta must be non-negative")
+        if self.advantage_eps <= 0.0:
+            raise ValueError("advantage_eps must be greater than zero")
+        if self.loss_reduction not in {"global_token_mean", "sequence_mean"}:
+            raise ValueError("loss_reduction must be 'global_token_mean' or 'sequence_mean'")
+
+
+@dataclass(frozen=True)
+class GRPOResult:
+    """Tensors and scalar metrics produced by the GRPO objective."""
+
+    loss: torch.Tensor
+    policy_loss: torch.Tensor
+    kl_loss: torch.Tensor
+    advantages: torch.Tensor
+    sequence_advantages: torch.Tensor
+    ratio: torch.Tensor
+    kl: torch.Tensor
+    metrics: Mapping[str, Any]
+
+    def with_metrics(self, extra: Mapping[str, Any]) -> GRPOResult:
+        """Return a copy with additional scalar or string metrics."""
+
+        return GRPOResult(
+            loss=self.loss,
+            policy_loss=self.policy_loss,
+            kl_loss=self.kl_loss,
+            advantages=self.advantages,
+            sequence_advantages=self.sequence_advantages,
+            ratio=self.ratio,
+            kl=self.kl,
+            metrics={**dict(self.metrics), **dict(extra)},
+        )
+
+
+def compute_group_relative_advantages(
+    rewards: torch.Tensor,
+    *,
+    group_ids: Optional[torch.Tensor] = None,
+    num_groups: Optional[int] = None,
+    eps: float = 1e-8,
+) -> torch.Tensor:
+    """Normalize scalar rewards independently inside each prompt group."""
+
+    if eps <= 0.0:
+        raise ValueError("eps must be greater than zero")
+    if rewards.ndim != 1:
+        raise ValueError(f"rewards must be one-dimensional, got shape {tuple(rewards.shape)}")
+    if rewards.numel() == 0:
+        raise ValueError("rewards must contain at least one value")
+
+    resolved_group_ids, resolved_num_groups = _resolve_group_ids(
+        rewards,
+        group_ids=group_ids,
+        num_groups=num_groups,
+    )
+    rewards_fp32 = rewards.detach().to(dtype=torch.float32)
+    advantages = torch.empty_like(rewards_fp32)
+
+    for group_index in range(resolved_num_groups):
+        mask = resolved_group_ids == group_index
+        if not bool(mask.any().item()):
+            raise ValueError(f"group {group_index} has no rewards")
+        group_rewards = rewards_fp32[mask]
+        mean = group_rewards.mean()
+        std = group_rewards.std(unbiased=False)
+        advantages[mask] = (group_rewards - mean) / std.clamp_min(float(eps))
+
+    if not bool(torch.isfinite(advantages).all().item()):
+        raise ValueError("computed group-relative advantages contain non-finite values")
+    return advantages
+
+
+def broadcast_sequence_advantages(
+    sequence_advantages: torch.Tensor,
+    completion_mask: torch.Tensor,
+) -> torch.Tensor:
+    """Broadcast per-sequence advantages onto active completion tokens only."""
+
+    if sequence_advantages.ndim != 1:
+        raise ValueError(
+            "sequence_advantages must be one-dimensional, got shape "
+            f"{tuple(sequence_advantages.shape)}"
+        )
+    if completion_mask.ndim != 2:
+        raise ValueError(
+            f"completion_mask must be two-dimensional, got shape {tuple(completion_mask.shape)}"
+        )
+    if sequence_advantages.shape[0] != completion_mask.shape[0]:
+        raise ValueError(
+            "sequence_advantages length must match completion_mask batch size, got "
+            f"{sequence_advantages.shape[0]} and {completion_mask.shape[0]}"
+        )
+
+    mask = completion_mask.to(dtype=torch.bool, device=sequence_advantages.device)
+    broadcast = sequence_advantages.float().unsqueeze(-1).expand_as(mask).clone()
+    return broadcast.masked_fill(~mask, 0.0)
+
+
+def compute_grpo_loss(
+    current_logps: torch.Tensor,
+    old_logps: torch.Tensor,
+    ref_logps: torch.Tensor,
+    rewards: torch.Tensor,
+    completion_mask: torch.Tensor,
+    *,
+    group_ids: Optional[torch.Tensor] = None,
+    num_groups: Optional[int] = None,
+    config: Optional[GRPOConfig] = None,
+) -> GRPOResult:
+    """Compute the reference GRPO clipped policy objective."""
+
+    cfg = config or GRPOConfig()
+    _validate_loss_shapes(current_logps, old_logps, ref_logps, rewards, completion_mask)
+
+    mask = completion_mask.to(dtype=torch.bool, device=current_logps.device)
+    active_tokens = int(mask.sum().item())
+    if active_tokens <= 0:
+        raise ValueError("completion_mask must contain at least one active token")
+
+    sequence_advantages = compute_group_relative_advantages(
+        rewards.to(device=current_logps.device),
+        group_ids=group_ids.to(device=current_logps.device) if group_ids is not None else None,
+        num_groups=num_groups,
+        eps=cfg.advantage_eps,
+    )
+    advantages = broadcast_sequence_advantages(sequence_advantages, mask)
+
+    current_fp32 = current_logps.float()
+    old_fp32 = old_logps.detach().to(device=current_logps.device, dtype=torch.float32)
+    ref_fp32 = ref_logps.detach().to(device=current_logps.device, dtype=torch.float32)
+
+    ratio = torch.exp(current_fp32 - old_fp32).masked_fill(~mask, 0.0)
+    unclipped = ratio * advantages
+    clipped_ratio = torch.clamp(
+        ratio,
+        1.0 - cfg.clip_epsilon,
+        1.0 + cfg.clip_epsilon,
+    )
+    clipped = clipped_ratio * advantages
+    token_policy_loss = -torch.minimum(unclipped, clipped).masked_fill(~mask, 0.0)
+
+    diff = ref_fp32 - current_fp32
+    kl = (torch.exp(diff) - diff - 1.0).masked_fill(~mask, 0.0)
+    loss_terms = token_policy_loss + cfg.kl_beta * kl
+
+    policy_loss = _reduce_loss_terms(token_policy_loss, mask, cfg.loss_reduction)
+    kl_mean = _reduce_loss_terms(kl, mask, cfg.loss_reduction)
+    kl_loss = cfg.kl_beta * kl_mean
+    loss = _reduce_loss_terms(loss_terms, mask, cfg.loss_reduction)
+
+    clipped_tokens = ((ratio < 1.0 - cfg.clip_epsilon) | (ratio > 1.0 + cfg.clip_epsilon)) & mask
+    clip_fraction = clipped_tokens.to(dtype=torch.float32).sum() / float(active_tokens)
+
+    active_advantages = advantages[mask]
+    metrics = {
+        "loss": _scalar(loss),
+        "policy_loss": _scalar(policy_loss),
+        "kl_loss": _scalar(kl_loss),
+        "kl_mean": _scalar(kl_mean),
+        "clip_fraction": _scalar(clip_fraction),
+        "active_tokens": float(active_tokens),
+        "reward_mean": _scalar(rewards.detach().float().mean()),
+        "reward_std": _scalar(rewards.detach().float().std(unbiased=False)),
+        "advantage_mean": _scalar(sequence_advantages.mean()),
+        "advantage_std": _scalar(sequence_advantages.std(unbiased=False)),
+        "token_advantage_mean": _scalar(active_advantages.mean()),
+        "token_advantage_std": _scalar(active_advantages.std(unbiased=False)),
+        "active_sequences": float(_active_sequence_count(mask)),
+        "loss_reduction": cfg.loss_reduction,
+    }
+
+    return GRPOResult(
+        loss=loss,
+        policy_loss=policy_loss,
+        kl_loss=kl_loss,
+        advantages=advantages,
+        sequence_advantages=sequence_advantages,
+        ratio=ratio,
+        kl=kl,
+        metrics=metrics,
+    )
+
+
+def _resolve_group_ids(
+    rewards: torch.Tensor,
+    *,
+    group_ids: Optional[torch.Tensor],
+    num_groups: Optional[int],
+) -> tuple[torch.Tensor, int]:
+    if num_groups is not None and num_groups <= 0:
+        raise ValueError("num_groups must be greater than zero")
+
+    if group_ids is None:
+        if num_groups is None:
+            raise ValueError("group_ids or num_groups is required")
+        if rewards.numel() % num_groups != 0:
+            raise ValueError(
+                "rewards length must be divisible by num_groups when group_ids are inferred"
+            )
+        group_size = rewards.numel() // num_groups
+        inferred = torch.arange(num_groups, device=rewards.device, dtype=torch.long)
+        return inferred.repeat_interleave(group_size), int(num_groups)
+
+    if group_ids.ndim != 1:
+        raise ValueError(f"group_ids must be one-dimensional, got shape {tuple(group_ids.shape)}")
+    if group_ids.shape[0] != rewards.shape[0]:
+        raise ValueError(
+            f"group_ids length {group_ids.shape[0]} must match rewards length {rewards.shape[0]}"
+        )
+
+    resolved = group_ids.to(device=rewards.device, dtype=torch.long)
+    if bool((resolved < 0).any().item()):
+        raise ValueError("group_ids must be non-negative")
+    inferred_num_groups = int(resolved.max().item()) + 1 if resolved.numel() else 0
+    resolved_num_groups = int(num_groups) if num_groups is not None else inferred_num_groups
+    if inferred_num_groups > resolved_num_groups:
+        raise ValueError("group_ids contain an id greater than or equal to num_groups")
+    for group_index in range(resolved_num_groups):
+        if not bool((resolved == group_index).any().item()):
+            raise ValueError(f"group {group_index} has no rewards")
+    return resolved, resolved_num_groups
+
+
+def _validate_loss_shapes(
+    current_logps: torch.Tensor,
+    old_logps: torch.Tensor,
+    ref_logps: torch.Tensor,
+    rewards: torch.Tensor,
+    completion_mask: torch.Tensor,
+) -> None:
+    if current_logps.ndim != 2:
+        raise ValueError(f"current_logps must be two-dimensional, got {tuple(current_logps.shape)}")
+    if old_logps.shape != current_logps.shape:
+        raise ValueError("old_logps shape must match current_logps shape")
+    if ref_logps.shape != current_logps.shape:
+        raise ValueError("ref_logps shape must match current_logps shape")
+    if completion_mask.shape != current_logps.shape:
+        raise ValueError("completion_mask shape must match current_logps shape")
+    if rewards.ndim != 1:
+        raise ValueError(f"rewards must be one-dimensional, got shape {tuple(rewards.shape)}")
+    if rewards.shape[0] != current_logps.shape[0]:
+        raise ValueError("rewards length must match current_logps batch size")
+
+
+def _masked_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    return values.masked_fill(~mask, 0.0).sum() / mask.sum().clamp_min(1).to(dtype=torch.float32)
+
+
+def _sequence_mean(values: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    masked = values.masked_fill(~mask, 0.0)
+    counts = mask.sum(dim=1)
+    active_rows = counts > 0
+    if not bool(active_rows.any().item()):
+        return values.new_tensor(0.0, dtype=torch.float32)
+    per_sequence = masked.sum(dim=1) / counts.clamp_min(1).to(dtype=torch.float32)
+    return per_sequence[active_rows].mean()
+
+
+def _reduce_loss_terms(values: torch.Tensor, mask: torch.Tensor, mode: str) -> torch.Tensor:
+    if mode == "global_token_mean":
+        return _masked_mean(values, mask)
+    if mode == "sequence_mean":
+        return _sequence_mean(values, mask)
+    raise ValueError(f"unsupported loss reduction mode {mode!r}")
+
+
+def _active_sequence_count(mask: torch.Tensor) -> int:
+    return int((mask.sum(dim=1) > 0).sum().item())
+
+
+def _scalar(value: torch.Tensor) -> float:
+    return float(value.detach().cpu().item())

--- a/rl_engine/executors/deepspeed_trainer.py
+++ b/rl_engine/executors/deepspeed_trainer.py
@@ -24,12 +24,7 @@ from rl_engine.executors.training_contract import (
     RolloutStageResult,
     TorchRLTrainingConfig,
     TrainingStageResult,
-)
-from rl_engine.testing import (
-    compute_policy_ratio,
-    compute_reference_kl,
-    masked_mean,
-    selected_logprobs_reference,
+    compute_training_grpo_objective,
 )
 
 _TDestination = TypeVar("_TDestination", bound=dict[str, Any])
@@ -106,20 +101,8 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
         batch, payload_metrics = self._batch_from_rollout_or_synthetic(rollout)
 
         logits = _extract_logits(self.engine(batch.token_ids.long()))
-        current_logps = selected_logprobs_reference(
-            logits,
-            batch.token_ids,
-            mask=batch.completion_mask,
-            output_dtype=torch.float32,
-        )
-        old_logps = current_logps.detach() - 0.01
-        ref_logps = current_logps.detach() - 0.02
-        ratio = compute_policy_ratio(current_logps, old_logps, batch.completion_mask)
-        unclipped = ratio * batch.advantages.float()
-        clipped = torch.clamp(ratio, 0.8, 1.2) * batch.advantages.float()
-        policy_loss = -torch.minimum(unclipped, clipped)
-        kl = compute_reference_kl(current_logps, ref_logps, batch.completion_mask)
-        loss = masked_mean(policy_loss + 0.01 * kl, batch.completion_mask)
+        objective = compute_training_grpo_objective(logits, batch, self.config)
+        loss = objective.loss
 
         if hasattr(self.engine, "zero_grad"):
             try:
@@ -145,6 +128,8 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
                 "training_device": str(self.device),
                 "deepspeed_engine": type(self.engine).__name__,
                 "deepspeed_zero_stage": self.config.zero_stage,
+                "objective": "grpo",
+                **objective.metrics,
                 **payload_metrics,
             },
             started_at=started_at,

--- a/rl_engine/executors/overlap_pipeline.py
+++ b/rl_engine/executors/overlap_pipeline.py
@@ -17,13 +17,9 @@ from rl_engine.executors.training_contract import (
     RolloutStageResult,
     TorchRLTrainingConfig,
     TrainingStageResult,
+    compute_training_grpo_objective,
+    extract_rollout_candidate_groups,
     extract_rollout_token_groups,
-)
-from rl_engine.testing import (
-    compute_policy_ratio,
-    compute_reference_kl,
-    masked_mean,
-    selected_logprobs_reference,
 )
 
 
@@ -534,20 +530,8 @@ class TorchRLTrainingWorker(RolloutBatchMixin):
         batch, payload_metrics = self._batch_from_rollout_or_synthetic(rollout)
 
         logits = self.model(batch.token_ids.long())
-        current_logps = selected_logprobs_reference(
-            logits,
-            batch.token_ids,
-            mask=batch.completion_mask,
-            output_dtype=torch.float32,
-        )
-        old_logps = current_logps.detach() - 0.01
-        ref_logps = current_logps.detach() - 0.02
-        ratio = compute_policy_ratio(current_logps, old_logps, batch.completion_mask)
-        unclipped = ratio * batch.advantages.float()
-        clipped = torch.clamp(ratio, 0.8, 1.2) * batch.advantages.float()
-        policy_loss = -torch.minimum(unclipped, clipped)
-        kl = compute_reference_kl(current_logps, ref_logps, batch.completion_mask)
-        loss = masked_mean(policy_loss + 0.01 * kl, batch.completion_mask)
+        objective = compute_training_grpo_objective(logits, batch, self.config)
+        loss = objective.loss
 
         self.optimizer.zero_grad(set_to_none=True)
         loss.backward()
@@ -564,6 +548,8 @@ class TorchRLTrainingWorker(RolloutBatchMixin):
                 "active_tokens": int(batch.completion_mask.sum().item()),
                 "payload_type": type(rollout.payload).__name__,
                 "training_backend": "torch",
+                "objective": "grpo",
+                **objective.metrics,
                 **payload_metrics,
             },
             started_at=started_at,
@@ -655,6 +641,7 @@ __all__ = [
     "TrainingWorker",
     "WeightHandoffRecord",
     "compute_stage_overlap_seconds",
+    "extract_rollout_candidate_groups",
     "extract_rollout_token_groups",
     "timeline_summary_to_dict",
 ]

--- a/rl_engine/executors/training_contract.py
+++ b/rl_engine/executors/training_contract.py
@@ -9,7 +9,33 @@ from typing import Any, Mapping, Optional, Protocol, Sequence
 
 import torch
 
+from rl_engine.alignment.grpo import (
+    GRPOConfig,
+    broadcast_sequence_advantages,
+    compute_group_relative_advantages,
+    compute_grpo_loss,
+)
 from rl_engine.testing import SyntheticRLKernelBatch, make_synthetic_rl_kernel_batch
+from rl_engine.testing.reference_ops import selected_logprobs_reference
+
+_OLD_LOGP_KEYS = (
+    "old_logps",
+    "old_logprobs",
+    "old_selected_logps",
+    "old_selected_logprobs",
+    "old_policy_logps",
+    "old_policy_logprobs",
+)
+_REF_LOGP_KEYS = (
+    "ref_logps",
+    "ref_logprobs",
+    "reference_logps",
+    "reference_logprobs",
+    "ref_selected_logps",
+    "ref_selected_logprobs",
+    "reference_selected_logps",
+    "reference_selected_logprobs",
+)
 
 
 @dataclass(frozen=True)
@@ -48,6 +74,16 @@ class TrainingWorker(Protocol):
     def train(self, rollout: RolloutStageResult) -> TrainingStageResult: ...
 
 
+class RewardProvider(Protocol):
+    """Callable reward source for grouped rollout candidates."""
+
+    def __call__(
+        self,
+        candidate_groups: Sequence[Sequence[Sequence[int]]],
+        rollout: RolloutStageResult,
+    ) -> Sequence[Sequence[float]]: ...
+
+
 @dataclass(frozen=True)
 class TorchRLTrainingConfig:
     """Config shared by local and DeepSpeed training workers."""
@@ -64,6 +100,13 @@ class TorchRLTrainingConfig:
     dtype: torch.dtype = torch.float32
     seed: int = 0
     min_completion_len: int = 1
+    clip_epsilon: float = 0.2
+    kl_beta: float = 0.01
+    advantage_eps: float = 1e-8
+    loss_reduction: str = "global_token_mean"
+    require_payload_rewards: bool = False
+    require_payload_logps: bool = False
+    reward_provider: Optional[RewardProvider] = None
 
 
 class RolloutBatchMixin:
@@ -74,13 +117,59 @@ class RolloutBatchMixin:
         self,
         rollout: RolloutStageResult,
     ) -> tuple[SyntheticRLKernelBatch, dict[str, Any]]:
-        token_groups = extract_rollout_token_groups(rollout.payload)
-        if token_groups:
-            return self._batch_from_token_groups(token_groups, rollout), {
+        candidate_groups = extract_rollout_candidate_groups(rollout.payload)
+        if candidate_groups:
+            reward_groups, reward_source = _resolve_reward_groups(
+                candidate_groups,
+                rollout,
+                self.config.reward_provider,
+            )
+            has_rewards = reward_groups is not None
+            if self.config.require_payload_rewards and not has_rewards:
+                raise ValueError(
+                    "require_payload_rewards=True requires one scalar reward for every "
+                    "rollout candidate"
+                )
+            old_logp_groups = extract_rollout_logp_groups(
+                rollout.payload,
+                keys=_OLD_LOGP_KEYS,
+            )
+            ref_logp_groups = extract_rollout_logp_groups(
+                rollout.payload,
+                keys=_REF_LOGP_KEYS,
+            )
+            has_payload_logps = _logp_groups_match(
+                candidate_groups,
+                old_logp_groups,
+            ) and _logp_groups_match(candidate_groups, ref_logp_groups)
+            if self.config.require_payload_logps and not has_payload_logps:
+                raise ValueError(
+                    "require_payload_logps=True requires old/ref selected logprobs "
+                    "for every rollout candidate token"
+                )
+            batch = self._batch_from_candidate_groups(
+                candidate_groups,
+                rollout,
+                reward_groups=reward_groups if has_rewards else None,
+                reward_source=reward_source if has_rewards else "token_id_proxy",
+                old_logp_groups=old_logp_groups if has_payload_logps else None,
+                ref_logp_groups=ref_logp_groups if has_payload_logps else None,
+            )
+            token_groups = [tokens for group in candidate_groups for tokens in group]
+            return batch, {
                 "training_data_source": "rollout_payload",
+                "reward_source": reward_source if has_rewards else "token_id_proxy",
+                "logprob_source": "payload_logps" if has_payload_logps else "smoke_logps",
+                "rollout_prompt_groups": len(candidate_groups),
                 "rollout_sequences": len(token_groups),
                 "rollout_tokens": sum(len(group) for group in token_groups),
             }
+
+        if self.config.require_payload_rewards or self.config.require_payload_logps:
+            raise ValueError(
+                "strict production inputs require rollout payload candidate groups; "
+                "strict mode requires rollout payload candidate groups before training"
+            )
 
         seed = self.config.seed + int(rollout.iteration)
         batch = make_synthetic_rl_kernel_batch(
@@ -98,6 +187,8 @@ class RolloutBatchMixin:
             "training_data_source": "synthetic_fallback",
             "rollout_sequences": 0,
             "rollout_tokens": 0,
+            "reward_source": "synthetic_rewards",
+            "logprob_source": "synthetic_logps",
         }
 
     def _batch_from_token_groups(
@@ -105,11 +196,29 @@ class RolloutBatchMixin:
         token_groups: Sequence[Sequence[int]],
         rollout: RolloutStageResult,
     ) -> SyntheticRLKernelBatch:
+        return self._batch_from_candidate_groups(
+            [[group] for group in token_groups],
+            rollout,
+            reward_groups=None,
+            reward_source="token_id_proxy",
+        )
+
+    def _batch_from_candidate_groups(
+        self,
+        candidate_groups: Sequence[Sequence[Sequence[int]]],
+        rollout: RolloutStageResult,
+        *,
+        reward_groups: Optional[Sequence[Sequence[float]]] = None,
+        reward_source: str = "token_id_proxy",
+        old_logp_groups: Optional[Sequence[Sequence[Sequence[float]]]] = None,
+        ref_logp_groups: Optional[Sequence[Sequence[Sequence[float]]]] = None,
+    ) -> SyntheticRLKernelBatch:
+        flat_token_groups = [tokens for group in candidate_groups for tokens in group]
         completion_len = max(
             self.config.min_completion_len,
-            min(self.config.completion_len, max(len(group) for group in token_groups)),
+            min(self.config.completion_len, max(len(group) for group in flat_token_groups)),
         )
-        batch_size = len(token_groups)
+        batch_size = len(flat_token_groups)
         token_ids = torch.zeros(
             (batch_size, completion_len),
             device=self.device,
@@ -120,13 +229,33 @@ class RolloutBatchMixin:
             device=self.device,
             dtype=torch.bool,
         )
-        for row, group in enumerate(token_groups):
-            clipped = [int(token) % self.config.vocab_size for token in group[:completion_len]]
-            if not clipped:
-                continue
-            values = torch.tensor(clipped, device=self.device, dtype=torch.long)
-            token_ids[row, : values.numel()] = values
-            completion_mask[row, : values.numel()] = True
+        flat_rewards: list[float] = []
+        flat_group_ids: list[int] = []
+        row = 0
+        for group_index, group in enumerate(candidate_groups):
+            for candidate_index, candidate_tokens in enumerate(group):
+                clipped = [
+                    int(token) % self.config.vocab_size
+                    for token in candidate_tokens[:completion_len]
+                ]
+                if clipped:
+                    values = torch.tensor(clipped, device=self.device, dtype=torch.long)
+                    token_ids[row, : values.numel()] = values
+                    completion_mask[row, : values.numel()] = True
+                flat_rewards.append(
+                    _candidate_reward_value(
+                        candidate_tokens,
+                        reward_groups,
+                        group_index,
+                        candidate_index,
+                        vocab_size=self.config.vocab_size,
+                    )
+                )
+                flat_group_ids.append(group_index)
+                row += 1
+
+        if not bool(completion_mask.any().item()):
+            completion_mask[:, :1] = True
 
         prompt_tokens = torch.zeros(
             (batch_size, self.config.prompt_len),
@@ -145,13 +274,16 @@ class RolloutBatchMixin:
             dim=1,
         )
 
-        generator = torch.Generator(device=self.device)
-        generator.manual_seed(self.config.seed + int(rollout.iteration))
-        advantages = torch.randn(
-            (batch_size, completion_len),
-            device=self.device,
-            generator=generator,
-            dtype=self.config.dtype,
+        rewards = torch.tensor(flat_rewards, device=self.device, dtype=self.config.dtype)
+        group_ids = torch.tensor(flat_group_ids, device=self.device, dtype=torch.long)
+        sequence_advantages = compute_group_relative_advantages(
+            rewards,
+            group_ids=group_ids,
+            num_groups=len(candidate_groups),
+            eps=self.config.advantage_eps,
+        )
+        advantages = broadcast_sequence_advantages(sequence_advantages, completion_mask).to(
+            dtype=self.config.dtype
         )
         old_logps = torch.zeros(
             (batch_size, completion_len),
@@ -163,16 +295,29 @@ class RolloutBatchMixin:
             device=self.device,
             dtype=self.config.dtype,
         )
-        rewards = torch.randn(
-            (batch_size,),
-            device=self.device,
-            generator=generator,
-            dtype=self.config.dtype,
-        )
+        if old_logp_groups is not None and ref_logp_groups is not None:
+            row = 0
+            for group_index, group in enumerate(candidate_groups):
+                for candidate_index, candidate_tokens in enumerate(group):
+                    token_count = min(len(candidate_tokens), completion_len)
+                    if token_count:
+                        old_values = torch.tensor(
+                            old_logp_groups[group_index][candidate_index][:token_count],
+                            device=self.device,
+                            dtype=self.config.dtype,
+                        )
+                        ref_values = torch.tensor(
+                            ref_logp_groups[group_index][candidate_index][:token_count],
+                            device=self.device,
+                            dtype=self.config.dtype,
+                        )
+                        old_logps[row, :token_count] = old_values
+                        ref_logps[row, :token_count] = ref_values
+                    row += 1
         valid_indices = completion_mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
         metadata: dict[str, Any] = {
-            "num_prompts": batch_size,
-            "samples_per_prompt": 1,
+            "num_prompts": len(candidate_groups),
+            "samples_per_prompt": max(len(group) for group in candidate_groups),
             "batch_size": batch_size,
             "prompt_len": self.config.prompt_len,
             "completion_len": completion_len,
@@ -184,6 +329,13 @@ class RolloutBatchMixin:
             "device": str(self.device),
             "seed": self.config.seed + int(rollout.iteration),
             "source": "rollout_payload",
+            "group_ids": flat_group_ids,
+            "reward_source": reward_source if reward_groups is not None else "token_id_proxy",
+            "logprob_source": (
+                "payload_logps"
+                if old_logp_groups is not None and ref_logp_groups is not None
+                else "smoke_logps"
+            ),
         }
         return SyntheticRLKernelBatch(
             input_ids=input_ids,
@@ -221,50 +373,183 @@ def make_rollout_result(
 def extract_rollout_token_groups(payload: Any) -> list[list[int]]:
     """Extract generated token ids from RL-Kernel/vLLM-style rollout payloads."""
 
-    groups: list[list[int]] = []
+    return [tokens for group in extract_rollout_candidate_groups(payload) for tokens in group]
+
+
+def extract_rollout_candidate_groups(payload: Any) -> list[list[list[int]]]:
+    """Extract generated token ids while preserving prompt-level candidate groups."""
+
     if not isinstance(payload, Mapping):
-        return groups
+        return []
 
     normalized_outputs = payload.get("normalized_outputs")
     if isinstance(normalized_outputs, Sequence) and not isinstance(
         normalized_outputs, (str, bytes)
     ):
-        for group in normalized_outputs:
-            if not isinstance(group, Sequence) or isinstance(group, (str, bytes)):
-                continue
-            for candidate in group:
-                token_ids = _candidate_token_ids(candidate)
-                if token_ids:
-                    groups.append(token_ids)
+        groups = _candidate_groups_from_grouped_outputs(normalized_outputs)
         if groups:
             return groups
 
     outputs = payload.get("outputs")
     if isinstance(outputs, Sequence) and not isinstance(outputs, (str, bytes)):
-        for group in outputs:
-            if isinstance(group, Sequence) and not isinstance(group, (str, bytes)):
-                candidates = group
-            else:
-                candidates = [group]
-            for candidate in candidates:
-                token_ids = _candidate_token_ids(candidate)
-                if token_ids:
-                    groups.append(token_ids)
+        return _candidate_groups_from_grouped_outputs(outputs)
+    return []
+
+
+def extract_rollout_reward_groups(payload: Any) -> list[list[float]]:
+    """Extract scalar reward groups from rollout payloads when they are present."""
+
+    if not isinstance(payload, Mapping):
+        return []
+
+    normalized_outputs = payload.get("normalized_outputs")
+    if isinstance(normalized_outputs, Sequence) and not isinstance(
+        normalized_outputs, (str, bytes)
+    ):
+        groups = _reward_groups_from_grouped_outputs(normalized_outputs)
+        if groups:
+            return groups
+
+    outputs = payload.get("outputs")
+    if isinstance(outputs, Sequence) and not isinstance(outputs, (str, bytes)):
+        return _reward_groups_from_grouped_outputs(outputs)
+    return []
+
+
+def extract_rollout_logp_groups(payload: Any, *, keys: Sequence[str]) -> list[list[list[float]]]:
+    """Extract selected token logprobs from grouped rollout payloads."""
+
+    if not isinstance(payload, Mapping):
+        return []
+
+    normalized_outputs = payload.get("normalized_outputs")
+    if isinstance(normalized_outputs, Sequence) and not isinstance(
+        normalized_outputs, (str, bytes)
+    ):
+        groups = _logp_groups_from_grouped_outputs(normalized_outputs, keys=keys)
+        if groups:
+            return groups
+
+    outputs = payload.get("outputs")
+    if isinstance(outputs, Sequence) and not isinstance(outputs, (str, bytes)):
+        return _logp_groups_from_grouped_outputs(outputs, keys=keys)
+    return []
+
+
+def compute_training_grpo_objective(
+    logits: torch.Tensor,
+    batch: SyntheticRLKernelBatch,
+    config: TorchRLTrainingConfig,
+):
+    current_logps = selected_logprobs_reference(
+        logits,
+        batch.token_ids,
+        mask=batch.completion_mask,
+        output_dtype=torch.float32,
+    )
+    if batch.metadata.get("logprob_source") == "payload_logps":
+        old_logps = batch.old_logps.detach().to(device=current_logps.device, dtype=torch.float32)
+        ref_logps = batch.ref_logps.detach().to(device=current_logps.device, dtype=torch.float32)
+        logprob_source = "payload_logps"
+    else:
+        old_logps = current_logps.detach() - 0.01
+        ref_logps = current_logps.detach() - 0.02
+        logprob_source = str(batch.metadata.get("logprob_source", "smoke_logps"))
+
+    return compute_grpo_loss(
+        current_logps=current_logps,
+        old_logps=old_logps,
+        ref_logps=ref_logps,
+        rewards=batch.rewards,
+        completion_mask=batch.completion_mask,
+        group_ids=batch_group_ids(batch),
+        num_groups=int(batch.metadata.get("num_prompts", 1)),
+        config=GRPOConfig(
+            clip_epsilon=config.clip_epsilon,
+            kl_beta=config.kl_beta,
+            advantage_eps=config.advantage_eps,
+            loss_reduction=config.loss_reduction,
+        ),
+    ).with_metrics({"logprob_source": logprob_source})
+
+
+def batch_group_ids(batch: SyntheticRLKernelBatch) -> Optional[torch.Tensor]:
+    group_ids = batch.metadata.get("group_ids")
+    if group_ids is None:
+        return None
+    if isinstance(group_ids, torch.Tensor):
+        return group_ids.to(device=batch.rewards.device, dtype=torch.long)
+    return torch.tensor(group_ids, device=batch.rewards.device, dtype=torch.long)
+
+
+def _candidate_groups_from_grouped_outputs(grouped_outputs: Sequence[Any]) -> list[list[list[int]]]:
+    groups: list[list[list[int]]] = []
+    for group in grouped_outputs:
+        if isinstance(group, Sequence) and not isinstance(group, (str, bytes, Mapping)):
+            candidates = group
+        else:
+            candidates = [group]
+        candidate_group = []
+        for candidate in candidates:
+            token_ids = _candidate_token_ids(candidate)
+            if token_ids is not None:
+                candidate_group.append(token_ids)
+        if candidate_group:
+            groups.append(candidate_group)
     return groups
 
 
-def _candidate_token_ids(candidate: Any) -> list[int]:
+def _reward_groups_from_grouped_outputs(grouped_outputs: Sequence[Any]) -> list[list[float]]:
+    groups: list[list[float]] = []
+    for group in grouped_outputs:
+        if isinstance(group, Sequence) and not isinstance(group, (str, bytes, Mapping)):
+            candidates = group
+        else:
+            candidates = [group]
+        reward_group = []
+        for candidate in candidates:
+            reward = _candidate_reward(candidate)
+            if reward is not None:
+                reward_group.append(reward)
+        if reward_group:
+            groups.append(reward_group)
+    return groups
+
+
+def _logp_groups_from_grouped_outputs(
+    grouped_outputs: Sequence[Any],
+    *,
+    keys: Sequence[str],
+) -> list[list[list[float]]]:
+    groups: list[list[list[float]]] = []
+    for group in grouped_outputs:
+        if isinstance(group, Sequence) and not isinstance(group, (str, bytes, Mapping)):
+            candidates = group
+        else:
+            candidates = [group]
+        logp_group = []
+        for candidate in candidates:
+            logps = _candidate_logps(candidate, keys=keys)
+            if logps is not None:
+                logp_group.append(logps)
+        if logp_group:
+            groups.append(logp_group)
+    return groups
+
+
+def _candidate_token_ids(candidate: Any) -> Optional[list[int]]:
     if candidate is None:
-        return []
+        return None
     if isinstance(candidate, Mapping):
         nested_outputs = candidate.get("outputs")
         if isinstance(nested_outputs, Sequence) and not isinstance(nested_outputs, (str, bytes)):
             for nested in nested_outputs:
                 token_ids = _candidate_token_ids(nested)
-                if token_ids:
+                if token_ids is not None:
                     return token_ids
-        value = candidate.get("token_ids")
-        return _copy_int_list(value)
+        if "token_ids" in candidate:
+            return _copy_int_list(candidate.get("token_ids"))
+        return None
 
     value = getattr(candidate, "token_ids", None)
     if value is not None:
@@ -273,9 +558,135 @@ def _candidate_token_ids(candidate: Any) -> list[int]:
     if isinstance(nested_outputs, Sequence) and not isinstance(nested_outputs, (str, bytes)):
         for nested in nested_outputs:
             token_ids = _candidate_token_ids(nested)
-            if token_ids:
+            if token_ids is not None:
                 return token_ids
-    return []
+    return None
+
+
+def _candidate_logps(candidate: Any, *, keys: Sequence[str]) -> Optional[list[float]]:
+    if candidate is None:
+        return None
+    if isinstance(candidate, Mapping):
+        nested_outputs = candidate.get("outputs")
+        if isinstance(nested_outputs, Sequence) and not isinstance(nested_outputs, (str, bytes)):
+            for nested in nested_outputs:
+                logps = _candidate_logps(nested, keys=keys)
+                if logps is not None:
+                    return logps
+        for key in keys:
+            if key in candidate:
+                return _copy_float_list(candidate[key])
+        return None
+
+    nested_outputs = getattr(candidate, "outputs", None)
+    if isinstance(nested_outputs, Sequence) and not isinstance(nested_outputs, (str, bytes)):
+        for nested in nested_outputs:
+            logps = _candidate_logps(nested, keys=keys)
+            if logps is not None:
+                return logps
+    for key in keys:
+        if hasattr(candidate, key):
+            return _copy_float_list(getattr(candidate, key))
+    return None
+
+
+def _candidate_reward(candidate: Any) -> Optional[float]:
+    if candidate is None:
+        return None
+    if isinstance(candidate, Mapping):
+        nested_outputs = candidate.get("outputs")
+        if isinstance(nested_outputs, Sequence) and not isinstance(nested_outputs, (str, bytes)):
+            for nested in nested_outputs:
+                reward = _candidate_reward(nested)
+                if reward is not None:
+                    return reward
+        for key in ("reward", "score", "scalar_reward", "reward_score"):
+            if key in candidate:
+                return _safe_float(candidate[key])
+        return None
+
+    nested_outputs = getattr(candidate, "outputs", None)
+    if isinstance(nested_outputs, Sequence) and not isinstance(nested_outputs, (str, bytes)):
+        for nested in nested_outputs:
+            reward = _candidate_reward(nested)
+            if reward is not None:
+                return reward
+    for attr in ("reward", "score", "scalar_reward", "reward_score"):
+        if hasattr(candidate, attr):
+            return _safe_float(getattr(candidate, attr))
+    return None
+
+
+def _resolve_reward_groups(
+    candidate_groups: Sequence[Sequence[Sequence[int]]],
+    rollout: RolloutStageResult,
+    reward_provider: Optional[RewardProvider],
+) -> tuple[Optional[Sequence[Sequence[float]]], str]:
+    payload_reward_groups = extract_rollout_reward_groups(rollout.payload)
+    if _reward_groups_match(candidate_groups, payload_reward_groups):
+        return payload_reward_groups, "payload_rewards"
+
+    if reward_provider is None:
+        return None, "token_id_proxy"
+
+    provided = reward_provider(candidate_groups, rollout)
+    if not _reward_groups_match(candidate_groups, provided):
+        raise ValueError(
+            "reward_provider must return one scalar reward for every rollout candidate"
+        )
+    return provided, "provider_rewards"
+
+
+def _safe_float(value: Any) -> float:
+    if isinstance(value, torch.Tensor):
+        flat = value.detach().cpu().reshape(-1)
+        if flat.numel() != 1:
+            raise ValueError("rollout reward tensors must contain exactly one value")
+        return float(flat[0].item())
+    return float(value)
+
+
+def _reward_groups_match(
+    candidate_groups: Sequence[Sequence[Sequence[int]]],
+    reward_groups: Sequence[Sequence[float]],
+) -> bool:
+    if len(candidate_groups) != len(reward_groups):
+        return False
+    return all(
+        len(candidates) == len(rewards)
+        for candidates, rewards in zip(candidate_groups, reward_groups, strict=False)
+    )
+
+
+def _logp_groups_match(
+    candidate_groups: Sequence[Sequence[Sequence[int]]],
+    logp_groups: Sequence[Sequence[Sequence[float]]],
+) -> bool:
+    if len(candidate_groups) != len(logp_groups):
+        return False
+    for candidate_group, logp_group in zip(candidate_groups, logp_groups, strict=False):
+        if len(candidate_group) != len(logp_group):
+            return False
+        for token_ids, logps in zip(candidate_group, logp_group, strict=False):
+            if len(token_ids) != len(logps):
+                return False
+    return True
+
+
+def _candidate_reward_value(
+    token_ids: Sequence[int],
+    reward_groups: Optional[Sequence[Sequence[float]]],
+    group_index: int,
+    candidate_index: int,
+    *,
+    vocab_size: int,
+) -> float:
+    if reward_groups is not None:
+        return float(reward_groups[group_index][candidate_index])
+    if not token_ids:
+        return 0.0
+    clipped = [int(token) % vocab_size for token in token_ids]
+    return float(sum(clipped)) / float(max(len(clipped), 1) * max(vocab_size - 1, 1))
 
 
 def _copy_int_list(value: Any) -> list[int]:
@@ -283,4 +694,12 @@ def _copy_int_list(value: Any) -> list[int]:
         return [int(item) for item in value.detach().cpu().reshape(-1).tolist()]
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
         return [int(item) for item in value]
+    return []
+
+
+def _copy_float_list(value: Any) -> list[float]:
+    if isinstance(value, torch.Tensor):
+        return [float(item) for item in value.detach().cpu().reshape(-1).tolist()]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [float(item) for item in value]
     return []

--- a/tests/test_deepspeed_training_worker.py
+++ b/tests/test_deepspeed_training_worker.py
@@ -224,6 +224,62 @@ def test_deepspeed_training_worker_uses_engine_backward_and_step(monkeypatch):
     assert math.isfinite(result.metrics["loss"])
 
 
+def test_deepspeed_training_worker_uses_payload_grpo_inputs(monkeypatch):
+    _install_fake_deepspeed(monkeypatch)
+    from rl_engine.executors.deepspeed_trainer import (
+        DeepSpeedTrainingConfig,
+        DeepSpeedTrainingWorker,
+    )
+
+    worker = DeepSpeedTrainingWorker(
+        DeepSpeedTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=29,
+            require_payload_rewards=True,
+            require_payload_logps=True,
+        )
+    )
+    result = worker.train(
+        RolloutStageResult(
+            iteration=0,
+            weight_version=4,
+            payload={
+                "normalized_outputs": [
+                    [
+                        {
+                            "token_ids": [1, 2],
+                            "reward": 1.0,
+                            "old_logps": [-0.2, -0.3],
+                            "ref_logps": [-0.4, -0.5],
+                        },
+                        {
+                            "token_ids": [3, 4],
+                            "reward": 3.0,
+                            "old_logps": [-1.0, -1.1],
+                            "ref_logps": [-0.8, -0.9],
+                        },
+                    ]
+                ]
+            },
+            started_at=time.perf_counter(),
+            finished_at=time.perf_counter(),
+        )
+    )
+
+    assert result.metrics["training_backend"] == "deepspeed"
+    assert result.metrics["training_data_source"] == "rollout_payload"
+    assert result.metrics["reward_source"] == "payload_rewards"
+    assert result.metrics["logprob_source"] == "payload_logps"
+    assert result.metrics["objective"] == "grpo"
+    assert math.isfinite(result.metrics["loss"])
+
+
 def test_deepspeed_training_worker_synthetic_fallback(monkeypatch):
     _install_fake_deepspeed(monkeypatch)
     from rl_engine.executors.deepspeed_trainer import (

--- a/tests/test_grpo_objective.py
+++ b/tests/test_grpo_objective.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 Kernel-Align Contributors
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from rl_engine.alignment.grpo import (
+    GRPOConfig,
+    broadcast_sequence_advantages,
+    compute_group_relative_advantages,
+    compute_grpo_loss,
+)
+
+
+def test_group_relative_advantages_normalize_each_prompt_group_independently():
+    rewards = torch.tensor([1.0, 3.0, 100.0, 104.0])
+    group_ids = torch.tensor([0, 0, 1, 1])
+
+    advantages = compute_group_relative_advantages(rewards, group_ids=group_ids)
+
+    assert torch.allclose(advantages, torch.tensor([-1.0, 1.0, -1.0, 1.0]))
+    assert torch.allclose(advantages[group_ids == 0].mean(), torch.tensor(0.0))
+    assert torch.allclose(advantages[group_ids == 1].mean(), torch.tensor(0.0))
+
+
+def test_group_relative_advantages_can_infer_contiguous_groups():
+    rewards = torch.tensor([1.0, 3.0, 10.0, 14.0])
+
+    advantages = compute_group_relative_advantages(rewards, num_groups=2)
+
+    assert torch.allclose(advantages, torch.tensor([-1.0, 1.0, -1.0, 1.0]))
+
+
+def test_equal_reward_and_single_sample_groups_are_finite_and_centered():
+    rewards = torch.tensor([5.0, 5.0, 2.0])
+    group_ids = torch.tensor([0, 0, 1])
+
+    advantages = compute_group_relative_advantages(rewards, group_ids=group_ids, num_groups=2)
+
+    assert torch.isfinite(advantages).all()
+    assert torch.equal(advantages, torch.zeros_like(advantages))
+
+
+def test_broadcast_sequence_advantages_masks_inactive_completion_tokens():
+    sequence_advantages = torch.tensor([2.0, -1.0])
+    completion_mask = torch.tensor([[True, False, True], [False, True, True]])
+
+    token_advantages = broadcast_sequence_advantages(sequence_advantages, completion_mask)
+
+    assert torch.equal(
+        token_advantages,
+        torch.tensor([[2.0, 0.0, 2.0], [0.0, -1.0, -1.0]]),
+    )
+
+
+def test_grpo_loss_matches_direct_pytorch_reference_and_masks_inactive_tokens():
+    current = torch.tensor(
+        [
+            [0.10, 0.20, 0.30],
+            [0.00, -0.10, -0.20],
+            [0.40, 0.30, 0.20],
+            [-0.30, -0.20, -0.10],
+        ],
+        dtype=torch.float32,
+    )
+    old = current.detach() - 0.05
+    ref = current.detach() - 0.02
+    rewards = torch.tensor([1.0, 3.0, 10.0, 14.0])
+    group_ids = torch.tensor([0, 0, 1, 1])
+    mask = torch.tensor(
+        [
+            [True, True, False],
+            [True, False, False],
+            [False, True, True],
+            [True, True, True],
+        ]
+    )
+    config = GRPOConfig(clip_epsilon=0.2, kl_beta=0.03)
+
+    result = compute_grpo_loss(
+        current,
+        old,
+        ref,
+        rewards,
+        mask,
+        group_ids=group_ids,
+        config=config,
+    )
+
+    sequence_advantages = torch.tensor([-1.0, 1.0, -1.0, 1.0])
+    advantages = sequence_advantages.unsqueeze(-1).expand_as(current).masked_fill(~mask, 0.0)
+    ratio = torch.exp(current - old).masked_fill(~mask, 0.0)
+    unclipped = ratio * advantages
+    clipped = torch.clamp(ratio, 0.8, 1.2) * advantages
+    policy_loss = -torch.minimum(unclipped, clipped).masked_fill(~mask, 0.0)
+    diff = ref - current
+    kl = (torch.exp(diff) - diff - 1.0).masked_fill(~mask, 0.0)
+    expected = (policy_loss + config.kl_beta * kl).sum() / mask.sum()
+
+    assert torch.allclose(result.sequence_advantages, sequence_advantages)
+    assert torch.equal(result.advantages[~mask], torch.zeros_like(result.advantages[~mask]))
+    assert torch.allclose(result.ratio[~mask], torch.zeros_like(result.ratio[~mask]))
+    assert torch.allclose(result.kl[~mask], torch.zeros_like(result.kl[~mask]))
+    assert torch.allclose(result.loss, expected)
+    assert result.metrics["active_tokens"] == float(mask.sum().item())
+    assert result.metrics["loss_reduction"] == "global_token_mean"
+
+
+def test_grpo_loss_sequence_mean_is_explicit_and_differs_on_ragged_completions():
+    current = torch.zeros((2, 3), dtype=torch.float32)
+    old = torch.zeros_like(current)
+    ref = torch.zeros_like(current)
+    rewards = torch.tensor([1.0, 3.0])
+    mask = torch.tensor(
+        [
+            [True, False, False],
+            [True, True, True],
+        ]
+    )
+
+    global_result = compute_grpo_loss(
+        current,
+        old,
+        ref,
+        rewards,
+        mask,
+        num_groups=1,
+        config=GRPOConfig(kl_beta=0.0),
+    )
+    sequence_result = compute_grpo_loss(
+        current,
+        old,
+        ref,
+        rewards,
+        mask,
+        num_groups=1,
+        config=GRPOConfig(kl_beta=0.0, loss_reduction="sequence_mean"),
+    )
+
+    assert torch.allclose(global_result.loss, torch.tensor(-0.5))
+    assert torch.allclose(global_result.policy_loss, torch.tensor(-0.5))
+    assert torch.allclose(sequence_result.loss, torch.tensor(0.0))
+    assert torch.allclose(sequence_result.policy_loss, torch.tensor(0.0))
+    assert global_result.metrics["loss_reduction"] == "global_token_mean"
+    assert sequence_result.metrics["loss_reduction"] == "sequence_mean"
+    assert global_result.metrics["active_sequences"] == 2.0
+    assert sequence_result.metrics["active_tokens"] == 4.0
+
+
+def test_grpo_config_rejects_unknown_loss_reduction():
+    with pytest.raises(ValueError, match="loss_reduction"):
+        GRPOConfig(loss_reduction="batch_mean")
+
+
+def test_grpo_loss_only_backpropagates_through_current_logps():
+    current = torch.tensor(
+        [[0.10, 0.20], [0.05, -0.15], [0.30, 0.40], [-0.20, -0.10]],
+        requires_grad=True,
+    )
+    old = torch.zeros_like(current, requires_grad=True)
+    ref = torch.zeros_like(current, requires_grad=True)
+    rewards = torch.tensor([1.0, 3.0, 2.0, 6.0], requires_grad=True)
+    mask = torch.ones_like(current, dtype=torch.bool)
+
+    result = compute_grpo_loss(current, old, ref, rewards, mask, num_groups=2)
+    result.loss.backward()
+
+    assert current.grad is not None
+    assert current.grad.abs().sum() > 0
+    assert old.grad is None
+    assert ref.grad is None
+    assert rewards.grad is None
+
+
+def test_grpo_loss_rejects_shape_mismatches_and_empty_masks():
+    current = torch.zeros(2, 3)
+    old = torch.zeros(2, 3)
+    ref = torch.zeros(2, 3)
+    rewards = torch.ones(2)
+    mask = torch.ones(2, 3, dtype=torch.bool)
+
+    with pytest.raises(ValueError, match="old_logps shape"):
+        compute_grpo_loss(current, torch.zeros(2, 2), ref, rewards, mask, num_groups=1)
+
+    with pytest.raises(ValueError, match="completion_mask must contain"):
+        compute_grpo_loss(current, old, ref, rewards, torch.zeros_like(mask), num_groups=1)
+
+    with pytest.raises(ValueError, match="divisible by num_groups"):
+        compute_grpo_loss(current, old, ref, rewards, mask, num_groups=3)
+
+
+def test_group_relative_advantages_reject_invalid_group_ids():
+    rewards = torch.ones(3)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        compute_group_relative_advantages(rewards, group_ids=torch.tensor([0, -1, 1]))
+
+    with pytest.raises(ValueError, match="has no rewards"):
+        compute_group_relative_advantages(
+            rewards,
+            group_ids=torch.tensor([0, 0, 2]),
+            num_groups=3,
+        )

--- a/tests/test_overlap_pipeline.py
+++ b/tests/test_overlap_pipeline.py
@@ -7,8 +7,10 @@ import math
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 
 import pytest
+import torch
 
 from rl_engine.executors.overlap_pipeline import (
     IterationSpec,
@@ -21,7 +23,12 @@ from rl_engine.executors.overlap_pipeline import (
     TorchRLTrainingConfig,
     TorchRLTrainingWorker,
     TrainingStageResult,
+    extract_rollout_candidate_groups,
     extract_rollout_token_groups,
+)
+from rl_engine.executors.training_contract import (
+    compute_training_grpo_objective,
+    extract_rollout_logp_groups,
 )
 
 
@@ -380,8 +387,378 @@ def test_torch_rl_training_worker_runs_real_optimizer_step():
     assert result.metrics["training_data_source"] == "rollout_payload"
     assert result.metrics["rollout_sequences"] == 2
     assert result.metrics["rollout_tokens"] == 6
+    assert result.metrics["reward_source"] == "token_id_proxy"
     assert math.isfinite(result.metrics["loss"])
     assert result.metrics["active_tokens"] == 6
+    assert result.metrics["objective"] == "grpo"
+
+
+def test_torch_rl_training_worker_uses_payload_rewards_for_grpo_groups():
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=7,
+        )
+    )
+    rollout = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={
+            "normalized_outputs": [
+                [
+                    {"token_ids": [1, 2], "reward": 1.0},
+                    {"token_ids": [3, 4], "reward": 3.0},
+                ]
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    result = worker.train(rollout)
+
+    assert result.metrics["training_data_source"] == "rollout_payload"
+    assert result.metrics["reward_source"] == "payload_rewards"
+    assert result.metrics["rollout_prompt_groups"] == 1
+    assert result.metrics["rollout_sequences"] == 2
+    assert result.metrics["advantage_mean"] == pytest.approx(0.0, abs=1e-6)
+    assert result.metrics["advantage_std"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_training_grpo_uses_payload_old_and_reference_logps_as_fixed_inputs():
+    config = TorchRLTrainingConfig(
+        num_prompts=1,
+        samples_per_prompt=2,
+        prompt_len=1,
+        completion_len=2,
+        vocab_size=16,
+        hidden_dim=8,
+        valid_density=1.0,
+        seed=11,
+        require_payload_rewards=True,
+        require_payload_logps=True,
+        kl_beta=0.4,
+    )
+    worker = TorchRLTrainingWorker(config)
+    rollout = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={
+            "normalized_outputs": [
+                [
+                    {
+                        "token_ids": [1, 2],
+                        "reward": 1.0,
+                        "old_logps": [-0.20, -0.30],
+                        "reference_logprobs": [-0.40, -0.50],
+                    },
+                    {
+                        "token_ids": [3, 4],
+                        "reward": 3.0,
+                        "old_selected_logprobs": [-1.20, -1.00],
+                        "ref_selected_logps": [-0.80, -0.90],
+                    },
+                ]
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    batch, metrics = worker._batch_from_rollout_or_synthetic(rollout)
+    logits = torch.zeros((2, 2, config.vocab_size), requires_grad=True)
+    batch.old_logps.requires_grad_()
+    batch.ref_logps.requires_grad_()
+
+    payload_result = compute_training_grpo_objective(logits, batch, config)
+    smoke_batch = replace(batch, metadata={**batch.metadata, "logprob_source": "smoke_logps"})
+    smoke_result = compute_training_grpo_objective(logits.detach().clone(), smoke_batch, config)
+    payload_result.loss.backward()
+
+    assert metrics["reward_source"] == "payload_rewards"
+    assert metrics["logprob_source"] == "payload_logps"
+    assert batch.metadata["logprob_source"] == "payload_logps"
+    assert torch.allclose(batch.old_logps, torch.tensor([[-0.20, -0.30], [-1.20, -1.00]]))
+    assert torch.allclose(batch.ref_logps, torch.tensor([[-0.40, -0.50], [-0.80, -0.90]]))
+    assert payload_result.metrics["logprob_source"] == "payload_logps"
+    assert not torch.allclose(payload_result.loss.detach(), smoke_result.loss.detach())
+    assert logits.grad is not None
+    assert logits.grad.abs().sum() > 0
+    assert batch.old_logps.grad is None
+    assert batch.ref_logps.grad is None
+
+
+def test_torch_rl_training_worker_strict_logps_reject_missing_or_mismatched_payload():
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=12,
+            require_payload_logps=True,
+        )
+    )
+    missing_ref = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={
+            "normalized_outputs": [
+                [
+                    {"token_ids": [1], "old_logps": [-0.1]},
+                    {"token_ids": [2], "old_logps": [-0.2]},
+                ]
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+    mismatched_lengths = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={
+            "normalized_outputs": [
+                [
+                    {
+                        "token_ids": [1, 2],
+                        "old_logps": [-0.1],
+                        "ref_logps": [-0.2, -0.3],
+                    },
+                    {
+                        "token_ids": [3],
+                        "old_logps": [-0.4],
+                        "ref_logps": [-0.5],
+                    },
+                ]
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    with pytest.raises(ValueError, match="old/ref selected logprobs"):
+        worker.train(missing_ref)
+    with pytest.raises(ValueError, match="old/ref selected logprobs"):
+        worker.train(mismatched_lengths)
+
+
+def test_torch_rl_training_worker_uses_reward_provider_when_payload_rewards_are_absent():
+    calls = []
+
+    def reward_provider(candidate_groups, rollout):
+        calls.append((candidate_groups, rollout.iteration))
+        return [[1.0, 5.0]]
+
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=13,
+            reward_provider=reward_provider,
+            require_payload_rewards=True,
+        )
+    )
+    rollout = RolloutStageResult(
+        iteration=7,
+        weight_version=4,
+        payload={"normalized_outputs": [[{"token_ids": [1, 2]}, {"token_ids": [3, 4]}]]},
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    batch, metrics = worker._batch_from_rollout_or_synthetic(rollout)
+
+    assert calls == [([[[1, 2], [3, 4]]], 7)]
+    assert metrics["reward_source"] == "provider_rewards"
+    assert batch.metadata["reward_source"] == "provider_rewards"
+    assert torch.allclose(batch.rewards, torch.tensor([1.0, 5.0]))
+
+
+def test_torch_rl_training_worker_rejects_malformed_reward_provider_output():
+    def reward_provider(candidate_groups, rollout):
+        del candidate_groups, rollout
+        return [[1.0]]
+
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=14,
+            reward_provider=reward_provider,
+        )
+    )
+    rollout = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={"normalized_outputs": [[{"token_ids": [1]}, {"token_ids": [2]}]]},
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    with pytest.raises(ValueError, match="reward_provider must return one scalar reward"):
+        worker.train(rollout)
+
+
+def test_torch_rl_training_worker_preserves_empty_completions_with_payload_rewards():
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=8,
+            require_payload_rewards=True,
+        )
+    )
+    rollout = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={
+            "normalized_outputs": [
+                [
+                    {"token_ids": [], "reward": 0.0},
+                    {"token_ids": [5], "reward": 2.0},
+                ]
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    result = worker.train(rollout)
+
+    assert result.metrics["training_data_source"] == "rollout_payload"
+    assert result.metrics["reward_source"] == "payload_rewards"
+    assert result.metrics["rollout_prompt_groups"] == 1
+    assert result.metrics["rollout_sequences"] == 2
+    assert result.metrics["rollout_tokens"] == 1
+    assert result.metrics["active_tokens"] == 1
+    assert result.metrics["advantage_mean"] == pytest.approx(0.0, abs=1e-6)
+    assert result.metrics["advantage_std"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_torch_rl_training_worker_accepts_empty_completion_payload_logps():
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=15,
+            require_payload_rewards=True,
+            require_payload_logps=True,
+        )
+    )
+    rollout = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={
+            "normalized_outputs": [
+                [
+                    {"token_ids": [], "reward": 0.0, "old_logps": [], "ref_logps": []},
+                    {
+                        "token_ids": [5],
+                        "reward": 2.0,
+                        "old_logps": [-0.4],
+                        "ref_logps": [-0.6],
+                    },
+                ]
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    result = worker.train(rollout)
+
+    assert result.metrics["reward_source"] == "payload_rewards"
+    assert result.metrics["logprob_source"] == "payload_logps"
+    assert result.metrics["rollout_tokens"] == 1
+    assert result.metrics["active_tokens"] == 1
+
+
+def test_torch_rl_training_worker_strict_rewards_reject_missing_rewards():
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=9,
+            require_payload_rewards=True,
+        )
+    )
+    rollout = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={
+            "normalized_outputs": [
+                [
+                    {"token_ids": [1], "reward": 1.0},
+                    {"token_ids": [2]},
+                ]
+            ]
+        },
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    with pytest.raises(ValueError, match="requires one scalar reward"):
+        worker.train(rollout)
+
+
+def test_torch_rl_training_worker_strict_rewards_reject_synthetic_fallback():
+    worker = TorchRLTrainingWorker(
+        TorchRLTrainingConfig(
+            num_prompts=1,
+            samples_per_prompt=2,
+            prompt_len=1,
+            completion_len=2,
+            vocab_size=16,
+            hidden_dim=8,
+            valid_density=1.0,
+            seed=10,
+            require_payload_rewards=True,
+        )
+    )
+    rollout = RolloutStageResult(
+        iteration=0,
+        weight_version=4,
+        payload={"prompts": ["no candidates"]},
+        started_at=time.perf_counter(),
+        finished_at=time.perf_counter(),
+    )
+
+    with pytest.raises(ValueError, match="requires rollout payload candidate groups"):
+        worker.train(rollout)
 
 
 def test_extract_rollout_token_groups_from_normalized_payload():
@@ -393,3 +770,52 @@ def test_extract_rollout_token_groups_from_normalized_payload():
     }
 
     assert extract_rollout_token_groups(payload) == [[1, 2], [3], [4, 5, 6]]
+
+
+def test_extract_rollout_candidate_groups_preserves_prompt_boundaries():
+    payload = {
+        "normalized_outputs": [
+            [{"token_ids": [1, 2]}, {"token_ids": [3]}],
+            [{"outputs": [{"token_ids": [4, 5, 6]}]}],
+        ]
+    }
+
+    assert extract_rollout_candidate_groups(payload) == [[[1, 2], [3]], [[4, 5, 6]]]
+
+
+def test_extract_rollout_candidate_groups_preserves_empty_completions():
+    payload = {
+        "normalized_outputs": [
+            [{"token_ids": []}, {"token_ids": [3]}],
+            [{"outputs": [{"token_ids": []}]}],
+        ]
+    }
+
+    assert extract_rollout_candidate_groups(payload) == [[[], [3]], [[]]]
+    assert extract_rollout_token_groups(payload) == [[], [3], []]
+
+
+def test_extract_rollout_logp_groups_supports_nested_aliases_and_empty_vectors():
+    payload = {
+        "outputs": [
+            [
+                {
+                    "outputs": [
+                        {
+                            "token_ids": [1, 2],
+                            "old_policy_logprobs": [-0.1, -0.2],
+                            "reference_selected_logprobs": [-0.3, -0.4],
+                        }
+                    ]
+                },
+                {"token_ids": [], "old_logps": [], "ref_logps": []},
+            ]
+        ]
+    }
+
+    assert extract_rollout_logp_groups(payload, keys=("old_logps", "old_policy_logprobs")) == [
+        [[-0.1, -0.2], []]
+    ]
+    assert extract_rollout_logp_groups(
+        payload, keys=("ref_logps", "reference_selected_logprobs")
+    ) == [[[-0.3, -0.4], []]]


### PR DESCRIPTION
## Summary

- Add a reusable production-facing GRPO objective module with group-relative reward normalization and clipped policy loss.
- Extend the rollout/training contract to consume production GRPO inputs:
  old-policy logprobs, reference-policy logprobs, payload/provider rewards, and prompt group ids.
- Make GRPO loss reduction semantics explicit:
  `global_token_mean` remains the default, and `sequence_mean` is available as an opt-in mode.
- Wire Torch and DeepSpeed training workers through the shared GRPO objective instead of relying on synthetic/demo-only advantage paths.
- Add focused tests and benchmarks covering grouped reward normalization, payload rewards, strict validation, loss reductions, and worker integration.

## Issues Covered

Closes #16.
Closes #63.
Closes #64.

## Why this PR is stacked

This PR is stacked on top of #61 (`feat: add overlapping rollout training pipeline`), which itself depends on #60 (`feat: zero copy weight bridge`).

The dependency chain is:

- #60 zero-copy weight bridge
- #61 overlap rollout training pipeline
- this PR: production GRPO objective, production GRPO inputs, and explicit reduction semantics

This keeps the review focused on the GRPO objective layer while reusing the already-built bridge and rollout/training pipeline.

## Main changes

- Add `rl_engine/alignment/grpo.py`
- Export the public GRPO API from `rl_engine/alignment/__init__.py`
- Integrate GRPO objective usage into:
  - `rl_engine/executors/training_contract.py`
  - `rl_engine/executors/overlap_pipeline.py`
  - `rl_engine/executors/deepspeed_trainer.py`
- Add focused coverage in:
  - `tests/test_grpo_objective.py`
  - `tests/test_overlap_pipeline.py`
  - `tests/test_deepspeed_training_worker.py`
- Add `benchmarks/benchmark_grpo_objective.py`

## Validation

- `pre-commit run --files rl_engine/alignment/__init__.py rl_engine/alignment/grpo.py rl_engine/executors/training_contract.py rl_engine/executors/overlap_pipeline.py rl_engine/executors/deepspeed_trainer.py tests/test_grpo_objective.py tests/test_overlap_pipeline.py tests/test_deepspeed_training_worker.py benchmarks/benchmark_grpo_objective.py`
- `py -3.13 -m mypy --ignore-missing-imports rl_engine`
- `py -3.13 -m pytest tests -q`
- `py -3.13 -m pytest rl_engine/tests/test_dispatch.py -v`
- `py -3.13 -m mkdocs build --strict -f mkdocs.yaml`

## Results

- Full test suite: `136 passed`
- Dispatch parity test: `3 passed`
- MyPy: passed
- MkDocs strict build: passed

## Notes

- The review base should remain the overlap pipeline branch so the diff does not include the bridge or pipeline prerequisite work again.