### PR TITLE
[FEAT][kernels] Fix CUDA extension build on non-Hopper SM>=90 (Blackkwell SM120)

### DIFF
--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -84,26 +84,34 @@ class KernelRegistry:
         self._adjust_priority_for_hardware()
 
     def _adjust_priority_for_hardware(self):
-        """
-        Probe NVIDIA Compute Capability; if >= 90,
-        inject the fused logp operator with the highest priority.
-        """
-        if device_ctx.device_type == "cuda":
-            try:
-                import torch
+        """Prioritize the fused TMA LogP kernel only when it is compiled into the
+        extension and the device is TMA-capable (SM90/100/120)."""
+        if device_ctx.device_type != "cuda":
+            return
+        try:
+            import torch
 
-                cc_major, cc_minor = torch.cuda.get_device_capability()
-                cc = cc_major * 10 + cc_minor
-                if cc >= 90:
-                    logger.info(
-                        f"Detected Advanced Architecture (SM{cc}). "
-                        "Enabling TMA & Warp Specialization."
-                    )
-                    logp_list = self._priority_map["cuda"]["logp"]
-                    if OpBackend.CUDA_FUSED_LOGP_SM90 not in logp_list:
-                        logp_list.insert(0, OpBackend.CUDA_FUSED_LOGP_SM90)
-            except Exception as e:
-                logger.warning(f"Failed to probe device capability: {e}")
+            from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
+
+            cc_major, cc_minor = torch.cuda.get_device_capability()
+            cc = cc_major * 10 + cc_minor
+            tma_compiled = _EXT_AVAILABLE and hasattr(_C, "fused_logp_sm90")
+
+            if tma_compiled and cc_major in (9, 10, 12):
+                logger.info(
+                    f"Detected TMA-capable architecture (SM{cc}); "
+                    "prioritizing fused TMA LogP kernel."
+                )
+                logp_list = self._priority_map["cuda"]["logp"]
+                if OpBackend.CUDA_FUSED_LOGP_SM90 not in logp_list:
+                    logp_list.insert(0, OpBackend.CUDA_FUSED_LOGP_SM90)
+            elif cc >= 90:
+                logger.debug(
+                    f"SM{cc}: fused TMA LogP kernel not compiled into _C; "
+                    "using generic fused kernel."
+                )
+        except Exception as e:
+            logger.warning(f"Failed to probe device capability: {e}")
 
     def get_op(self, op_type: str) -> Any:
         """Core distribution logic: Automatically select the best operator

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def get_extensions():
             "csrc/cuda/attention/prefix_shared_attention.cu",
         ]
 
-        cc_major, _ = torch.cuda.get_device_capability()
+        cc_major, cc_minor = torch.cuda.get_device_capability()
         nvcc_flags = ["-O3", "--use_fast_math", "-Xfatbin", "-compress-all"]
         nvcc_flags.extend(
             _cuda_define_from_env(
@@ -111,10 +111,11 @@ def get_extensions():
         extra_link_args = []
 
         tma_src = "csrc/cuda/fused_logp_sm90.cu"
-        enable_sm90 = cc_major >= 9 or os.environ.get("KERNEL_ALIGN_FORCE_SM90") == "1"
+        enable_sm90 = os.environ.get("KERNEL_ALIGN_FORCE_SM90") == "1"
         if enable_sm90 and os.path.exists(tma_src):
+            tma_arch = f"{cc_major}{cc_minor}a"
             cuda_sources.append(tma_src)
-            nvcc_flags.append("-gencode=arch=compute_90a,code=sm_90a")
+            nvcc_flags.append(f"-gencode=arch=compute_{tma_arch},code=sm_{tma_arch}")
             cxx_flags.append("-DKERNEL_ALIGN_WITH_SM90")
             extra_link_args.append("-lcuda")
 


### PR DESCRIPTION
#87 

## Summary
`pip install -e .` force-built the Hopper-only TMA fused-logp kernel (csrc/cuda/fused_logp_sm90.cu) on every device with compute capability >= 9, including Blackwell (SM120) and SM100. Its hardcoded `gencode=arch=compute_90a,code=sm_90a` also suppressed PyTorch's automatic native-arch gencode, so the entire extension — including the generic and attention kernels — was compiled for sm_90a only and could not load on the actual device.

## Change
- ```setup.py```: When opted in, emit the detected device's architecture-specific gencode (SM90->90a, SM120->120a) instead of a hardcoded compute_90a.
- ```registry.py```: Prioritize the TMA logp op only when its symbol is compiled into _C, and drop the misleading "Failed to instantiate CUDA_FUSED_LOGP_SM90" ERROR that fired on every non-Hopper SM>=9 run before falling back.

## Tests on Blackwell and Hopper
- Blackwell (SM120) + CUDA13
```bash
> pip install -e . # No error
> python examples/grpo_single_gpu.py --require-fused-logp --device cuda
INFO 06-08 20:00:03 [RL-Kernel]: RL-Engine initialized with NVIDIA CUDA backend (Version: 13.0)
INFO 06-08 20:00:03 [RL-Kernel]: KernelRegistry initialized for cuda
INFO 06-08 20:00:03 [RL-Kernel]: Successfully linked to precompiled _C.fused_logp fallback kernel.
starting grpo_single_gpu device=cuda backend=FusedLogpGenericOp batch=8x16 active_tokens=115
reward_stats mean=0.446666 min=0.297619 max=0.600000
step=0 loss=0.002686 policy_loss=0.002686 kl=0.000000 train_logp_source=autograd_reference kernel_max_abs_error=4.768372e-07
step=1 loss=-0.084697 policy_loss=-0.086432 kl=0.173448 train_logp_source=autograd_reference kernel_max_abs_error=4.768372e-07
step=2 loss=-0.103133 policy_loss=-0.107106 kl=0.397346 train_logp_source=autograd_reference kernel_max_abs_error=4.768372e-07
step=3 loss=-0.102970 policy_loss=-0.109759 kl=0.678900 train_logp_source=autograd_reference kernel_max_abs_error=4.768372e-07
completed grpo_single_gpu steps=4 device=cuda backend=FusedLogpGenericOp
```
- H100 (SM90) + CUDA12.8
```bash
> pip install -e . # No error
> python examples/grpo_single_gpu.py --require-fused-logp --device cuda
backend=FusedLogpGenericOp
INFO 06-08 11:52:22 [RL-Kernel]: RL-Engine initialized with NVIDIA CUDA backend (Version: 12.8)
INFO 06-08 11:52:22 [RL-Kernel]: KernelRegistry initialized for cuda
INFO 06-08 11:52:22 [RL-Kernel]: Successfully linked to precompiled _C.fused_logp fallback kernel.
starting grpo_single_gpu device=cuda backend=FusedLogpGenericOp batch=8x16 active_tokens=115
reward_stats mean=0.446666 min=0.297619 max=0.600000
step=0 loss=0.002686 policy_loss=0.002686 kl=0.000000 train_logp_source=autograd_reference kernel_max_abs_error=4.768372e-07
step=1 loss=-0.084697 policy_loss=-0.086432 kl=0.173448 train_logp_source=autograd_reference kernel_max_abs_error=4.768372e-07
step=2 loss=-0.103133 policy_loss=-0.107106 kl=0.397345 train_logp_source=autograd_reference kernel_max_abs_error=4.768372e-07
step=3 loss=-0.102970 policy_loss=-0.109759 kl=0.678900 train_logp_source=autograd_reference kernel_max_abs_error=4.768372e-07
completed grpo_single_gpu steps=4 device=cuda backend=FusedLogpGenericOp
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CUDA kernel backend selection logic with stricter hardware compatibility checks.
  * Refined SM90 optimization enablement to require explicit environment variable configuration (`KERNEL_ALIGN_FORCE_SM90="1"`).
  * Enhanced device capability detection during build process for more precise hardware targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->