### PR TITLE
[FEAT][alignment]: add policy and reference model wrappers

### DIFF
--- a/rl_engine/alignment/__init__.py
+++ b/rl_engine/alignment/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from rl_engine.alignment.model_wrappers import (
+    PolicyModelWrapper,
+    ReferenceModelWrapper,
+    extract_logits,
+)
+
+__all__ = [
+    "PolicyModelWrapper",
+    "ReferenceModelWrapper",
+    "extract_logits",
+]

--- a/rl_engine/alignment/model_wrappers.py
+++ b/rl_engine/alignment/model_wrappers.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Optional
+
+import torch
+
+from rl_engine.testing import selected_logprobs_reference
+
+
+def _require_tensor(value: Any, source: str) -> torch.Tensor:
+    if isinstance(value, torch.Tensor):
+        return value
+    raise TypeError(f"{source} must be a torch.Tensor, got {type(value)!r}")
+
+
+def extract_logits(model_output: Any) -> torch.Tensor:
+    """Extract logits from common model output shapes."""
+
+    if isinstance(model_output, torch.Tensor):
+        return model_output
+
+    if isinstance(model_output, Mapping):
+        if "logits" not in model_output:
+            raise TypeError("model output mapping does not contain a 'logits' entry")
+        return _require_tensor(model_output["logits"], "model output['logits']")
+
+    logits = getattr(model_output, "logits", None)
+    if logits is not None:
+        return _require_tensor(logits, "model output.logits")
+
+    if isinstance(model_output, (tuple, list)) and model_output:
+        return extract_logits(model_output[0])
+
+    raise TypeError(f"model output does not expose logits: {type(model_output)!r}")
+
+
+class PolicyModelWrapper(torch.nn.Module):
+    """Standard adapter for the trainable policy model used by RL losses."""
+
+    def __init__(self, model: torch.nn.Module):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids: torch.Tensor, **model_kwargs: Any) -> Any:
+        return self.model(input_ids, **model_kwargs)
+
+    def forward_logits(self, input_ids: torch.Tensor, **model_kwargs: Any) -> torch.Tensor:
+        return extract_logits(self.forward(input_ids, **model_kwargs))
+
+    def selected_logprobs(
+        self,
+        input_ids: torch.Tensor,
+        token_ids: torch.Tensor,
+        *,
+        mask: Optional[torch.Tensor] = None,
+        temperature: float = 1.0,
+        output_dtype: torch.dtype = torch.float32,
+        **model_kwargs: Any,
+    ) -> torch.Tensor:
+        logits = self.forward_logits(input_ids, **model_kwargs)
+        return selected_logprobs_reference(
+            logits,
+            token_ids,
+            mask=mask,
+            temperature=temperature,
+            output_dtype=output_dtype,
+        )
+
+
+class ReferenceModelWrapper(PolicyModelWrapper):
+    """Standard adapter for the frozen reference model used by KL penalties."""
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        *,
+        freeze: bool = True,
+        eval_mode: bool = True,
+    ):
+        super().__init__(model)
+        if freeze:
+            self.freeze()
+        if eval_mode:
+            self.eval()
+
+    def freeze(self) -> "ReferenceModelWrapper":
+        for parameter in self.model.parameters():
+            parameter.requires_grad_(False)
+        return self
+
+    def forward_logits(self, input_ids: torch.Tensor, **model_kwargs: Any) -> torch.Tensor:
+        with torch.no_grad():
+            return super().forward_logits(input_ids, **model_kwargs)
+
+    def selected_logprobs(
+        self,
+        input_ids: torch.Tensor,
+        token_ids: torch.Tensor,
+        *,
+        mask: Optional[torch.Tensor] = None,
+        temperature: float = 1.0,
+        output_dtype: torch.dtype = torch.float32,
+        **model_kwargs: Any,
+    ) -> torch.Tensor:
+        with torch.no_grad():
+            return super().selected_logprobs(
+                input_ids,
+                token_ids,
+                mask=mask,
+                temperature=temperature,
+                output_dtype=output_dtype,
+                **model_kwargs,
+            )

--- a/rl_engine/alignment/model_wrappers.py
+++ b/rl_engine/alignment/model_wrappers.py
@@ -17,6 +17,26 @@ def _require_tensor(value: Any, source: str) -> torch.Tensor:
     raise TypeError(f"{source} must be a torch.Tensor, got {type(value)!r}")
 
 
+def _has_logits_rank(value: torch.Tensor) -> bool:
+    return value.ndim >= 2
+
+
+def _slice_logits(
+    logits: torch.Tensor,
+    *,
+    logits_start: Optional[int] = None,
+    logits_end: Optional[int] = None,
+) -> torch.Tensor:
+    if logits_start is None and logits_end is None:
+        return logits
+    if logits.ndim < 2:
+        raise ValueError("logits must have at least two dimensions to slice token positions")
+
+    index = [slice(None)] * logits.ndim
+    index[-2] = slice(logits_start, logits_end)
+    return logits[tuple(index)]
+
+
 def extract_logits(model_output: Any) -> torch.Tensor:
     """Extract logits from common model output shapes."""
 
