### PR TITLE
[Bugfix][ci]: enable gpu-ci for fork PRs with secure checkout

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -1,7 +1,7 @@
 name: GPU CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [ main ]
     paths:
       - 'csrc/**'
@@ -26,7 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout secure orchestrator script from base branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Install runpodctl
         run: |


### PR DESCRIPTION
Fixes the API key not found error when running GPU CI on PRs from external forks (PR #97).

**Key Changes:**
- Switched workflow trigger to pull_request_target to allow secret access for fork PRs.
- Added ref: ${{ github.event.pull_request.base.sha }} to enforce strict base checkout. This ensures only our trusted orchestration script runs with secrets, completely closing the code injection vulnerability.

**Test Result**

```
tests/test_weight_sync_bridge.py::test_vllm_weight_install_adapter_uses_explicit_capability PASSED [ 88%]
tests/test_weight_sync_bridge.py::test_vllm_weight_install_adapter_requires_verified_capability PASSED [ 88%]
tests/test_weight_sync_bridge.py::test_vllm_weight_install_adapter_uses_public_update_weights_request_builder PASSED [ 89%]
tests/test_weight_sync_bridge.py::test_vllm_update_weights_api_requires_explicit_request_builder PASSED [ 90%]
tests/test_weight_sync_bridge.py::test_vllm_ipc_request_builder_creates_public_update_request_for_cuda_tensors PASSED [ 90%]
tests/test_weight_sync_bridge.py::test_vllm_ipc_request_builder_requires_cuda_tensors PASSED [ 91%]
tests/test_weight_sync_bridge.py::test_vllm_install_adapter_releases_ipc_request_builder_keepalive PASSED [ 92%]
tests/test_weight_sync_bridge.py::test_vllm_install_adapter_releases_ipc_keepalive_when_update_fails PASSED [ 92%]
tests/test_weight_sync_bridge.py::test_vllm_in_process_reload_adapter_uses_collective_rpc_reload_weights PASSED [ 93%]
tests/test_weight_sync_bridge.py::test_vllm_in_process_reload_adapter_uses_direct_reload_weights_capability PASSED [ 94%]
tests/test_weight_sync_bridge.py::test_vllm_in_process_reload_adapter_requires_complete_manifest PASSED [ 94%]
tests/test_weight_sync_bridge.py::test_vllm_in_process_reload_adapter_does_not_activate_failed_reload PASSED [ 95%]
tests/test_weight_sync_bridge.py::test_vllm_checkpoint_reload_adapter_uses_manifest_weights_path PASSED [ 96%]
tests/test_weight_sync_bridge.py::test_vllm_checkpoint_reload_adapter_uses_resolver PASSED [ 96%]
tests/test_weight_sync_bridge.py::test_vllm_checkpoint_reload_adapter_requires_weights_path PASSED [ 97%]
tests/test_weight_sync_bridge.py::test_vllm_cuda_vmm_external_storage_adapter_requires_cuda_vmm_manifest PASSED [ 98%]
tests/test_weight_sync_bridge.py::test_vllm_cuda_vmm_external_storage_adapter_rebinds_matching_parameters PASSED [ 98%]
tests/test_weight_sync_bridge.py::test_vllm_cuda_vmm_external_storage_adapter_rolls_back_partial_rebind PASSED [ 99%]
tests/test_weight_sync_bridge.py::test_cuda_vmm_driver_backend_prefers_env_libcuda PASSED [100%]

======================= 149 passed, 1 skipped in 15.36s ========================
[ci] Remote execution finished with exit code = 0

[ci] ========================================================
[ci] === AUTOMATIC CLEANUP: Removing pod 0sq5w2muvwp3xm ===
[ci] ========================================================
{
  "deleted": true,
  "id": "0sq5w2muvwp3xm"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GPU continuous integration workflow configuration for enhanced security and stability in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->