### PR TITLE
[FEAT][kernels]: implement fused GRPO loss with in-place group reward normalization

### DIFF
--- a/benchmarks/benchmark_grpo_loss.py
+++ b/benchmarks/benchmark_grpo_loss.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Benchmark NativeGRPOLossOp vs TritonGRPOLossOp.
+
+Reports forward and forward+backward latency (and peak extra VRAM for the
+forward pass) across a range of (groups x samples x completion-length) shapes.
+The ops operate on per-token log-probs, so the working set scales with
+N = num_prompts * samples_per_prompt * completion_len.
+
+Usage:
+    python benchmarks/benchmark_grpo_loss.py
+    python benchmarks/benchmark_grpo_loss.py --iters 50 --clip-eps 0.2 --beta 0.04
+"""
+
+import argparse
+
+import torch
+from tabulate import tabulate
+
+from rl_engine.kernels.ops.pytorch.loss.grpo_loss import NativeGRPOLossOp
+from rl_engine.kernels.ops.triton.triton_grpo_loss import TritonGRPOLossOp
+from rl_engine.platforms.device import device_ctx
+from rl_engine.utils.logger import logger
+
+# (num_prompts, samples_per_prompt, completion_len)
+DEFAULT_CONFIGS = [
+    (32, 8, 256),
+    (64, 8, 512),
+    (128, 8, 1024),
+    (256, 16, 1024),
+]
+
+
+def _make_inputs(num_prompts, spp, completion_len, device, dtype):
+    batch = num_prompts * spp
+    current = torch.randn(batch, completion_len, device=device, dtype=dtype)
+    old = torch.randn(batch, completion_len, device=device, dtype=dtype)
+    ref = torch.randn(batch, completion_len, device=device, dtype=dtype)
+    rewards = torch.randn(batch, device=device, dtype=dtype)
+    mask = torch.ones(batch, completion_len, dtype=torch.bool, device=device)
+    return current, old, ref, rewards, mask
+
+
+def _time_ms(fn, warmup, iters):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters
+
+
+def _peak_vram_gb(fn, warmup=3, iters=5):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    return (torch.cuda.max_memory_allocated() - baseline) / (1024**3)
+
+
+def run_benchmark(args):
+    if device_ctx.device_type != "cuda":
+        raise RuntimeError("GRPO loss benchmark requires a CUDA device (Triton op is CUDA-only).")
+
+    device = device_ctx.device
+    dtype = torch.float32
+    native = NativeGRPOLossOp()
+    triton_op = TritonGRPOLossOp()
+    kwargs = dict(clip_eps=args.clip_eps, beta=args.beta)
+
+    logger.info(f"GRPO loss benchmark on {device} (dtype={dtype})")
+
+    rows = []
+    for num_prompts, spp, comp_len in args.configs:
+        current, old, ref, rewards, mask = _make_inputs(num_prompts, spp, comp_len, device, dtype)
+        n_tokens = current.numel()
+        call_args = (old, ref, rewards, mask)
+
+        def native_fwd(c=current):
+            with torch.no_grad():
+                native.forward(c, *call_args, samples_per_prompt=spp, **kwargs)
+
+        def triton_fwd(c=current):
+            with torch.no_grad():
+                triton_op.forward(c, *call_args, samples_per_prompt=spp, **kwargs)
+
+        cur_grad = current.clone().requires_grad_(True)
+
+        def native_fwd_bwd(c=cur_grad):
+            loss, _, _ = native.forward(c, *call_args, samples_per_prompt=spp, **kwargs)
+            torch.autograd.grad(loss, c)
+
+        def triton_fwd_bwd(c=cur_grad):
+            loss, _, _ = triton_op.forward(c, *call_args, samples_per_prompt=spp, **kwargs)
+            torch.autograd.grad(loss, c)
+
+        n_fwd = _time_ms(native_fwd, args.warmup, args.iters)
+        t_fwd = _time_ms(triton_fwd, args.warmup, args.iters)
+        n_fb = _time_ms(native_fwd_bwd, args.warmup, args.iters)
+        t_fb = _time_ms(triton_fwd_bwd, args.warmup, args.iters)
+        n_vram = _peak_vram_gb(native_fwd)
+        t_vram = _peak_vram_gb(triton_fwd)
+
+        rows.append(
+            [
+                f"{num_prompts}x{spp}x{comp_len}",
+                f"{n_tokens/1e6:.2f}M",
+                f"{n_fwd:.3f}",
+                f"{t_fwd:.3f}",
+                f"{n_fwd/t_fwd:.2f}x",
+                f"{n_fb:.3f}",
+                f"{t_fb:.3f}",
+                f"{n_fb/t_fb:.2f}x",
+                f"{n_vram*1024:.1f}",
+                f"{t_vram*1024:.1f}",
+            ]
+        )
+
+    headers = [
+        "shape (P x S x L)",
+        "tokens",
+        "native fwd ms",
+        "triton fwd ms",
+        "fwd speedup",
+        "native f+b ms",
+        "triton f+b ms",
+        "f+b speedup",
+        "native fwd MB",
+        "triton fwd MB",
+    ]
+    print(tabulate(rows, headers=headers, tablefmt="github"))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iters", type=int, default=30)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument("--clip-eps", type=float, default=0.2)
+    parser.add_argument("--beta", type=float, default=0.04)
+    parser.add_argument(
+        "--configs",
+        type=str,
+        default=None,
+        help="Semicolon-separated 'prompts,samples,len' triples, e.g. '64,8,512;128,8,1024'.",
+    )
+    args = parser.parse_args()
+    if args.configs:
+        args.configs = [
+            tuple(int(x) for x in triple.split(",")) for triple in args.configs.split(";")
+        ]
+    else:
+        args.configs = DEFAULT_CONFIGS
+    return args
+
+
+if __name__ == "__main__":
+    run_benchmark(parse_args())

--- a/docs/operators/README.md
+++ b/docs/operators/README.md
@@ -19,5 +19,6 @@ Every operator page should include:
 ## Current Pages
 
 - [Fused LogP](fused-logp.md)
+- [GRPO Loss](grpo-loss.md)
 - [Sampling](sampling.md)
 - [Operator Doc Template](../contributing/operator-doc-template.md)

--- a/docs/operators/grpo-loss.md
+++ b/docs/operators/grpo-loss.md
@@ -1,0 +1,167 @@
+# GRPO Loss
+
+GRPO Loss computes the Group Relative Policy Optimization objective for RL post-training:
+it normalizes raw sequence rewards within each generation group into advantages, then
+evaluates the clipped surrogate objective plus a reference-KL penalty over the active
+completion tokens. It targets the GRPO training step, where a naive PyTorch implementation
+allocates several broadcasted `[batch, completion_len]` intermediates and a per-token
+advantage tensor.
+
+The operator consumes per-token **log-probs**, so it composes directly with the
+[Fused LogP](fused-logp.md) operator:
+
+```
+logits --[logp op]--> current_logps --[grpo_loss op]--> loss
+```
+
+It does not re-implement `log_softmax`; produce `current_logps` with the `logp` operator
+(or any equivalent) first.
+
+## Entry Point
+
+```python
+from rl_engine.kernels.registry import kernel_registry
+
+grpo = kernel_registry.get_op("grpo_loss")
+
+loss, policy_loss, kl = grpo.forward(
+    current_logps,        # [B, T] current-policy per-token log-probs (differentiable)
+    old_logps,            # [B, T] behavior-policy log-probs (constant)
+    ref_logps,            # [B, T] reference-model log-probs (constant)
+    rewards,              # [B]    one scalar reward per sequence
+    completion_mask,      # [B, T] bool; True = active completion token
+    clip_eps=0.2,
+    beta=0.04,
+    samples_per_prompt=8,  # uniform groups; or pass group_boundaries=[...]
+)
+
+loss.backward()           # gradient flows into current_logps
+```
+
+`B = num_prompts * samples_per_prompt`. `forward` returns a 3-tuple
+`(loss, policy_loss, kl)`; only `loss` is differentiable (`policy_loss` and `kl` are
+detached reporting scalars).
+
+### Group specification
+
+Provide **exactly one** of:
+
+- `samples_per_prompt: int` — uniform groups (every prompt has the same number of samples).
+- `group_boundaries` — CSR-style offsets of length `num_groups + 1` (e.g. `[0, 8, 16, 24]`)
+  for variable-sized groups.
+
+### Lower-level helpers
+
+```python
+adv = grpo.group_advantages(rewards, samples_per_prompt=8)        # [B] per-sequence advantages
+loss, policy_loss, kl = grpo.apply(                               # skip reward normalization
+    current_logps, old_logps, ref_logps, advantages, completion_mask,
+    clip_eps=0.2, beta=0.04,
+)
+```
+
+!!! note "`apply` advantage layout differs by backend"
+    `NativeGRPOLossOp.apply` takes **per-token** advantages `[B, T]` (use
+    `expand_advantages`), while `TritonGRPOLossOp.apply` takes **per-sequence**
+    advantages `[B]` and gathers per token inside the kernel. Prefer `forward`, whose
+    signature is identical across backends.
+
+## Backends
+
+| Backend | Wrapper | Native symbol | Status |
+| --- | --- | --- | --- |
+| CUDA | `TritonGRPOLossOp` | Triton JIT kernels | Fused forward + analytic backward. |
+| ROCm | `TritonGRPOLossOp` | Triton JIT kernels | Same kernels; requires Triton. |
+| PyTorch fallback | `NativeGRPOLossOp` | None | Reference path; CPU and Triton-less GPUs. |
+
+The Triton op fuses three kernels: `_group_norm_kernel` (per-group reward mean/std in
+registers), and token-parallel `_grpo_fwd_kernel` / `_grpo_bwd_kernel`. Each token gathers
+its advantage on the fly (`seq_id = token_index // completion_len`), so the broadcasted
+`[B, T]` advantage tensor is never materialized.
+
+## Tensor Contract
+
+| Argument | Shape | Dtype | Requirements |
+| --- | --- | --- | --- |
+| `current_logps` | `[B, T]` | float (fp32 recommended) | Differentiable input; on the target device. |
+| `old_logps` | `[B, T]` | float | Constant (no grad). |
+| `ref_logps` | `[B, T]` | float | Constant (no grad). |
+| `rewards` | `[B]` | float | One scalar per sequence. |
+| `completion_mask` | `[B, T]` | bool / {0,1} | 2-D; `True` marks active tokens. |
+| `loss` (output) | scalar | float32 | `policy_loss + beta * kl`. |
+| `policy_loss`, `kl` (output) | scalar | float32 | Detached reporting values. |
+
+## Dispatch Behavior
+
+`kernel_registry.get_op("grpo_loss")` selects `TritonGRPOLossOp` first on CUDA and ROCm,
+and `NativeGRPOLossOp` on CPU or when Triton / the CUDA backend is unavailable. The Triton
+op raises if handed CPU tensors, so on CPU always use the native op (the registry does this
+automatically).
+
+## Accuracy
+
+Reference semantics (matching `examples/grpo_single_gpu.py`):
+
+```python
+# advantages: group-normalized rewards (population std, unbiased=False)
+grouped = rewards.view(-1, samples_per_prompt)
+adv = (grouped - grouped.mean(1, keepdim=True)) / grouped.std(1, keepdim=True, unbiased=False).clamp_min(1e-6)
+adv = adv.reshape(-1)[:, None].expand_as(completion_mask)
+
+ratio = torch.exp(current_logps - old_logps)
+policy = -torch.minimum(ratio * adv, torch.clamp(ratio, 1 - clip_eps, 1 + clip_eps) * adv)
+diff = ref_logps - current_logps
+kl = torch.exp(diff) - diff - 1.0                      # k3 estimator
+loss = masked_mean(policy, completion_mask) + beta * masked_mean(kl, completion_mask)
+```
+
+The Triton op matches the native reference (forward and backward) to `atol=1e-4` in fp32.
+Composing with the dispatched CUDA fused logp matches a torch oracle to `atol=1e-3`.
+
+## Performance Notes
+
+```bash
+python benchmarks/benchmark_grpo_loss.py
+python benchmarks/benchmark_grpo_loss.py --configs "64,8,512;256,16,1024"
+```
+
+Indicative results (RTX PRO 6000, SM120, fp32):
+
+| shape (prompts × samples × len) | tokens | forward speedup | fwd+bwd speedup | peak VRAM (native → Triton) |
+| --- | --- | --- | --- | --- |
+| 64 × 8 × 512 | 0.26M | 4.7× | 3.0× | 10 MB → 1 MB |
+| 128 × 8 × 1024 | 1.05M | 3.2× | 2.7× | 40 MB → 4 MB |
+| 256 × 16 × 1024 | 4.19M | 3.0× | 3.0× | 160 MB → 16 MB |
+
+The ~10× VRAM reduction comes from not materializing the broadcasted advantage and
+per-token surrogate/KL intermediates.
+
+## Tests
+
+```bash
+python -m pytest tests/test_grpo_loss.py -v
+```
+
+Covers the native reference, Triton forward/backward vs native, the
+`logp → grpo_loss` pipeline, masked-token invariance, an SGD loss step, and registry
+dispatch. Triton tests skip without CUDA + Triton.
+
+## Known Limitations
+
+- `TritonGRPOLossOp` requires CUDA tensors and a working Triton install; CPU falls back to
+  the native op.
+- `old_logps` / `ref_logps` are precomputed per-token constants — only the current policy
+  is differentiated (standard for GRPO).
+- Inputs are dense `[B, T]` (rectangular). Variable-length completions should be padded and
+  masked via `completion_mask`.
+- Group reward normalization is a separate lightweight kernel (one scalar per sequence);
+  it is intentionally not fused into the token kernel, which would trade away
+  token-level parallelism.
+
+## Implementation Files
+
+- `rl_engine/kernels/ops/pytorch/loss/grpo_loss.py`
+- `rl_engine/kernels/ops/triton/triton_grpo_loss.py`
+- `rl_engine/kernels/registry.py`
+- `tests/test_grpo_loss.py`
+- `benchmarks/benchmark_grpo_loss.py`

--- a/docs/operators/grpo-loss.md
+++ b/docs/operators/grpo-loss.md
@@ -7,29 +7,24 @@ completion tokens. It targets the GRPO training step, where a naive PyTorch impl
 allocates several broadcasted `[batch, completion_len]` intermediates and a per-token
 advantage tensor.
 
-The operator consumes per-token **log-probs**, so it composes directly with the
-[Fused LogP](fused-logp.md) operator:
+The operator consumes per-token **log-probs**, so it composes directly with the [Fused LogP](fused-logp.md) operator:
 
 ```
-logits --[logp op]--> current_logps --[grpo_loss op]--> loss
+logits --[logp op]--> logps --[grpo_loss op]--> loss
 ```
-
-It does not re-implement `log_softmax`; produce `current_logps` with the `logp` operator
-(or any equivalent) first.
 
 ## Entry Point
-
 ```python
 from rl_engine.kernels.registry import kernel_registry
 
-grpo = kernel_registry.get_op("grpo_loss")
+grpo_loss = kernel_registry.get_op("grpo_loss")
 
-loss, policy_loss, kl = grpo.forward(
-    current_logps,        # [B, T] current-policy per-token log-probs (differentiable)
-    old_logps,            # [B, T] behavior-policy log-probs (constant)
-    ref_logps,            # [B, T] reference-model log-probs (constant)
-    rewards,              # [B]    one scalar reward per sequence
-    completion_mask,      # [B, T] bool; True = active completion token
+loss, policy_loss, kl = grpo_loss(
+    current_logps,        # [B, T] current policy logps (differentiable)
+    old_logps,            # [B, T] inference engine log-probs
+    ref_logps,            # [B, T] reference model log-probs
+    rewards,              # [B]
+    completion_mask,      # [B, T]
     clip_eps=0.2,
     beta=0.04,
     samples_per_prompt=8,  # uniform groups; or pass group_boundaries=[...]
@@ -38,40 +33,20 @@ loss, policy_loss, kl = grpo.forward(
 loss.backward()           # gradient flows into current_logps
 ```
 
-`B = num_prompts * samples_per_prompt`. `forward` returns a 3-tuple
-`(loss, policy_loss, kl)`; only `loss` is differentiable (`policy_loss` and `kl` are
-detached reporting scalars).
+Note: `B = num_prompts * samples_per_prompt`. The [B, T] tensors are made contiguous and flattened to 1-D [N = B*T] before the kernel launch.
 
 ### Group specification
 
 Provide **exactly one** of:
-
 - `samples_per_prompt: int` — uniform groups (every prompt has the same number of samples).
 - `group_boundaries` — CSR-style offsets of length `num_groups + 1` (e.g. `[0, 8, 16, 24]`)
   for variable-sized groups.
-
-### Lower-level helpers
-
-```python
-adv = grpo.group_advantages(rewards, samples_per_prompt=8)        # [B] per-sequence advantages
-loss, policy_loss, kl = grpo.apply(                               # skip reward normalization
-    current_logps, old_logps, ref_logps, advantages, completion_mask,
-    clip_eps=0.2, beta=0.04,
-)
-```
-
-!!! note "`apply` advantage layout differs by backend"
-    `NativeGRPOLossOp.apply` takes **per-token** advantages `[B, T]` (use
-    `expand_advantages`), while `TritonGRPOLossOp.apply` takes **per-sequence**
-    advantages `[B]` and gathers per token inside the kernel. Prefer `forward`, whose
-    signature is identical across backends.
 
 ## Backends
 
 | Backend | Wrapper | Native symbol | Status |
 | --- | --- | --- | --- |
 | CUDA | `TritonGRPOLossOp` | Triton JIT kernels | Fused forward + analytic backward. |
-| ROCm | `TritonGRPOLossOp` | Triton JIT kernels | Same kernels; requires Triton. |
 | PyTorch fallback | `NativeGRPOLossOp` | None | Reference path; CPU and Triton-less GPUs. |
 
 The Triton op fuses three kernels: `_group_norm_kernel` (per-group reward mean/std in
@@ -83,20 +58,13 @@ its advantage on the fly (`seq_id = token_index // completion_len`), so the broa
 
 | Argument | Shape | Dtype | Requirements |
 | --- | --- | --- | --- |
-| `current_logps` | `[B, T]` | float (fp32 recommended) | Differentiable input; on the target device. |
+| `current_logps` | `[B, T]` | float (fp32 recommended) | Differentiable input |
 | `old_logps` | `[B, T]` | float | Constant (no grad). |
 | `ref_logps` | `[B, T]` | float | Constant (no grad). |
 | `rewards` | `[B]` | float | One scalar per sequence. |
 | `completion_mask` | `[B, T]` | bool / {0,1} | 2-D; `True` marks active tokens. |
 | `loss` (output) | scalar | float32 | `policy_loss + beta * kl`. |
 | `policy_loss`, `kl` (output) | scalar | float32 | Detached reporting values. |
-
-## Dispatch Behavior
-
-`kernel_registry.get_op("grpo_loss")` selects `TritonGRPOLossOp` first on CUDA and ROCm,
-and `NativeGRPOLossOp` on CPU or when Triton / the CUDA backend is unavailable. The Triton
-op raises if handed CPU tensors, so on CPU always use the native op (the registry does this
-automatically).
 
 ## Accuracy
 
@@ -145,18 +113,6 @@ python -m pytest tests/test_grpo_loss.py -v
 Covers the native reference, Triton forward/backward vs native, the
 `logp → grpo_loss` pipeline, masked-token invariance, an SGD loss step, and registry
 dispatch. Triton tests skip without CUDA + Triton.
-
-## Known Limitations
-
-- `TritonGRPOLossOp` requires CUDA tensors and a working Triton install; CPU falls back to
-  the native op.
-- `old_logps` / `ref_logps` are precomputed per-token constants — only the current policy
-  is differentiated (standard for GRPO).
-- Inputs are dense `[B, T]` (rectangular). Variable-length completions should be padded and
-  masked via `completion_mask`.
-- Group reward normalization is a separate lightweight kernel (one scalar per sequence);
-  it is intentionally not fused into the token kernel, which would trade away
-  token-level parallelism.
 
 ## Implementation Files
 

--- a/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
+++ b/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
@@ -70,7 +70,7 @@ class NativeGRPOLossOp:
 
         means = sums / counts
         variance = (sq_sums / counts) - means * means
-        stds = variance.clamp_min(0.0).sqrt().clamp_min(eps)
+        stds = variance.clamp_min(eps**2).sqrt()
 
         return (flat_rewards - means[group_id]) / stds[group_id]
 

--- a/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
+++ b/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+from typing import Optional, Sequence, Tuple
+
+import torch
+
+
+class NativeGRPOLossOp:
+    """Pure PyTorch native fallback for the fused GRPO loss."""
+
+    def __init__(self) -> None:
+        pass
+
+    def __call__(
+        self,
+        current_logps: torch.Tensor,
+        old_logps: torch.Tensor,
+        ref_logps: torch.Tensor,
+        rewards: torch.Tensor,
+        completion_mask: torch.Tensor,
+        *,
+        clip_eps: float = 0.2,
+        beta: float = 0.0,
+        samples_per_prompt: Optional[int] = None,
+        group_boundaries: Optional[Sequence[int] | torch.Tensor] = None,
+        eps: float = 1e-6,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self.forward(
+            current_logps,
+            old_logps,
+            ref_logps,
+            rewards,
+            completion_mask,
+            clip_eps=clip_eps,
+            beta=beta,
+            samples_per_prompt=samples_per_prompt,
+            group_boundaries=group_boundaries,
+            eps=eps,
+        )
+
+    def group_advantages(
+        self,
+        rewards: torch.Tensor,
+        *,
+        samples_per_prompt: Optional[int] = None,
+        group_boundaries: Optional[Sequence[int] | torch.Tensor] = None,
+        eps: float = 1e-6,
+    ) -> torch.Tensor:
+        """Normalize raw per-sequence rewards within each generation group."""
+        flat_rewards = rewards.reshape(-1).float()
+        num_sequences = flat_rewards.numel()
+        group_id = self._resolve_group_ids(
+            num_sequences,
+            device=flat_rewards.device,
+            samples_per_prompt=samples_per_prompt,
+            group_boundaries=group_boundaries,
+        )
+
+        num_groups = int(group_id.max().item()) + 1 if num_sequences else 0
+        counts = flat_rewards.new_zeros(num_groups).index_add_(
+            0, group_id, torch.ones_like(flat_rewards)
+        )
+        sums = flat_rewards.new_zeros(num_groups).index_add_(0, group_id, flat_rewards)
+        sq_sums = flat_rewards.new_zeros(num_groups).index_add_(
+            0, group_id, flat_rewards * flat_rewards
+        )
+
+        means = sums / counts
+        variance = (sq_sums / counts) - means * means
+        stds = variance.clamp_min(0.0).sqrt().clamp_min(eps)
+
+        return (flat_rewards - means[group_id]) / stds[group_id]
+
+    @staticmethod
+    def expand_advantages(
+        sample_advantages: torch.Tensor,
+        completion_mask: torch.Tensor,
+    ) -> torch.Tensor:
+        """Broadcast per-sequence advantages to per-token, zeroing masked tokens."""
+        bool_mask = completion_mask.bool()
+        expanded = sample_advantages.reshape(-1, 1).expand_as(bool_mask).clone()
+        return expanded.masked_fill(~bool_mask, 0.0)
+
+    def apply(
+        self,
+        current_logps: torch.Tensor,
+        old_logps: torch.Tensor,
+        ref_logps: torch.Tensor,
+        advantages: torch.Tensor,
+        completion_mask: torch.Tensor,
+        *,
+        clip_eps: float = 0.2,
+        beta: float = 0.0,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Compute ``(loss, policy_loss, kl)`` from per-token log-probabilities."""
+        bool_mask = completion_mask.bool()
+
+        ratio = torch.exp(current_logps.float() - old_logps.float())
+        adv = advantages.float()
+        unclipped = ratio * adv
+        clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * adv
+        policy_loss_terms = -torch.minimum(unclipped, clipped)
+
+        # k3 reference-KL estimator: exp(d) - d - 1, with d = ref - current.
+        diff = ref_logps.float() - current_logps.float()
+        kl_terms = torch.exp(diff) - diff - 1.0
+
+        policy_loss = self._masked_mean(policy_loss_terms, bool_mask)
+        kl = self._masked_mean(kl_terms, bool_mask)
+        return policy_loss + beta * kl, policy_loss, kl
+
+    def forward(
+        self,
+        current_logps: torch.Tensor,
+        old_logps: torch.Tensor,
+        ref_logps: torch.Tensor,
+        rewards: torch.Tensor,
+        completion_mask: torch.Tensor,
+        *,
+        clip_eps: float = 0.2,
+        beta: float = 0.0,
+        samples_per_prompt: Optional[int] = None,
+        group_boundaries: Optional[Sequence[int] | torch.Tensor] = None,
+        eps: float = 1e-6,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sample_advantages = self.group_advantages(
+            rewards,
+            samples_per_prompt=samples_per_prompt,
+            group_boundaries=group_boundaries,
+            eps=eps,
+        )
+        advantages = self.expand_advantages(sample_advantages, completion_mask)
+        return self.apply(
+            current_logps,
+            old_logps,
+            ref_logps,
+            advantages,
+            completion_mask,
+            clip_eps=clip_eps,
+            beta=beta,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _masked_mean(
+        values: torch.Tensor, bool_mask: torch.Tensor, eps: float = 1e-8
+    ) -> torch.Tensor:
+        masked = values.masked_fill(~bool_mask, 0.0)
+        denom = bool_mask.sum().to(values.dtype).clamp_min(eps)
+        return masked.sum() / denom
+
+    @staticmethod
+    def _resolve_group_ids(
+        num_sequences: int,
+        *,
+        device: torch.device,
+        samples_per_prompt: Optional[int],
+        group_boundaries: Optional[Sequence[int] | torch.Tensor],
+    ) -> torch.Tensor:
+        provided = [spec is not None for spec in (samples_per_prompt, group_boundaries)]
+        if sum(provided) != 1:
+            raise ValueError("Provide exactly one of samples_per_prompt or group_boundaries.")
+
+        if samples_per_prompt is not None:
+            if samples_per_prompt < 2:
+                raise ValueError("samples_per_prompt must be at least 2 for group normalization.")
+            if num_sequences % samples_per_prompt != 0:
+                raise ValueError(
+                    f"num_sequences ({num_sequences}) must be divisible by "
+                    f"samples_per_prompt ({samples_per_prompt})."
+                )
+            return torch.arange(num_sequences, device=device) // samples_per_prompt
+
+        boundaries = torch.as_tensor(group_boundaries, device=device, dtype=torch.long)
+        if boundaries.ndim != 1 or boundaries.numel() < 2:
+            raise ValueError("group_boundaries must be a 1D tensor of length num_groups + 1.")
+        sizes = boundaries[1:] - boundaries[:-1]
+
+        if int(sizes.sum().item()) != num_sequences:
+            raise ValueError(
+                f"group sizes sum to {int(sizes.sum().item())} but there are "
+                f"{num_sequences} sequences."
+            )
+        if bool((sizes < 1).any().item()):
+            raise ValueError("each group must contain at least one sequence.")
+
+        group_index = torch.arange(sizes.numel(), device=device)
+        return torch.repeat_interleave(group_index, sizes)

--- a/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
+++ b/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
@@ -98,14 +98,15 @@ class NativeGRPOLossOp:
         """Compute ``(loss, policy_loss, kl)`` from per-token log-probabilities."""
         bool_mask = completion_mask.bool()
 
-        ratio = torch.exp(current_logps.float() - old_logps.float())
+        delta = (current_logps.float() - old_logps.float()).masked_fill(~bool_mask, 0.0)
+        diff = (ref_logps.float() - current_logps.float()).masked_fill(~bool_mask, 0.0)
+        ratio = torch.exp(delta)
         adv = advantages.float()
         unclipped = ratio * adv
         clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * adv
         policy_loss_terms = -torch.minimum(unclipped, clipped)
 
         # k3 reference-KL estimator: exp(d) - d - 1, with d = ref - current.
-        diff = ref_logps.float() - current_logps.float()
         kl_terms = torch.exp(diff) - diff - 1.0
 
         policy_loss = self._masked_mean(policy_loss_terms, bool_mask)

--- a/rl_engine/kernels/ops/triton/triton_grpo_loss.py
+++ b/rl_engine/kernels/ops/triton/triton_grpo_loss.py
@@ -15,6 +15,18 @@ def _next_pow2(x: int) -> int:
     return 1 if x <= 1 else 1 << (x - 1).bit_length()
 
 
+_MAX_GROUP_SIZE = 1024
+
+
+def _check_group_block_limit(max_group: int) -> None:
+    if max_group > _MAX_GROUP_SIZE:
+        raise ValueError(
+            f"max group size {max_group} exceeds the Triton GRPO kernel limit of "
+            f"{_MAX_GROUP_SIZE}. Reduce samples_per_prompt / group sizes, or use a "
+            "tiled reduction kernel for larger groups."
+        )
+
+
 @triton.jit
 def _group_norm_kernel(
     rewards_ptr,
@@ -50,7 +62,7 @@ def _grpo_fwd_kernel(
     ref_ptr,
     adv_seq_ptr,  # float32[B], per-sequence advantages
     mask_ptr,
-    partials_ptr,  # float32[2]: (policy_sum, kl_sum)
+    partials_ptr,  # float32[grid, 2]: per-block (policy_sum, kl_sum)
     n_elements,
     T,  # completion length (tokens per sequence)
     clip_eps,
@@ -81,8 +93,8 @@ def _grpo_fwd_kernel(
     policy_term = tl.where(keep, policy_term, 0.0)
     kl_term = tl.where(keep, kl_term, 0.0)
 
-    tl.atomic_add(partials_ptr + 0, tl.sum(policy_term, axis=0))
-    tl.atomic_add(partials_ptr + 1, tl.sum(kl_term, axis=0))
+    tl.store(partials_ptr + pid * 2 + 0, tl.sum(policy_term, axis=0))
+    tl.store(partials_ptr + pid * 2 + 1, tl.sum(kl_term, axis=0))
 
 
 @triton.jit
@@ -149,9 +161,9 @@ class _GRPOLossFunction(torch.autograd.Function):
 
         n = cur.numel()
         num_active = mask_f.sum().clamp_min(1e-8)
-        partials = torch.zeros(2, device=cur.device, dtype=torch.float32)
 
         grid = (triton.cdiv(n, _BLOCK),)
+        partials = torch.empty(grid[0], 2, device=cur.device, dtype=torch.float32)
         _grpo_fwd_kernel[grid](
             cur.reshape(-1),
             old.reshape(-1),
@@ -165,8 +177,9 @@ class _GRPOLossFunction(torch.autograd.Function):
             BLOCK=_BLOCK,
         )
 
-        policy_loss = partials[0] / num_active
-        kl = partials[1] / num_active
+        block_sums = partials.sum(dim=0)
+        policy_loss = block_sums[0] / num_active
+        kl = block_sums[1] / num_active
         loss = policy_loss + beta * kl
 
         ctx.save_for_backward(cur, old, ref, adv, mask_f)
@@ -260,6 +273,7 @@ class TritonGRPOLossOp:
                     f"num_sequences ({num_sequences}) must be divisible by "
                     f"samples_per_prompt ({samples_per_prompt})."
                 )
+            _check_group_block_limit(samples_per_prompt)
             bounds = torch.arange(
                 0, num_sequences + 1, samples_per_prompt, device=device, dtype=torch.int32
             )
@@ -273,7 +287,9 @@ class TritonGRPOLossOp:
             raise ValueError("group_boundaries must start at 0 and end at num_sequences.")
         if bool((sizes < 1).any().item()):
             raise ValueError("each group must contain at least one sequence.")
-        return bounds, int(sizes.max().item())
+        max_group = int(sizes.max().item())
+        _check_group_block_limit(max_group)
+        return bounds, max_group
 
     def group_advantages(
         self,
@@ -291,6 +307,9 @@ class TritonGRPOLossOp:
         bounds, max_group = self._build_bounds(n, flat.device, samples_per_prompt, group_boundaries)
         num_groups = bounds.numel() - 1
         adv = torch.empty(n, device=flat.device, dtype=torch.float32)
+
+        # TODO: for larger groups, implement a tiled reduction version of the
+        # kernel that can handle >1024 sequences per group.
         _group_norm_kernel[(num_groups,)](
             flat,
             bounds,

--- a/rl_engine/kernels/ops/triton/triton_grpo_loss.py
+++ b/rl_engine/kernels/ops/triton/triton_grpo_loss.py
@@ -1,0 +1,359 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+from __future__ import annotations
+
+from typing import Optional, Sequence, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+_BLOCK = 1024
+
+
+def _next_pow2(x: int) -> int:
+    return 1 if x <= 1 else 1 << (x - 1).bit_length()
+
+
+@triton.jit
+def _group_norm_kernel(
+    rewards_ptr,
+    bounds_ptr,  # int32[num_groups + 1], CSR-style group offsets
+    adv_ptr,  # float32[N], per-sequence advantages (output)
+    eps,
+    GROUP_BLOCK: tl.constexpr,
+):
+    g = tl.program_id(0)
+    start = tl.load(bounds_ptr + g)
+    end = tl.load(bounds_ptr + g + 1)
+    size = end - start
+
+    offs = tl.arange(0, GROUP_BLOCK)
+    keep = offs < size
+    rewards = tl.load(rewards_ptr + start + offs, mask=keep, other=0.0).to(tl.float32)
+
+    count = (end - start).to(tl.float32)
+    mean = tl.sum(rewards, axis=0) / count
+    # Population variance (unbiased=False): E[x^2] - E[x]^2. Masked lanes are 0.
+    sq_mean = tl.sum(rewards * rewards, axis=0) / count
+    std = tl.sqrt(tl.maximum(sq_mean - mean * mean, 0.0))
+    std = tl.maximum(std, eps)
+
+    adv = (rewards - mean) / std
+    tl.store(adv_ptr + start + offs, adv, mask=keep)
+
+
+@triton.jit
+def _grpo_fwd_kernel(
+    cur_ptr,
+    old_ptr,
+    ref_ptr,
+    adv_seq_ptr,  # float32[B], per-sequence advantages
+    mask_ptr,
+    partials_ptr,  # float32[2]: (policy_sum, kl_sum)
+    n_elements,
+    T,  # completion length (tokens per sequence)
+    clip_eps,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    bound = offs < n_elements
+    seq_id = offs // T
+
+    cur = tl.load(cur_ptr + offs, mask=bound, other=0.0).to(tl.float32)
+    old = tl.load(old_ptr + offs, mask=bound, other=0.0).to(tl.float32)
+    ref = tl.load(ref_ptr + offs, mask=bound, other=0.0).to(tl.float32)
+    adv = tl.load(adv_seq_ptr + seq_id, mask=bound, other=0.0).to(tl.float32)
+    active = tl.load(mask_ptr + offs, mask=bound, other=0).to(tl.float32)
+    keep = bound & (active != 0.0)
+
+    ratio = tl.exp(cur - old)
+    lo = 1.0 - clip_eps
+    hi = 1.0 + clip_eps
+    unclipped = ratio * adv
+    clipped = tl.minimum(tl.maximum(ratio, lo), hi) * adv
+    policy_term = -tl.minimum(unclipped, clipped)
+
+    diff = ref - cur
+    kl_term = tl.exp(diff) - diff - 1.0
+
+    policy_term = tl.where(keep, policy_term, 0.0)
+    kl_term = tl.where(keep, kl_term, 0.0)
+
+    tl.atomic_add(partials_ptr + 0, tl.sum(policy_term, axis=0))
+    tl.atomic_add(partials_ptr + 1, tl.sum(kl_term, axis=0))
+
+
+@triton.jit
+def _grpo_bwd_kernel(
+    cur_ptr,
+    old_ptr,
+    ref_ptr,
+    adv_seq_ptr,
+    mask_ptr,
+    grad_cur_ptr,
+    scale,  # grad_output / num_active
+    beta,
+    clip_eps,
+    n_elements,
+    T,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    bound = offs < n_elements
+    seq_id = offs // T
+
+    cur = tl.load(cur_ptr + offs, mask=bound, other=0.0).to(tl.float32)
+    old = tl.load(old_ptr + offs, mask=bound, other=0.0).to(tl.float32)
+    ref = tl.load(ref_ptr + offs, mask=bound, other=0.0).to(tl.float32)
+    adv = tl.load(adv_seq_ptr + seq_id, mask=bound, other=0.0).to(tl.float32)
+    active = tl.load(mask_ptr + offs, mask=bound, other=0).to(tl.float32)
+    keep = bound & (active != 0.0)
+
+    ratio = tl.exp(cur - old)
+    lo = 1.0 - clip_eps
+    hi = 1.0 + clip_eps
+    unclipped = ratio * adv
+    clipped = tl.minimum(tl.maximum(ratio, lo), hi) * adv
+
+    # d(ratio)/d(cur) = ratio. The surrogate selects the smaller branch; the
+    # clamped branch has zero gradient outside (lo, hi).
+    in_range = (ratio > lo) & (ratio < hi)
+    d_clipped = tl.where(in_range, ratio * adv, 0.0)
+    sel_unclipped = unclipped <= clipped
+    deriv_sel = tl.where(sel_unclipped, ratio * adv, d_clipped)
+    d_policy = -deriv_sel
+
+    # d(kl)/d(cur) for kl = exp(ref - cur) - (ref - cur) - 1.
+    d_kl = 1.0 - tl.exp(ref - cur)
+
+    grad = scale * (d_policy + beta * d_kl)
+    grad = tl.where(keep, grad, 0.0)
+    tl.store(grad_cur_ptr + offs, grad, mask=bound)
+
+
+class _GRPOLossFunction(torch.autograd.Function):
+    """Autograd wrapper around the token-parallel Triton kernels."""
+
+    @staticmethod
+    def forward(
+        ctx, current_logps, old_logps, ref_logps, adv_seq, mask, completion_len, clip_eps, beta
+    ):
+        cur = current_logps.contiguous()
+        old = old_logps.contiguous().to(cur.dtype)
+        ref = ref_logps.contiguous().to(cur.dtype)
+        adv = adv_seq.contiguous().to(torch.float32)
+        mask_f = mask.contiguous().to(torch.float32)
+
+        n = cur.numel()
+        num_active = mask_f.sum().clamp_min(1e-8)
+        partials = torch.zeros(2, device=cur.device, dtype=torch.float32)
+
+        grid = (triton.cdiv(n, _BLOCK),)
+        _grpo_fwd_kernel[grid](
+            cur.reshape(-1),
+            old.reshape(-1),
+            ref.reshape(-1),
+            adv,
+            mask_f.reshape(-1),
+            partials,
+            n,
+            int(completion_len),
+            float(clip_eps),
+            BLOCK=_BLOCK,
+        )
+
+        policy_loss = partials[0] / num_active
+        kl = partials[1] / num_active
+        loss = policy_loss + beta * kl
+
+        ctx.save_for_backward(cur, old, ref, adv, mask_f)
+        ctx.clip_eps = float(clip_eps)
+        ctx.beta = float(beta)
+        ctx.completion_len = int(completion_len)
+        ctx.num_active = num_active
+        ctx.mark_non_differentiable(policy_loss, kl)
+        return loss, policy_loss, kl
+
+    @staticmethod
+    def backward(ctx, grad_loss, grad_policy, grad_kl):
+        cur, old, ref, adv, mask_f = ctx.saved_tensors
+        n = cur.numel()
+        grad_cur = torch.empty_like(cur, dtype=torch.float32)
+        scale = float((grad_loss / ctx.num_active).item())
+
+        grid = (triton.cdiv(n, _BLOCK),)
+        _grpo_bwd_kernel[grid](
+            cur.reshape(-1),
+            old.reshape(-1),
+            ref.reshape(-1),
+            adv,
+            mask_f.reshape(-1),
+            grad_cur.reshape(-1),
+            scale,
+            ctx.beta,
+            ctx.clip_eps,
+            n,
+            ctx.completion_len,
+            BLOCK=_BLOCK,
+        )
+
+        grad_cur = grad_cur.to(cur.dtype)
+        # Inputs: current, old, ref, adv_seq, mask, completion_len, clip_eps, beta.
+        return grad_cur, None, None, None, None, None, None, None
+
+
+class TritonGRPOLossOp:
+    """Triton fused GRPO loss op.
+
+    ``forward`` is the drop-in equivalent of ``NativeGRPOLossOp.forward`` (raw
+    rewards in, scalar loss out). ``apply`` takes the per-sequence advantage
+    vector directly (the fused representation), not a per-token tensor.
+    """
+
+    def __call__(
+        self,
+        current_logps: torch.Tensor,
+        old_logps: torch.Tensor,
+        ref_logps: torch.Tensor,
+        rewards: torch.Tensor,
+        completion_mask: torch.Tensor,
+        *,
+        clip_eps: float = 0.2,
+        beta: float = 0.0,
+        samples_per_prompt: Optional[int] = None,
+        group_boundaries: Optional[Sequence[int] | torch.Tensor] = None,
+        eps: float = 1e-6,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self.forward(
+            current_logps,
+            old_logps,
+            ref_logps,
+            rewards,
+            completion_mask,
+            clip_eps=clip_eps,
+            beta=beta,
+            samples_per_prompt=samples_per_prompt,
+            group_boundaries=group_boundaries,
+            eps=eps,
+        )
+
+    @staticmethod
+    def _build_bounds(
+        num_sequences: int,
+        device: torch.device,
+        samples_per_prompt: Optional[int],
+        group_boundaries: Optional[Sequence[int] | torch.Tensor],
+    ) -> Tuple[torch.Tensor, int]:
+        """Return CSR-style group offsets (int32) and the max group size."""
+        provided = [spec is not None for spec in (samples_per_prompt, group_boundaries)]
+        if sum(provided) != 1:
+            raise ValueError("Provide exactly one of samples_per_prompt or group_boundaries.")
+
+        if samples_per_prompt is not None:
+            if samples_per_prompt < 2:
+                raise ValueError("samples_per_prompt must be at least 2 for group normalization.")
+            if num_sequences % samples_per_prompt != 0:
+                raise ValueError(
+                    f"num_sequences ({num_sequences}) must be divisible by "
+                    f"samples_per_prompt ({samples_per_prompt})."
+                )
+            bounds = torch.arange(
+                0, num_sequences + 1, samples_per_prompt, device=device, dtype=torch.int32
+            )
+            return bounds, samples_per_prompt
+
+        bounds = torch.as_tensor(group_boundaries, device=device, dtype=torch.int32)
+        if bounds.ndim != 1 or bounds.numel() < 2:
+            raise ValueError("group_boundaries must be a 1D tensor of length num_groups + 1.")
+        sizes = bounds[1:] - bounds[:-1]
+        if int(bounds[0].item()) != 0 or int(bounds[-1].item()) != num_sequences:
+            raise ValueError("group_boundaries must start at 0 and end at num_sequences.")
+        if bool((sizes < 1).any().item()):
+            raise ValueError("each group must contain at least one sequence.")
+        return bounds, int(sizes.max().item())
+
+    def group_advantages(
+        self,
+        rewards: torch.Tensor,
+        *,
+        samples_per_prompt: Optional[int] = None,
+        group_boundaries: Optional[Sequence[int] | torch.Tensor] = None,
+        eps: float = 1e-6,
+    ) -> torch.Tensor:
+        """Per-sequence reward normalization, computed by the Triton group kernel."""
+        if not rewards.is_cuda:
+            raise RuntimeError("TritonGRPOLossOp requires CUDA tensors.")
+        flat = rewards.reshape(-1).to(torch.float32)
+        n = flat.numel()
+        bounds, max_group = self._build_bounds(n, flat.device, samples_per_prompt, group_boundaries)
+        num_groups = bounds.numel() - 1
+        adv = torch.empty(n, device=flat.device, dtype=torch.float32)
+        _group_norm_kernel[(num_groups,)](
+            flat,
+            bounds,
+            adv,
+            float(eps),
+            GROUP_BLOCK=_next_pow2(max_group),
+        )
+        return adv
+
+    def apply(
+        self,
+        current_logps: torch.Tensor,
+        old_logps: torch.Tensor,
+        ref_logps: torch.Tensor,
+        sample_advantages: torch.Tensor,
+        completion_mask: torch.Tensor,
+        *,
+        clip_eps: float = 0.2,
+        beta: float = 0.0,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Evaluate the loss from per-sequence advantages (gathered per token)."""
+        if not current_logps.is_cuda:
+            raise RuntimeError("TritonGRPOLossOp requires CUDA tensors.")
+        if completion_mask.ndim != 2:
+            raise ValueError("completion_mask must be 2D [num_sequences, completion_len].")
+        completion_len = completion_mask.shape[1]
+        return _GRPOLossFunction.apply(
+            current_logps,
+            old_logps,
+            ref_logps,
+            sample_advantages,
+            completion_mask,
+            completion_len,
+            clip_eps,
+            beta,
+        )
+
+    def forward(
+        self,
+        current_logps: torch.Tensor,
+        old_logps: torch.Tensor,
+        ref_logps: torch.Tensor,
+        rewards: torch.Tensor,
+        completion_mask: torch.Tensor,
+        *,
+        clip_eps: float = 0.2,
+        beta: float = 0.0,
+        samples_per_prompt: Optional[int] = None,
+        group_boundaries: Optional[Sequence[int] | torch.Tensor] = None,
+        eps: float = 1e-6,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        sample_advantages = self.group_advantages(
+            rewards,
+            samples_per_prompt=samples_per_prompt,
+            group_boundaries=group_boundaries,
+            eps=eps,
+        )
+        return self.apply(
+            current_logps,
+            old_logps,
+            ref_logps,
+            sample_advantages,
+            completion_mask,
+            clip_eps=clip_eps,
+            beta=beta,
+        )

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -33,6 +33,10 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     ROCM_AITER = "rl_engine.kernels.ops.rocm.aiter.AiterOp"
     ROCM_CK = "rl_engine.kernels.ops.rocm.composable_kernel.CKOp"
 
+    # GRPO loss (group reward normalization + clipped surrogate + KL)
+    TRITON_GRPO_LOSS = "rl_engine.kernels.ops.triton.triton_grpo_loss.TritonGRPOLossOp"
+    PYTORCH_GRPO_LOSS = "rl_engine.kernels.ops.pytorch.loss.grpo_loss.NativeGRPOLossOp"
+
     # Generic fallback
     TRITON_GENERIC = "rl_engine.kernels.ops.triton.generic.TritonOp"
     PYTORCH_NATIVE = "rl_engine.kernels.ops.pytorch.loss.logp.NativeLogpOp"
@@ -69,15 +73,18 @@ class KernelRegistry:
                     OpBackend.PYTORCH_NATIVE,
                 ],
                 "attn": [OpBackend.FLASH_ATTN, OpBackend.TRITON_GENERIC, OpBackend.PYTORCH_NATIVE],
+                "grpo_loss": [OpBackend.TRITON_GRPO_LOSS, OpBackend.PYTORCH_GRPO_LOSS],
                 # Default dispatch logic for new operators
             },
             "rocm": {
                 "logp": [OpBackend.ROCM_AITER, OpBackend.TRITON_GENERIC, OpBackend.PYTORCH_NATIVE],
                 "attn": [OpBackend.TRITON_GENERIC, OpBackend.PYTORCH_NATIVE],
+                "grpo_loss": [OpBackend.TRITON_GRPO_LOSS, OpBackend.PYTORCH_GRPO_LOSS],
             },
             "cpu": {
                 "logp": [OpBackend.PYTORCH_NATIVE],
                 "attn": [OpBackend.PYTORCH_NATIVE],
+                "grpo_loss": [OpBackend.PYTORCH_GRPO_LOSS],
             },
         }
         logger.info(f"KernelRegistry initialized for {device_ctx.device_type}")

--- a/tests/test_grpo_loss.py
+++ b/tests/test_grpo_loss.py
@@ -1,0 +1,422 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+import pytest
+import torch
+
+from rl_engine.kernels.ops.pytorch.loss.grpo_loss import NativeGRPOLossOp
+from rl_engine.kernels.ops.pytorch.loss.logp import NativeLogpOp
+from rl_engine.kernels.ops.triton.triton_grpo_loss import TritonGRPOLossOp
+from rl_engine.testing import (
+    compute_policy_ratio,
+    compute_reference_kl,
+    make_synthetic_rl_kernel_batch,
+    masked_mean,
+    selected_logprobs_reference,
+)
+
+try:
+    import triton  # noqa: F401
+
+    _HAS_TRITON = True
+except ImportError:  # pragma: no cover
+    _HAS_TRITON = False
+
+requires_triton_cuda = pytest.mark.skipif(
+    not (_HAS_TRITON and torch.cuda.is_available()),
+    reason="Triton GRPO loss requires a CUDA device and Triton.",
+)
+
+_NUM_PROMPTS = 3
+_SPP = 4
+_COMP_LEN = 6
+_VOCAB = 64
+
+
+# Shared helpers
+def _batch(seed=0, *, device="cpu", valid_density=0.9):
+    return make_synthetic_rl_kernel_batch(
+        num_prompts=_NUM_PROMPTS,
+        samples_per_prompt=_SPP,
+        prompt_len=0,
+        completion_len=_COMP_LEN,
+        vocab_size=_VOCAB,
+        valid_density=valid_density,
+        device=device,
+        seed=seed,
+    )
+
+
+def _logits_like(batch, seed, device="cpu"):
+    gen = torch.Generator(device=device).manual_seed(seed)
+    return torch.randn(batch.batch_size, batch.completion_len, _VOCAB, generator=gen, device=device)
+
+
+def _current_logps(batch, seed, *, device="cpu"):
+    """A realistic per-token current-policy logp derived from synthetic logits."""
+    logits = _logits_like(batch, seed, device=device)
+    return selected_logprobs_reference(logits, batch.token_ids)
+
+
+def _reference_group_advantages(rewards, samples_per_prompt, eps=1e-6):
+    """Mirror of examples.grpo_single_gpu.make_group_advantages normalization."""
+    grouped = rewards.view(-1, samples_per_prompt)
+    group_mean = grouped.mean(dim=1, keepdim=True)
+    group_std = grouped.std(dim=1, keepdim=True, unbiased=False).clamp_min(eps)
+    return ((grouped - group_mean) / group_std).reshape(-1)
+
+
+def _reference_loss(current_logps, old_logps, ref_logps, advantages, mask, clip_eps, beta):
+    """Mirror of examples.grpo_single_gpu.grpo_loss using the testing helpers."""
+    ratio = compute_policy_ratio(current_logps, old_logps, mask)
+    unclipped = ratio * advantages.float()
+    clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * advantages.float()
+    policy_loss_terms = -torch.minimum(unclipped, clipped)
+    kl_terms = compute_reference_kl(current_logps, ref_logps, mask)
+    policy_loss = masked_mean(policy_loss_terms, mask)
+    kl = masked_mean(kl_terms, mask)
+    return policy_loss + beta * kl, policy_loss, kl
+
+
+# pure-PyTorch reference op
+def test_group_advantages_matches_reference_uniform():
+    op = NativeGRPOLossOp()
+    rewards = _batch(seed=1).rewards
+    got = op.group_advantages(rewards, samples_per_prompt=_SPP)
+    expected = _reference_group_advantages(rewards, samples_per_prompt=_SPP)
+    assert torch.allclose(got, expected, atol=1e-6)
+
+
+def test_boundaries_agree_with_uniform():
+    op = NativeGRPOLossOp()
+    rewards = _batch(seed=2).rewards
+    base = op.group_advantages(rewards, samples_per_prompt=_SPP)
+    bounds = list(range(0, _NUM_PROMPTS * _SPP + 1, _SPP))
+    by_bounds = op.group_advantages(rewards, group_boundaries=bounds)
+    assert torch.allclose(base, by_bounds, atol=1e-6)
+
+
+def test_variable_group_boundaries():
+    op = NativeGRPOLossOp()
+    rewards = torch.tensor([1.0, 3.0, 10.0, 20.0, 30.0])
+    got = op.group_advantages(rewards, group_boundaries=[0, 2, 5])
+    # Group 0: [1, 3] -> mean 2, std 1 -> [-1, 1]
+    g0 = torch.tensor([-1.0, 1.0])
+    # Group 1: [10, 20, 30] -> mean 20, std sqrt(200/3)
+    g1 = (torch.tensor([10.0, 20.0, 30.0]) - 20.0) / (200.0 / 3.0) ** 0.5
+    expected = torch.cat([g0, g1])
+    assert torch.allclose(got, expected, atol=1e-5)
+
+
+def test_forward_loss_matches_reference():
+    op = NativeGRPOLossOp()
+    batch = _batch(seed=0)
+    current = _current_logps(batch, seed=100)
+    clip_eps, beta = 0.2, 0.01
+
+    loss, policy_loss, kl = op.forward(
+        current,
+        batch.old_logps,
+        batch.ref_logps,
+        batch.rewards,
+        batch.completion_mask,
+        clip_eps=clip_eps,
+        beta=beta,
+        samples_per_prompt=_SPP,
+    )
+
+    sample_adv = _reference_group_advantages(batch.rewards, samples_per_prompt=_SPP)
+    adv_tokens = (
+        sample_adv[:, None]
+        .expand_as(batch.completion_mask)
+        .clone()
+        .masked_fill(~batch.completion_mask, 0.0)
+    )
+    exp_loss, exp_policy, exp_kl = _reference_loss(
+        current, batch.old_logps, batch.ref_logps, adv_tokens, batch.completion_mask, clip_eps, beta
+    )
+
+    assert torch.allclose(loss, exp_loss, atol=1e-6)
+    assert torch.allclose(policy_loss, exp_policy, atol=1e-6)
+    assert torch.allclose(kl, exp_kl, atol=1e-6)
+
+
+def test_gradient_flows_to_policy_logits():
+    op = NativeGRPOLossOp()
+    batch = _batch(seed=4)
+    current = _current_logps(batch, seed=104).clone().requires_grad_(True)
+
+    loss, _, _ = op.forward(
+        current,
+        batch.old_logps,
+        batch.ref_logps,
+        batch.rewards,
+        batch.completion_mask,
+        clip_eps=0.2,
+        beta=0.01,
+        samples_per_prompt=_SPP,
+    )
+    loss.backward()
+
+    assert current.grad is not None
+    assert torch.isfinite(current.grad).all()
+    # Masked-out tokens must receive zero gradient.
+    assert torch.all(current.grad[~batch.completion_mask] == 0.0)
+
+
+def test_requires_exactly_one_group_spec():
+    op = NativeGRPOLossOp()
+    rewards = _batch(seed=6).rewards
+    with pytest.raises(ValueError):
+        op.group_advantages(rewards)
+    with pytest.raises(ValueError):
+        op.group_advantages(rewards, samples_per_prompt=_SPP, group_boundaries=[0, 4, 8, 12])
+
+
+# Triton fused op (validated against the native reference)
+@requires_triton_cuda
+def test_triton_forward_matches_native():
+    native = NativeGRPOLossOp()
+    fused = TritonGRPOLossOp()
+    batch = _batch(seed=0, device="cuda")
+    current = _current_logps(batch, seed=100, device="cuda")
+    kwargs = dict(clip_eps=0.2, beta=0.05, samples_per_prompt=_SPP)
+
+    args = (current, batch.old_logps, batch.ref_logps, batch.rewards, batch.completion_mask)
+    n_loss, n_policy, n_kl = native.forward(*args, **kwargs)
+    t_loss, t_policy, t_kl = fused.forward(*args, **kwargs)
+
+    assert torch.allclose(t_loss, n_loss, atol=1e-4, rtol=1e-4)
+    assert torch.allclose(t_policy, n_policy, atol=1e-4, rtol=1e-4)
+    assert torch.allclose(t_kl, n_kl, atol=1e-4, rtol=1e-4)
+
+
+@requires_triton_cuda
+def test_triton_backward_matches_native():
+    native = NativeGRPOLossOp()
+    fused = TritonGRPOLossOp()
+    batch = _batch(seed=7, device="cuda")
+    current = _current_logps(batch, seed=107, device="cuda")
+    rest = (batch.old_logps, batch.ref_logps, batch.rewards, batch.completion_mask)
+    kwargs = dict(clip_eps=0.2, beta=0.05, samples_per_prompt=_SPP)
+
+    cur_n = current.clone().requires_grad_(True)
+    loss_n, _, _ = native.forward(cur_n, *rest, **kwargs)
+    loss_n.backward()
+
+    cur_t = current.clone().requires_grad_(True)
+    loss_t, _, _ = fused.forward(cur_t, *rest, **kwargs)
+    loss_t.backward()
+
+    assert cur_t.grad is not None
+    assert torch.allclose(cur_t.grad, cur_n.grad, atol=1e-4, rtol=1e-4)
+    assert torch.all(cur_t.grad[~batch.completion_mask] == 0.0)
+
+
+@requires_triton_cuda
+def test_triton_backward_with_grad_scaling():
+    """A non-unit upstream gradient must scale the policy-logp gradient linearly."""
+    fused = TritonGRPOLossOp()
+    batch = _batch(seed=3, device="cuda")
+    current = _current_logps(batch, seed=103, device="cuda")
+    rest = (batch.old_logps, batch.ref_logps, batch.rewards, batch.completion_mask)
+    kwargs = dict(clip_eps=0.2, beta=0.05, samples_per_prompt=_SPP)
+
+    cur1 = current.clone().requires_grad_(True)
+    loss1, _, _ = fused.forward(cur1, *rest, **kwargs)
+    loss1.backward()
+
+    cur2 = current.clone().requires_grad_(True)
+    loss2, _, _ = fused.forward(cur2, *rest, **kwargs)
+    (3.0 * loss2).backward()
+
+    assert torch.allclose(cur2.grad, 3.0 * cur1.grad, atol=1e-4, rtol=1e-4)
+
+
+@requires_triton_cuda
+def test_triton_group_advantages_matches_native():
+    native = NativeGRPOLossOp()
+    fused = TritonGRPOLossOp()
+    rewards = _batch(seed=5, device="cuda").rewards
+    got = fused.group_advantages(rewards, samples_per_prompt=_SPP)
+    expected = native.group_advantages(rewards, samples_per_prompt=_SPP)
+    assert torch.allclose(got, expected, atol=1e-5)
+    # Variable group sizes via boundaries.
+    got_b = fused.group_advantages(rewards, group_boundaries=[0, 5, 12])
+    exp_b = native.group_advantages(rewards, group_boundaries=[0, 5, 12])
+    assert torch.allclose(got_b, exp_b, atol=1e-5)
+
+
+@requires_triton_cuda
+def test_triton_apply_with_per_sequence_advantages_matches_native():
+    native = NativeGRPOLossOp()
+    fused = TritonGRPOLossOp()
+    batch = _batch(seed=11, device="cuda")
+    current = _current_logps(batch, seed=111, device="cuda")
+
+    sample_adv = native.group_advantages(batch.rewards, samples_per_prompt=_SPP)  # per-sequence
+    adv_tokens = native.expand_advantages(sample_adv, batch.completion_mask)  # per-token for native
+
+    n_loss, _, _ = native.apply(
+        current,
+        batch.old_logps,
+        batch.ref_logps,
+        adv_tokens,
+        batch.completion_mask,
+        clip_eps=0.2,
+        beta=0.05,
+    )
+    t_loss, _, _ = fused.apply(
+        current,
+        batch.old_logps,
+        batch.ref_logps,
+        sample_adv,
+        batch.completion_mask,
+        clip_eps=0.2,
+        beta=0.05,
+    )
+    assert torch.allclose(t_loss, n_loss, atol=1e-4, rtol=1e-4)
+
+
+# Pipeline composition: logp op -> grpo_loss op
+def test_native_logp_composes_with_native_grpo():
+    logp_op = NativeLogpOp()
+    grpo = NativeGRPOLossOp()
+    batch = _batch(seed=21)
+    logits = _logits_like(batch, seed=121)
+    kwargs = dict(clip_eps=0.2, beta=0.05, samples_per_prompt=_SPP)
+    rest = (batch.old_logps, batch.ref_logps, batch.rewards, batch.completion_mask)
+
+    current = logp_op.apply_fp32(logits, batch.token_ids)
+    loss, _, _ = grpo.forward(current, *rest, **kwargs)
+
+    oracle = selected_logprobs_reference(logits, batch.token_ids)
+    exp, _, _ = grpo.forward(oracle, *rest, **kwargs)
+    assert torch.isfinite(loss)
+    assert torch.allclose(loss, exp, atol=1e-6)
+
+
+def test_native_logp_grpo_pipeline_is_differentiable_to_logits():
+    """NativeLogpOp uses log_softmax/gather, so grads flow logits -> loss."""
+    logp_op = NativeLogpOp()
+    grpo = NativeGRPOLossOp()
+    batch = _batch(seed=22)
+    logits = _logits_like(batch, seed=122).clone().requires_grad_(True)
+
+    current = logp_op.apply_fp32(logits, batch.token_ids)
+    loss, _, _ = grpo.forward(
+        current,
+        batch.old_logps,
+        batch.ref_logps,
+        batch.rewards,
+        batch.completion_mask,
+        clip_eps=0.2,
+        beta=0.05,
+        samples_per_prompt=_SPP,
+    )
+    loss.backward()
+
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()
+
+
+@requires_triton_cuda
+def test_dispatched_logp_composes_with_triton_grpo():
+    """Real pipeline: dispatched CUDA fused logp -> Triton GRPO loss."""
+    from rl_engine.kernels.registry import kernel_registry
+
+    logp_op = kernel_registry.get_op("logp")
+    grpo = TritonGRPOLossOp()
+    batch = _batch(seed=23, device="cuda")
+    logits = _logits_like(batch, seed=123, device="cuda")
+    kwargs = dict(clip_eps=0.2, beta=0.05, samples_per_prompt=_SPP)
+    rest = (batch.old_logps, batch.ref_logps, batch.rewards, batch.completion_mask)
+
+    current = logp_op.apply_fp32(logits, batch.token_ids)
+    loss, _, _ = grpo.forward(current, *rest, **kwargs)
+
+    oracle = selected_logprobs_reference(logits, batch.token_ids)
+    exp, _, _ = NativeGRPOLossOp().forward(oracle, *rest, **kwargs)
+    assert torch.isfinite(loss)
+    assert torch.allclose(loss, exp, atol=1e-3, rtol=1e-3)
+
+
+# Loss step: masked-token invariance and a gradient step
+def _perturb_inactive(batch, current):
+    """Set garbage at masked positions; the loss must ignore them."""
+    inactive = ~batch.completion_mask
+    cur = current.clone()
+    old = batch.old_logps.clone()
+    ref = batch.ref_logps.clone()
+    cur[inactive] = 1000.0
+    old[inactive] = -1000.0
+    ref[inactive] = 500.0
+    return cur, old, ref
+
+
+def test_masked_tokens_do_not_affect_native_loss():
+    op = NativeGRPOLossOp()
+    batch = _batch(seed=8, valid_density=0.75)
+    current = _current_logps(batch, seed=108)
+    kwargs = dict(clip_eps=0.2, beta=0.05, samples_per_prompt=_SPP)
+
+    base, _, _ = op.forward(
+        current, batch.old_logps, batch.ref_logps, batch.rewards, batch.completion_mask, **kwargs
+    )
+    cur_p, old_p, ref_p = _perturb_inactive(batch, current)
+    pert, _, _ = op.forward(cur_p, old_p, ref_p, batch.rewards, batch.completion_mask, **kwargs)
+    assert torch.allclose(base, pert)
+
+
+@requires_triton_cuda
+def test_masked_tokens_do_not_affect_triton_loss():
+    fused = TritonGRPOLossOp()
+    batch = _batch(seed=8, device="cuda", valid_density=0.75)
+    current = _current_logps(batch, seed=108, device="cuda")
+    kwargs = dict(clip_eps=0.2, beta=0.05, samples_per_prompt=_SPP)
+
+    base, _, _ = fused.forward(
+        current, batch.old_logps, batch.ref_logps, batch.rewards, batch.completion_mask, **kwargs
+    )
+    cur_p, old_p, ref_p = _perturb_inactive(batch, current)
+    pert, _, _ = fused.forward(cur_p, old_p, ref_p, batch.rewards, batch.completion_mask, **kwargs)
+    assert torch.allclose(base, pert, atol=1e-5)
+
+
+def _descend(op, batch, seed, *, device="cpu", steps=5, lr=0.05):
+    rest = (batch.old_logps, batch.ref_logps, batch.rewards, batch.completion_mask)
+    kwargs = dict(clip_eps=0.2, beta=0.05, samples_per_prompt=_SPP)
+    initial = op.forward(_current_logps(batch, seed, device=device), *rest, **kwargs)[0]
+    params = _current_logps(batch, seed, device=device).clone().requires_grad_(True)
+    for _ in range(steps):
+        loss, _, _ = op.forward(params, *rest, **kwargs)
+        (grad,) = torch.autograd.grad(loss, params)
+        params = (params - lr * grad).detach().requires_grad_(True)
+    final = op.forward(params, *rest, **kwargs)[0]
+    return initial, final
+
+
+def test_grpo_gradient_step_reduces_loss():
+    """Full loss step: forward -> backward -> SGD on the policy logps lowers the loss."""
+    op = NativeGRPOLossOp()
+    initial, final = _descend(op, _batch(seed=9), seed=109)
+    assert final.item() < initial.item()
+
+
+@requires_triton_cuda
+def test_triton_grpo_gradient_step_reduces_loss():
+    fused = TritonGRPOLossOp()
+    initial, final = _descend(fused, _batch(seed=9, device="cuda"), seed=109, device="cuda")
+    assert final.item() < initial.item()
+
+
+# Registry dispatch (device-dependent backend selection)
+def test_registry_dispatches_grpo_loss():
+    from rl_engine.kernels.registry import kernel_registry
+
+    op = kernel_registry.get_op("grpo_loss")
+    assert hasattr(op, "forward") and hasattr(op, "group_advantages")
+    if _HAS_TRITON and torch.cuda.is_available():
+        assert isinstance(op, TritonGRPOLossOp)
+    else:
+        assert isinstance(op, NativeGRPOLossOp)


### PR DESCRIPTION
#46 

## Summary
Implements the GRPO loss as a dispatchable `grpo_loss` op, eliminating the broadcasting/allocation overhead of a naive PyTorch implementation.

1. **`NativeGRPOLossOp`**: group-wise reward normalization (mean / population std, `clamp_min`), clipped surrogate objective + k3 reference-KL over active tokens.
2. **`TritonGRPOLossOp`**: `_group_norm_kernel` (per-group reward stats in registers) + token-parallel `_grpo_fwd_kernel`/`_grpo_bwd_kernel` with an **analytic** backward w.r.t. per-token logps. Each token gathers its advantage on the fly (`seq_id = idx // completion_len`), so **no broadcasted `[B, T]` advantage tensor is ever materialized**. Wrapped in a `torch.autograd.Function`.
3. **Registry dispatch** — `grpo_loss` resolves to the Triton backend on CUDA/ROCm, PyTorch native on CPU / when Triton is unavailable.

## Tests (`tests/test_grpo_loss.py`)
Built on `rl_engine.testing` fixtures (`make_synthetic_rl_kernel_batch`, `selected_logprobs_reference`, reference helpers):
- native op vs the reference group-norm + surrogate/KL recipe;
- Triton forward / backward / grad-scaling / per-sequence-apply vs native;
- `logp → grpo_loss` pipeline (NativeLogpOp + dispatched CUDA fused logp), incl.
  differentiability to logits;
- loss-step: masked-token invariance + an SGD step that lowers the loss;
- registry dispatch.

## Benchmark (`benchmarks/benchmark_grpo_loss.py`)
| shape (P×S×L) | tokens | fwd speedup | fwd+bwd speedup | VRAM (native→triton) |
|---|---|---|---|---|
| 64×8×512   | 0.26M | 4.70× | 2.98× | 10 MB → 1 MB |
| 128×8×1024 | 1.05M | 3.16× | 2.66× | 40 MB → 4 MB |
| 256×16×1024| 4.19M | 2.97× | 2.99× | 160 MB → 16 MB |

~3–4.7× faster forward, ~3× forward+backward, ~10× less peak VRAM.

## Notes
- `old_logps`/`ref_logps` are precomputed per-token constants.
- Group normalization stays a separate lightweight kernel by design (scalar per sequence; fusing it into the token kernel would trade away token-parallelism).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GRPO (Group Relative Policy Optimization) loss with both high-performance CUDA (Triton) and native PyTorch backends; runtime selects the best available implementation.

* **Benchmarks**
  * Added a CLI benchmark tool measuring forward and forward+backward latency and peak VRAM across configurable shapes, outputting markdown tables.

* **Tests**
  * Added comprehensive tests for loss values, gradients, grouping modes, backend parity, masked tokens, and integration.

* **Documentation**
  * Added operator docs and index entry describing usage, tensor contracts, and performance notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->