@@ -33,7 +53,23 @@ def extract_logits(model_output: Any) -> torch.Tensor:
         return _require_tensor(logits, "model output.logits")
 
     if isinstance(model_output, (tuple, list)) and model_output:
-        return extract_logits(model_output[0])
+        last_error: Optional[Exception] = None
+        for index, item in enumerate(model_output):
+            try:
+                candidate = extract_logits(item)
+            except TypeError as exc:
+                last_error = exc
+                continue
+            if not _has_logits_rank(candidate):
+                last_error = TypeError(
+                    f"model output sequence item {index} has too few dimensions for logits"
+                )
+                continue
+            return candidate
+        message = "model output sequence does not contain a logits tensor"
+        if last_error is not None:
+            message = f"{message}: {last_error}"
+        raise TypeError(message)
 
     raise TypeError(f"model output does not expose logits: {type(model_output)!r}")
 
@@ -57,11 +93,14 @@ class PolicyModelWrapper(torch.nn.Module):
         token_ids: torch.Tensor,
         *,
         mask: Optional[torch.Tensor] = None,
+        logits_start: Optional[int] = None,
+        logits_end: Optional[int] = None,
         temperature: float = 1.0,
         output_dtype: torch.dtype = torch.float32,
         **model_kwargs: Any,
     ) -> torch.Tensor:
         logits = self.forward_logits(input_ids, **model_kwargs)
