### PR TITLE
fix(ratio_kl): sanitize out-of-range action ids at masked positions

### DIFF
--- a/rl_engine/kernels/ops/pytorch/loss/ratio_kl.py
+++ b/rl_engine/kernels/ops/pytorch/loss/ratio_kl.py
@@ -45,9 +45,11 @@ class NativeRatioKLOp:
                 f"action_ids at active (unmasked) positions must be in "
                 f"[0, {vocab_size}); found out-of-range ids."
             )
-        logp_policy = self._selected_logp(policy_logits, action_ids)
+        # Masked positions may hold out-of-range ids; clamp before gather to avoid a CUDA assert.
+        safe_action_ids = action_ids.masked_fill(~mask, 0)
+        logp_policy = self._selected_logp(policy_logits, safe_action_ids)
         with torch.no_grad():
-            logp_ref = self._selected_logp(ref_logits, action_ids)
+            logp_ref = self._selected_logp(ref_logits, safe_action_ids)
 
         delta = (logp_policy - old_logps.float()).masked_fill(~mask, 0.0)
         diff = (logp_ref - logp_policy).masked_fill(~mask, 0.0)


### PR DESCRIPTION
## Summary

`NativeRatioKLOp` passed raw `action_ids` to `torch.gather` even at masked/padding positions. Out-of-range ids there trigger a CUDA device-side assert. This sanitizes masked-position ids before gather; those positions are zeroed out downstream so results are unchanged. Out-of-range ids at active positions still raise.

Fixes #161

## Test

### Command
```bash
CUDA_LAUNCH_BLOCKING=1 python -m pytest tests/test_ratio_kl.py::test_triton_handles_oob_action_ids -v
```

### Before
```
FAILED tests/test_ratio_kl.py::test_triton_handles_oob_action_ids - torch.AcceleratorError: CUDA error: device-side assert triggered
============================================================== 1 failed in 2.10s ==============================================================
```

### After
```
tests/test_ratio_kl.py::test_triton_handles_oob_action_ids PASSED                                                                       [100%]
============================================================== 1 passed in 2.34s ==============================================================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of masked positions in loss computations to ensure more stable and accurate gradient calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->