### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,70 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# for more info about CODEOWNERS file.
+
+# This list covers the core components of RL-Kernel that require careful review.
+/rl_engine/ @Flink-ddd @inaniloquentee
+/rl_engine/alignment/ @inaniloquentee @Flink-ddd
+/rl_engine/executors/ @inaniloquentee @Flink-ddd
+/rl_engine/platforms/ @Flink-ddd
+/rl_engine/utils/ @Flink-ddd
+
+# Kernel dispatch, Python fallbacks, and native extensions.
+/rl_engine/kernels/ @Flink-ddd @inaniloquentee
+/rl_engine/kernels/ops/base.py @Flink-ddd
+/rl_engine/kernels/registry.py @Flink-ddd @inaniloquentee
+/rl_engine/kernels/sampling.py @Flink-ddd @inaniloquentee
+/rl_engine/kernels/ops/cuda/ @Flink-ddd @inaniloquentee
+/rl_engine/kernels/ops/cuda/attention/ @Flink-ddd @EthanZero2Hero
+/rl_engine/kernels/ops/cuda/loss/ @Flink-ddd @inaniloquentee
+/rl_engine/kernels/ops/pytorch/ @inaniloquentee @Flink-ddd
+/rl_engine/kernels/ops/pytorch/norm/ @maxiaosong1124 @Flink-ddd
+/rl_engine/kernels/ops/triton/ @EthanZero2Hero @Flink-ddd
+/rl_engine/kernels/ops/rocm/ @Flink-ddd
+
+# C++/CUDA sources.
+/csrc/ @Flink-ddd @inaniloquentee @bitborne
+/csrc/fused_logp_kernel.cu @inaniloquentee @Flink-ddd @bitborne
+/csrc/cuda/fused_logp_sm90.cu @Flink-ddd @bitborne
+/csrc/cuda/attention/ @Flink-ddd @EthanZero2Hero @bitborne
+/csrc/utils/ @Flink-ddd @bitborne
+
+# Rollout, training, and RL examples.
+/rl_engine/alignment/model_wrappers.py @inaniloquentee @Flink-ddd
+/examples/ @inaniloquentee @Flink-ddd
+/examples/grpo_single_gpu.py @inaniloquentee @Flink-ddd
+
+# Benchmarks and profiling.
+/benchmarks/ @Flink-ddd @inaniloquentee
+/benchmarks/profiler.py @Flink-ddd
+/scripts/ @Flink-ddd
+/scripts/run_profile_suite.py @Flink-ddd
+
+# Tests.
+/tests/ @Flink-ddd @inaniloquentee
+/tests/test_alignment_model_wrappers.py @inaniloquentee @Flink-ddd
+/tests/test_grpo_single_gpu_example.py @inaniloquentee @Flink-ddd
+/tests/test_op_accuracy.py @Flink-ddd @inaniloquentee
+/tests/test_reference_ops.py @inaniloquentee @maxiaosong1124
+/tests/test_profiler.py @Flink-ddd
+/tests/test_vllm_rollout_sampler.py @inaniloquentee @Flink-ddd
+/tests/test_weight_sync_bridge.py @inaniloquentee @Flink-ddd
+
+# CI, packaging, and build configuration.
+/.github/ @Flink-ddd @bitborne @ziying
+/.github/workflows/ @Flink-ddd @bitborne @ziying
+/.pre-commit-config.yaml @Flink-ddd
+/pyproject.toml @Flink-ddd @inaniloquentee
+/setup.py @Flink-ddd @inaniloquentee
+/requirements*.txt @Flink-ddd
+
+# Documentation.
+/docs/ @Flink-ddd @inaniloquentee
+/docs/benchmarking/ @Flink-ddd
+/docs/contributing/ @Flink-ddd
+/docs/getting_started/ @Flink-ddd @inaniloquentee
+/docs/operators/ @Flink-ddd @inaniloquentee
+/docs/usage/ @inaniloquentee @Flink-ddd
+/docs/usage/grpo-single-gpu-example.md @inaniloquentee @Flink-ddd
+/docs/usage/weight-sync-bridge.md @inaniloquentee @Flink-ddd
+/mkdocs.yaml @Flink-ddd
+/requirements-docs.txt @Flink-ddd


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` with module-level ownership for RL-Kernel core areas.
- Cover kernels, native CUDA/C++ sources, executors, tests, CI/build files, docs, examples, and benchmarks.
- Use existing core reviewer handles from the repository reviewer configuration and contributor history.

## Validation
- Verified the PR diff only changes `.github/CODEOWNERS`.
- Ran `git diff --cached --check` before committing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added repository ownership configuration (CODEOWNERS) to clarify review responsibilities across core components, runtime ops, native sources, examples, benchmarks, tests, CI/build, and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->