### PR TITLE
Add docs wiki links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://github.com/Flink-ddd/RL-Kernel"><img src="https://img.shields.io/badge/Hardware-NVIDIA%20CUDA%20%7C%20AMD%20ROCm-orange" alt="Hardware"></a>
   <a href="https://discord.gg/RGUQrr74z"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
-  <a href="https://github.com/RL-Align/RL-Kernel/tree/main/docs"><img src="https://img.shields.io/badge/Documentation-Docs-2ea44f" alt="Documentation"></a>
+  <a href="https://a-kaa.github.io/RL-Kernel/"><img src="https://img.shields.io/badge/Documentation-Docs-2ea44f" alt="Documentation"></a>
   <a href="https://deepwiki.com/RL-Align/RL-Kernel"><img src="https://img.shields.io/badge/Ask-DeepWiki-7B3FE4" alt="Ask DeepWiki"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
-  <a href="https://github.com/Flink-ddd/RL-Kernel"><img src="https://img.shields.io/badge/Hardware-NVIDIA%20CUDA%20%7C%20AMD%20ROCm-orange" alt="Hardware"></a>
+  <a href="https://github.com/RL-Align/RL-Kernel"><img src="https://img.shields.io/badge/Hardware-NVIDIA%20CUDA%20%7C%20AMD%20ROCm-orange" alt="Hardware"></a>
   <a href="https://discord.gg/RGUQrr74z"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <a href="https://rl-align.github.io/RL-Kernel/"><img src="https://img.shields.io/badge/Documentation-Docs-2ea44f" alt="Documentation"></a>
   <a href="https://deepwiki.com/RL-Align/RL-Kernel"><img src="https://img.shields.io/badge/Ask-DeepWiki-7B3FE4" alt="Ask DeepWiki"></a>
@@ -89,7 +89,7 @@ RL-Kernel sits between high-level alignment libraries and low-level GPU kernels,
 ### Installation
 ```bash
 # Clone the repository
-git clone https://github.com/Flink-ddd/RL-Kernel.git
+git clone https://github.com/RL-Align/RL-Kernel.git
 cd RL-Kernel
 
 # Install core dependencies (CUDA 12.4+ recommended)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License"></a>
   <a href="https://github.com/Flink-ddd/RL-Kernel"><img src="https://img.shields.io/badge/Hardware-NVIDIA%20CUDA%20%7C%20AMD%20ROCm-orange" alt="Hardware"></a>
   <a href="https://discord.gg/RGUQrr74z"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
-  <a href="https://a-kaa.github.io/RL-Kernel/"><img src="https://img.shields.io/badge/Documentation-Docs-2ea44f" alt="Documentation"></a>
+  <a href="https://rl-align.github.io/RL-Kernel/"><img src="https://img.shields.io/badge/Documentation-Docs-2ea44f" alt="Documentation"></a>
   <a href="https://deepwiki.com/RL-Align/RL-Kernel"><img src="https://img.shields.io/badge/Ask-DeepWiki-7B3FE4" alt="Ask DeepWiki"></a>
 </p>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,9 @@ hide:
 
 <p style="text-align:center">
 <script async defer src="https://buttons.github.io/buttons.js"></script>
-<a class="github-button" href="https://github.com/Flink-ddd/RL-Kernel" data-show-count="true" data-size="large" aria-label="Star">Star</a>
-<a class="github-button" href="https://github.com/Flink-ddd/RL-Kernel/subscription" data-show-count="true" data-icon="octicon-eye" data-size="large" aria-label="Watch">Watch</a>
-<a class="github-button" href="https://github.com/Flink-ddd/RL-Kernel/fork" data-show-count="true" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork">Fork</a>
+<a class="github-button" href="https://github.com/RL-Align/RL-Kernel" data-show-count="true" data-size="large" aria-label="Star">Star</a>
+<a class="github-button" href="https://github.com/RL-Align/RL-Kernel/subscription" data-show-count="true" data-icon="octicon-eye" data-size="large" aria-label="Watch">Watch</a>
+<a class="github-button" href="https://github.com/RL-Align/RL-Kernel/fork" data-show-count="true" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork">Fork</a>
 </p>
 
 RL-Kernel bridges high-level alignment algorithms and low-level hardware optimizations.

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -2,8 +2,8 @@
 
 RL-Kernel is developed in the open at:
 
-- [GitHub repository](https://github.com/Flink-ddd/RL-Kernel)
-- [Apache-2.0 license](https://github.com/Flink-ddd/RL-Kernel/blob/main/LICENSE)
+- [GitHub repository](https://github.com/RL-Align/RL-Kernel)
+- [Apache-2.0 license](https://github.com/RL-Align/RL-Kernel/blob/main/LICENSE)
 
 Use GitHub issues and pull requests for bug reports, operator proposals, and documentation
 improvements.

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -6,7 +6,7 @@ CUDA toolchain; ROCm builds require a compatible ROCm environment.
 ## From Source
 
 ```bash
-git clone https://github.com/Flink-ddd/RL-Kernel.git
+git clone https://github.com/RL-Align/RL-Kernel.git
 cd RL-Kernel
 pip install -e .
 ```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,5 +1,5 @@
 site_name: RL-Kernel
-site_url: https://flink-ddd.github.io/RL-Kernel/
+site_url: https://a-kaa.github.io/RL-Kernel/
 repo_url: https://github.com/Flink-ddd/RL-Kernel
 edit_uri: edit/main/docs/
 exclude_docs: |

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,6 +1,6 @@
 site_name: RL-Kernel
-site_url: https://a-kaa.github.io/RL-Kernel/
-repo_url: https://github.com/Flink-ddd/RL-Kernel
+site_url: https://rl-align.github.io/RL-Kernel/
+repo_url: https://github.com/RL-Align/RL-Kernel
 edit_uri: edit/main/docs/
 exclude_docs: |
 


### PR DESCRIPTION
This PR updates the documentation and repository links to point to the official `RL-Align/RL-Kernel` repository.

## Changes

- Added documentation wiki links.
- Updated documentation site URL references.
- Replaced fork repository links with the official repository URL.
- Updated remaining README/docs links to use `RL-Align/RL-Kernel`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository references throughout documentation to point to the new RL-Align/RL-Kernel repository location
  * Updated installation and clone instructions to use the new repository URL
  * Updated GitHub buttons and site metadata links to reflect the new repository

<!-- end of auto-generated comment: release notes by coderabbit.ai -->