### PR TITLE
[CI] Add stale PR management workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,42 @@
+name: Mark stale pull requests
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Handle stale PRs
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          # only handle PR，not issues
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # PR rules
+          days-before-pr-stale: 30
+          days-before-pr-close: 30
+          stale-pr-label: "stale"
+
+          # exclude labels
+          exempt-pr-labels: "WIP,pinned,security"
+          exempt-draft-pr: true
+
+          # message
+          stale-pr-message: >
+            This pull request has been inactive for 30 days.
+            To keep things moving, please update it or let us know
+            if it's still in progress. Otherwise it will be
+            automatically closed in 30 days.
+
+          close-pr-message: >
+            Closing this pull request due to 60 days of inactivity.
+            Feel free to reopen it if you'd like to continue the work,
+            or open a new PR. Thank you for your contribution!:-)


### PR DESCRIPTION
## Summary

Adds an automated GitHub Actions workflow to manage inactive Pull Requests using `actions/stale@v10`.

Closes #123

## Behavior

| Event | Trigger | Action |
|---|---|---|
| No activity | 30 days | Add `stale` label + post warning comment |
| Still no activity | +30 days (60 total) | Close PR + post closing comment |
| Exempt label present (`WIP`, `pinned`, `security`) | Any time | Skip |
| Draft PR | Any time | Skip |

Issues are explicitly disabled (`days-before-issue-stale: -1`).

## Testing

✅ `actionlint` syntax validation passed with no errors
✅ Workflow triggered via `push` on branch with `days-before-pr-stale: 0` — ran successfully, no warnings
✅ Upgraded from `actions/stale@v9` to `v10` for Node.js 24 compatibility — warning resolved
✅ Verified `days-before-issue-stale: -1` correctly skips all issues in run logs
✅ Restored production config (`days-before-pr-stale: 30`, `days-before-pr-close: 30`) before this PR

---
*Assisted by Claude Sonnet 4.6*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated stale pull request management workflow that runs daily (and supports manual triggering). Pull requests inactive for 30 days are labeled as “stale,” with exemptions for specific labels and draft pull requests, and customized notifications for both staleness and eventual closure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->