+        logits = _slice_logits(logits, logits_start=logits_start, logits_end=logits_end)
         return selected_logprobs_reference(
             logits,
             token_ids,
@@ -102,6 +141,8 @@ class ReferenceModelWrapper(PolicyModelWrapper):
         token_ids: torch.Tensor,
         *,
         mask: Optional[torch.Tensor] = None,
+        logits_start: Optional[int] = None,
+        logits_end: Optional[int] = None,
         temperature: float = 1.0,
         output_dtype: torch.dtype = torch.float32,
         **model_kwargs: Any,
@@ -111,6 +152,8 @@ class ReferenceModelWrapper(PolicyModelWrapper):
                 input_ids,
                 token_ids,
                 mask=mask,
+                logits_start=logits_start,
+                logits_end=logits_end,
                 temperature=temperature,
                 output_dtype=output_dtype,
                 **model_kwargs,

--- a/rl_engine/testing/reference_ops.py
+++ b/rl_engine/testing/reference_ops.py
@@ -31,12 +31,18 @@ def selected_logprobs_reference(
     if mask is not None and mask.shape != token_ids.shape:
         raise ValueError(f"mask shape {tuple(mask.shape)} must match token_ids shape")
 
+    gather_token_ids = token_ids.long()
+    active_mask = None
+    if mask is not None:
+        active_mask = _bool_mask(mask, device=token_ids.device)
+        gather_token_ids = gather_token_ids.masked_fill(~active_mask, 0)
+
     scaled_logits = logits.float() / float(temperature)
     log_probs = torch.log_softmax(scaled_logits, dim=-1)
-    selected = torch.gather(log_probs, dim=-1, index=token_ids.long().unsqueeze(-1)).squeeze(-1)
+    selected = torch.gather(log_probs, dim=-1, index=gather_token_ids.unsqueeze(-1)).squeeze(-1)
 
-    if mask is not None:
-        selected = selected.masked_fill(~_bool_mask(mask, device=selected.device), 0.0)
+    if active_mask is not None:
+        selected = selected.masked_fill(~active_mask.to(device=selected.device), 0.0)
 
     return selected.to(dtype=output_dtype)
 

--- a/tests/test_alignment_model_wrappers.py
+++ b/tests/test_alignment_model_wrappers.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+
+from rl_engine.alignment import PolicyModelWrapper, ReferenceModelWrapper, extract_logits
+from rl_engine.testing import selected_logprobs_reference
+
+
+@dataclass
+class ObjectOutput:
+    logits: torch.Tensor
+
+
+class FixedLogitsModel(torch.nn.Module):
+    def __init__(self, logits: torch.Tensor, *, output_kind: str = "tensor"):
+        super().__init__()
+        self.output_kind = output_kind
+        self.weight = torch.nn.Parameter(torch.tensor(1.0))
+        self.register_buffer("base_logits", logits.clone())
+
+    def forward(self, input_ids: torch.Tensor, *, logit_bias: float = 0.0):
+        del input_ids
+        logits = self.base_logits * self.weight + float(logit_bias)
+        if self.output_kind == "tensor":
+            return logits
+        if self.output_kind == "mapping":
+            return {"logits": logits}
+        if self.output_kind == "object":
+            return ObjectOutput(logits)
+        if self.output_kind == "tuple":
+            return (logits, {"hidden_states": None})
+        raise AssertionError(f"unknown output kind: {self.output_kind}")
+
+
+@pytest.mark.parametrize("output_kind", ("tensor", "mapping", "object", "tuple"))
+def test_extract_logits_accepts_common_model_outputs(output_kind: str):
+    logits = torch.randn(2, 3, 5)
+    model = FixedLogitsModel(logits, output_kind=output_kind)
+
+    actual = extract_logits(model(torch.zeros(2, 3, dtype=torch.long)))
+
+    assert torch.allclose(actual, logits)
+
+
+def test_extract_logits_rejects_missing_or_invalid_logits():
+    with pytest.raises(TypeError, match="logits"):
+        extract_logits({"hidden_states": torch.randn(1, 2)})
+
+    with pytest.raises(TypeError, match="torch.Tensor"):
+        extract_logits(ObjectOutput(logits="not-a-tensor"))
+
+
+def test_policy_wrapper_keeps_model_trainable():
+    model = FixedLogitsModel(torch.randn(2, 3, 7))
+
+    PolicyModelWrapper(model)
+
+    assert any(parameter.requires_grad for parameter in model.parameters())
+    assert model.training is True
+
+
+def test_reference_wrapper_freezes_and_evals_model():
+    model = FixedLogitsModel(torch.randn(2, 3, 7))
+    model.train()
+
+    wrapper = ReferenceModelWrapper(model)
+
+    assert wrapper.training is False
+    assert model.training is False
+    assert all(not parameter.requires_grad for parameter in model.parameters())
+
+
+def test_policy_wrapper_selected_logprobs_matches_reference():
+    logits = torch.randn(2, 3, 7)
+    token_ids = torch.tensor([[0, 1, 2], [3, 4, 5]])
+    mask = torch.tensor([[True, False, True], [True, True, False]])
+    input_ids = torch.zeros_like(token_ids)
+    model = FixedLogitsModel(logits, output_kind="mapping")
+    wrapper = PolicyModelWrapper(model)
+
+    actual = wrapper.selected_logprobs(input_ids, token_ids, mask=mask, logit_bias=0.5)
+    expected_logits = model(input_ids, logit_bias=0.5)["logits"]
+    expected = selected_logprobs_reference(expected_logits, token_ids, mask=mask)
+
+    assert torch.allclose(actual, expected)
+    assert torch.equal(actual[~mask], torch.zeros_like(actual[~mask]))
+
+
+def test_policy_wrapper_selected_logprobs_preserves_gradient():
+    logits = torch.randn(2, 3, 7)
+    token_ids = torch.tensor([[0, 1, 2], [3, 4, 5]])
+    input_ids = torch.zeros_like(token_ids)
+    model = FixedLogitsModel(logits)
+    wrapper = PolicyModelWrapper(model)
+
+    logps = wrapper.selected_logprobs(input_ids, token_ids)
+    loss = logps.sum()
+    loss.backward()
+
+    assert logps.requires_grad is True
+    assert model.weight.grad is not None
+
+
+def test_reference_wrapper_selected_logprobs_does_not_track_gradient():
+    logits = torch.randn(2, 3, 7)
+    token_ids = torch.tensor([[0, 1, 2], [3, 4, 5]])
+    input_ids = torch.zeros_like(token_ids)
+    model = FixedLogitsModel(logits)
+    wrapper = ReferenceModelWrapper(model)
+
+    logps = wrapper.selected_logprobs(input_ids, token_ids)
+
+    assert logps.requires_grad is False
+    assert all(parameter.grad is None for parameter in model.parameters())

--- a/tests/test_alignment_model_wrappers.py
+++ b/tests/test_alignment_model_wrappers.py
@@ -35,6 +35,8 @@ class FixedLogitsModel(torch.nn.Module):
             return ObjectOutput(logits)
         if self.output_kind == "tuple":
             return (logits, {"hidden_states": None})
+        if self.output_kind == "loss_tuple":
+            return (logits.sum(), logits, {"hidden_states": None})
         raise AssertionError(f"unknown output kind: {self.output_kind}")
 
 
@@ -54,6 +56,20 @@ def test_extract_logits_rejects_missing_or_invalid_logits():
 
     with pytest.raises(TypeError, match=r"torch\.Tensor"):
         extract_logits(ObjectOutput(logits="not-a-tensor"))
+
+
+def test_extract_logits_accepts_loss_first_tuple_outputs():
+    logits = torch.randn(2, 3, 5)
+    model = FixedLogitsModel(logits, output_kind="loss_tuple")
+
+    actual = extract_logits(model(torch.zeros(2, 3, dtype=torch.long)))
+
+    assert torch.allclose(actual, logits)
+
+
+def test_extract_logits_rejects_tuple_without_logits_tensor():
+    with pytest.raises(TypeError, match="does not contain a logits tensor"):
+        extract_logits((torch.tensor(1.0), {"hidden_states": torch.randn(1, 2)}))
 
 
 def test_policy_wrapper_keeps_model_trainable():
@@ -90,6 +106,33 @@ def test_policy_wrapper_selected_logprobs_matches_reference():
 
     assert torch.allclose(actual, expected)
     assert torch.equal(actual[~mask], torch.zeros_like(actual[~mask]))
+
+
+def test_policy_wrapper_selected_logprobs_supports_logits_slice():
+    logits = torch.randn(2, 5, 7)
+    token_ids = torch.tensor([[0, 1, 2], [3, 4, 5]])
+    mask = torch.tensor([[True, True, False], [True, False, True]])
+    input_ids = torch.zeros(2, 5, dtype=torch.long)
+    model = FixedLogitsModel(logits)
+    wrapper = PolicyModelWrapper(model)
+
+    actual = wrapper.selected_logprobs(input_ids, token_ids, mask=mask, logits_start=2)
+    expected = selected_logprobs_reference(logits[:, 2:, :], token_ids, mask=mask)
+
+    assert torch.allclose(actual, expected)
+
+
+def test_policy_wrapper_selected_logprobs_accepts_masked_ignore_index():
+    logits = torch.randn(1, 3, 7)
+    token_ids = torch.tensor([[0, -100, 2]])
+    mask = torch.tensor([[True, False, True]])
+    input_ids = torch.zeros_like(token_ids)
+    model = FixedLogitsModel(logits)
+    wrapper = PolicyModelWrapper(model)
+
+    actual = wrapper.selected_logprobs(input_ids, token_ids, mask=mask)
+
+    assert actual[0, 1] == 0.0
 
 
 def test_policy_wrapper_selected_logprobs_preserves_gradient():

--- a/tests/test_alignment_model_wrappers.py
+++ b/tests/test_alignment_model_wrappers.py
@@ -52,7 +52,7 @@ def test_extract_logits_rejects_missing_or_invalid_logits():
     with pytest.raises(TypeError, match="logits"):
         extract_logits({"hidden_states": torch.randn(1, 2)})
 
-    with pytest.raises(TypeError, match="torch.Tensor"):
+    with pytest.raises(TypeError, match=r"torch\.Tensor"):
         extract_logits(ObjectOutput(logits="not-a-tensor"))
 
 

--- a/tests/test_reference_ops.py
+++ b/tests/test_reference_ops.py
@@ -39,6 +39,24 @@ def test_selected_logprobs_reference_mask_and_dtype():
     assert torch.equal(actual[~mask], torch.zeros_like(actual[~mask]))
 
 
+def test_selected_logprobs_reference_allows_ignore_index_when_masked_out():
+    logits = torch.randn(1, 3, 6)
+    token_ids = torch.tensor([[1, -100, 2]])
+    mask = torch.tensor([[True, False, True]])
+
+    actual = selected_logprobs_reference(logits, token_ids, mask=mask)
+    safe_token_ids = token_ids.masked_fill(~mask, 0)
+    expected = (
+        torch.log_softmax(logits.float(), dim=-1)
+        .gather(-1, safe_token_ids.unsqueeze(-1))
+        .squeeze(-1)
+        .masked_fill(~mask, 0.0)
+    )
+
+    assert torch.allclose(actual, expected)
+    assert actual[0, 1] == 0.0
+
+
 def test_selected_logprobs_reference_temperature():
     logits = torch.tensor([[1.0, 3.0, -1.0]])
     token_ids = torch.tensor([1])


### PR DESCRIPTION
Closes #14

## Summary
- Add `rl_engine.alignment` with policy/reference model wrappers.
- Add `extract_logits(...)` for common model output shapes.
- Freeze/eval reference models by default.
- Add CPU tests for logits extraction, selected logprobs, masking, and gradients.

## Tests
- `.venv/bin/python -m pytest tests/test_alignment_model_wrappers.py -q`
- `.venv/bin/python -m pytest tests/test_reference_ops.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alignment utilities expose core model-wrapping tools for RL workflows.
  * Model outputs are normalized from multiple common formats into logits.
  * Policy wrapper supports logits slicing, training-mode behavior, log-probability computation, and gradient flow.
  * Reference wrapper offers optional parameter freezing and gradient-free evaluation for reference/KL use.

* **Bug Fixes**
  * Selected-logprob computation safely handles ignored token IDs when masked out.

* **Tests**
  * Added comprehensive tests for logits extraction, wrapper behaviors, masking, and gradient semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->