### PR TITLE
[Fix][CI] Correct pull_request_target YAML syntax in auto-review workflow

### DIFF
--- a/.github/workflows/auto-reviewer.yml
+++ b/.github/workflows/auto-reviewer.yml
@@ -5,7 +5,7 @@ name: Auto-Request-Review
 
 on:
     pull_request_target:
-    types: [opened, reopened]
+      types: [opened, reopened]
 
 jobs:
   add-reviewer:


### PR DESCRIPTION
## Purpose
Fix #144 

## Problem
GitHub Actions failed with: Unexpected value 'types'
<img width="605" height="172" alt="image" src="https://github.com/user-attachments/assets/775ba9e3-6f86-401f-ba36-b5cfa938b798" />


## Solution
- Corrected indentation under `pull_request_target`
- Ensured valid event structure

## Result
- Workflow loads successfully without syntax errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal workflow configuration maintenance with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->