### PR TITLE
[BUG] Fix temperature applied twice in FlashInfer sampling path

### DIFF
--- a/rl_engine/kernels/sampling.py
+++ b/rl_engine/kernels/sampling.py
@@ -50,9 +50,8 @@ class SamplerBackend(nn.Module):
         if self.backend == constants.BackendLib.FLASHINFER.value:
             from flashinfer.sampling import top_k_renorm_probs, top_p_sampling_from_probs
 
+            # Temperature is already applied above; do not re-divide here.
             logits = logits.float().contiguous()
-            if temperature != 1.0:
-                logits.div_(temperature)
 
             probs = torch.softmax(logits, dim=-1)
 

--- a/rl_engine/kernels/sampling.py
+++ b/rl_engine/kernels/sampling.py
@@ -50,9 +50,6 @@ class SamplerBackend(nn.Module):
         if self.backend == constants.BackendLib.FLASHINFER.value:
             from flashinfer.sampling import top_k_renorm_probs, top_p_sampling_from_probs
 
-            # Temperature is already applied above; do not re-divide here.
-            logits = logits.float().contiguous()
-
             probs = torch.softmax(logits, dim=-1)
 
             if top_k is None and top_p is None:

--- a/rl_engine/kernels/sampling.py
+++ b/rl_engine/kernels/sampling.py
@@ -50,6 +50,7 @@ class SamplerBackend(nn.Module):
         if self.backend == constants.BackendLib.FLASHINFER.value:
             from flashinfer.sampling import top_k_renorm_probs, top_p_sampling_from_probs
 
+            logits = logits.float().contiguous()
             probs = torch.softmax(logits, dim=-1)
 
             if top_k is None and top_p is None:

--- a/tests/test_sampler_temperature.py
+++ b/tests/test_sampler_temperature.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+import sys
+import types
+
+import torch
+
+from rl_engine.platforms.constants import constants
+
+
+def _install_fake_flashinfer(monkeypatch, capture):
+    """Inject a stub ``flashinfer.sampling`` so the FlashInfer code path runs on CPU.
+
+    ``top_p_sampling_from_probs`` records the probabilities it receives so the test
+    can assert how temperature was applied before sampling.
+    """
+    fi = types.ModuleType("flashinfer")
+    fi_sampling = types.ModuleType("flashinfer.sampling")
+
+    def top_k_renorm_probs(probs, top_k):
+        return probs
+
+    def top_p_sampling_from_probs(probs, top_p, deterministic=True):
+        capture["probs"] = probs.clone()
+        return torch.zeros(probs.shape[0], dtype=torch.long)
+
+    fi_sampling.top_k_renorm_probs = top_k_renorm_probs
+    fi_sampling.top_p_sampling_from_probs = top_p_sampling_from_probs
+    fi.sampling = fi_sampling
+
+    monkeypatch.setitem(sys.modules, "flashinfer", fi)
+    monkeypatch.setitem(sys.modules, "flashinfer.sampling", fi_sampling)
+
+
+def test_flashinfer_temperature_applied_once(monkeypatch):
+    """Regression: the FlashInfer path must scale logits by 1/T exactly once.
+
+    Previously temperature was divided once for all backends and a second time
+    inside the FlashInfer branch, yielding softmax(logits / T**2).
+    """
+    capture = {}
+    _install_fake_flashinfer(monkeypatch, capture)
+
+    from rl_engine.kernels.sampling import SamplerBackend
+
+    sampler = SamplerBackend()
+    # Force the FlashInfer path regardless of the detected hardware.
+    sampler.backend = constants.BackendLib.FLASHINFER.value
+
+    torch.manual_seed(0)
+    logits = torch.randn(4, 16)
+    temperature = 2.0
+
+    sampler.sample(logits, top_p=0.9, temperature=temperature)
+
+    expected = torch.softmax(logits.float() / temperature, dim=-1)
+    assert torch.allclose(capture["probs"], expected, atol=1e-6), (
+        "FlashInfer path must apply temperature exactly once (got T**2 scaling)"
+    )
+
+
+def test_flashinfer_temperature_one_is_unchanged(monkeypatch):
+    """temperature == 1.0 must leave logits unscaled (both divisions are skipped)."""
+    capture = {}
+    _install_fake_flashinfer(monkeypatch, capture)
+
+    from rl_engine.kernels.sampling import SamplerBackend
+
+    sampler = SamplerBackend()
+    sampler.backend = constants.BackendLib.FLASHINFER.value
+
+    torch.manual_seed(0)
+    logits = torch.randn(4, 16)
+
+    sampler.sample(logits, top_p=0.9, temperature=1.0)
+
+    expected = torch.softmax(logits.float(), dim=-1)
+    assert torch.allclose(capture["probs"], expected, atol=1e-6)

--- a/tests/test_sampler_temperature.py
+++ b/tests/test_sampler_temperature.py
@@ -55,9 +55,9 @@ def test_flashinfer_temperature_applied_once(monkeypatch):
     sampler.sample(logits, top_p=0.9, temperature=temperature)
 
     expected = torch.softmax(logits.float() / temperature, dim=-1)
-    assert torch.allclose(capture["probs"], expected, atol=1e-6), (
-        "FlashInfer path must apply temperature exactly once (got T**2 scaling)"
-    )
+    assert torch.allclose(
+        capture["probs"], expected, atol=1e-6
+    ), "FlashInfer path must apply temperature exactly once (got T**2 scaling)"
 
 
 def test_flashinfer_temperature_one_is_unchanged(monkeypatch):


### PR DESCRIPTION
SamplerBackend.sample() divided logits by temperature once for all backends, then divided again inside the FlashInfer branch, producing softmax(logits / temperature**2) for any temperature != 1.0.

Remove the redundant second division so temperature is applied exactly once. The PyTorch fallback path was already correct, so this only affects FlashInfer deployments; temperature == 1.0 was unaffected (both divisions were guarded), which is why default-temperature tests never caught it.

Add tests/test_sampler_temperature.py covering the FlashInfer path with a stubbed flashinfer module: the recorded probs must equal softmax(logits / temperature), and temperature == 1.0 must be unscaled.

fixes #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure temperature scaling is applied exactly once during sampling so probability computations are correct.

* **Tests**
  * Added CPU regression tests that verify probabilities are computed correctly for scaled (temperature=2.0) and unscaled (temperature=1.0) scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->