### PR TITLE
test(ws3): decouple sampling from logprob scoring

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -14,6 +14,27 @@ python -m pytest rl_engine/tests/test_dispatch.py -v
 python tests/test_op_accuracy.py
 ```
 
+## Teacher-Forced Logprob Checks
+
+Consistency benchmarks must score a fixed token sequence. Rollout sampling
+parameters such as temperature, top-p, or top-k choose the generated tokens, but
+they must not be applied again when training or benchmark code computes selected
+log-probs for that sequence.
+
+Use `teacher_forced_logprobs_reference` for reference scoring:
+
+```python
+from rl_engine.testing import teacher_forced_logprobs_reference
+
+logps = teacher_forced_logprobs_reference(logits, token_ids, mask=completion_mask)
+```
+
+Focused checks:
+
+```bash
+python -m pytest tests/test_reference_ops.py tests/test_training_contract.py -v
+```
+
 ## Documentation Build
 
 ```bash

--- a/examples/grpo_single_gpu.py
+++ b/examples/grpo_single_gpu.py
@@ -27,8 +27,8 @@ from rl_engine.testing import (  # noqa: E402
     compute_reference_kl,
     make_synthetic_rl_kernel_batch,
     masked_mean,
-    selected_logprobs_reference,
     summarize_kernel_drift,
+    teacher_forced_logprobs_reference,
 )
 
 
@@ -199,7 +199,7 @@ def run_training(args: argparse.Namespace) -> list[StepMetrics]:
 
     with torch.no_grad():
         initial_logits = policy(batch.token_ids)
-        old_logps = selected_logprobs_reference(
+        old_logps = teacher_forced_logprobs_reference(
             initial_logits,
             batch.token_ids,
             mask=batch.completion_mask,
@@ -223,7 +223,7 @@ def run_training(args: argparse.Namespace) -> list[StepMetrics]:
     for step in range(args.steps):
         optimizer.zero_grad(set_to_none=True)
         logits = policy(batch.token_ids)
-        reference_logps = selected_logprobs_reference(
+        reference_logps = teacher_forced_logprobs_reference(
             logits,
             batch.token_ids,
             mask=batch.completion_mask,

--- a/rl_engine/executors/deepspeed_trainer.py
+++ b/rl_engine/executors/deepspeed_trainer.py
@@ -29,7 +29,7 @@ from rl_engine.testing import (
     compute_policy_ratio,
     compute_reference_kl,
     masked_mean,
-    selected_logprobs_reference,
+    teacher_forced_logprobs_reference,
 )
 
 _TDestination = TypeVar("_TDestination", bound=dict[str, Any])
@@ -106,7 +106,7 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
         batch, payload_metrics = self._batch_from_rollout_or_synthetic(rollout)
 
         logits = _extract_logits(self.engine(batch.token_ids.long()))
-        current_logps = selected_logprobs_reference(
+        current_logps = teacher_forced_logprobs_reference(
             logits,
             batch.token_ids,
             mask=batch.completion_mask,

--- a/rl_engine/executors/training_contract.py
+++ b/rl_engine/executors/training_contract.py
@@ -78,6 +78,7 @@ class RolloutBatchMixin:
         if token_groups:
             return self._batch_from_token_groups(token_groups, rollout), {
                 "training_data_source": "rollout_payload",
+                "logprob_scoring_mode": "teacher_forcing",
                 "rollout_sequences": len(token_groups),
                 "rollout_tokens": sum(len(group) for group in token_groups),
             }
@@ -96,6 +97,7 @@ class RolloutBatchMixin:
         )
         return batch, {
             "training_data_source": "synthetic_fallback",
+            "logprob_scoring_mode": "synthetic_teacher_forcing",
             "rollout_sequences": 0,
             "rollout_tokens": 0,
         }
@@ -184,6 +186,7 @@ class RolloutBatchMixin:
             "device": str(self.device),
             "seed": self.config.seed + int(rollout.iteration),
             "source": "rollout_payload",
+            "logprob_scoring_mode": "teacher_forcing",
         }
         return SyntheticRLKernelBatch(
             input_ids=input_ids,

--- a/rl_engine/testing/__init__.py
+++ b/rl_engine/testing/__init__.py
@@ -11,6 +11,7 @@ from .reference_ops import (
     masked_sum,
     selected_logprobs_reference,
     summarize_kernel_drift,
+    teacher_forced_logprobs_reference,
 )
 from .rl_batch import SyntheticRLKernelBatch, make_synthetic_rl_kernel_batch
 
@@ -24,4 +25,5 @@ __all__ = [
     "masked_sum",
     "selected_logprobs_reference",
     "summarize_kernel_drift",
+    "teacher_forced_logprobs_reference",
 ]

--- a/rl_engine/testing/reference_ops.py
+++ b/rl_engine/testing/reference_ops.py
@@ -47,6 +47,29 @@ def selected_logprobs_reference(
     return selected.to(dtype=output_dtype)
 
 
+def teacher_forced_logprobs_reference(
+    logits: torch.Tensor,
+    token_ids: torch.Tensor,
+    mask: torch.Tensor | None = None,
+    output_dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Reference logprobs for scoring a fixed token sequence.
+
+    Sampling parameters choose the sequence during rollout; they are not part of
+    teacher-forced scoring. This helper intentionally fixes temperature to 1.0
+    so cross-engine drift checks compare log p(token_ids | context), not sampling
+    variance.
+    """
+
+    return selected_logprobs_reference(
+        logits,
+        token_ids,
+        mask=mask,
+        temperature=1.0,
+        output_dtype=output_dtype,
+    )
+
+
 def masked_sum(values: torch.Tensor, mask: torch.Tensor | None = None) -> torch.Tensor:
     """Sum values while ignoring masked-out entries."""
 

--- a/tests/test_reference_ops.py
+++ b/tests/test_reference_ops.py
@@ -12,6 +12,7 @@ from rl_engine.testing import (
     masked_sum,
     selected_logprobs_reference,
     summarize_kernel_drift,
+    teacher_forced_logprobs_reference,
 )
 
 
@@ -74,6 +75,41 @@ def test_selected_logprobs_reference_temperature():
 def test_selected_logprobs_reference_rejects_bad_temperature():
     with pytest.raises(ValueError, match="temperature"):
         selected_logprobs_reference(torch.randn(1, 3), torch.tensor([0]), temperature=0.0)
+
+
+def test_teacher_forced_logprobs_match_unit_temperature_reference():
+    logits = torch.tensor([[[2.0, -1.0, 0.5], [0.25, 1.25, -0.5]]])
+    token_ids = torch.tensor([[0, 1]])
+    mask = torch.tensor([[True, False]])
+
+    actual = teacher_forced_logprobs_reference(logits, token_ids, mask=mask)
+    expected = selected_logprobs_reference(logits, token_ids, mask=mask, temperature=1.0)
+
+    assert torch.allclose(actual, expected)
+    assert actual[0, 1] == 0.0
+
+
+def test_teacher_forced_logprobs_do_not_apply_sampling_temperature():
+    logits = torch.tensor([[[4.0, 1.0, -1.0], [0.1, 2.0, -0.5]]])
+    token_ids = torch.tensor([[0, 1]])
+
+    actual = teacher_forced_logprobs_reference(logits, token_ids)
+    wrongly_temperature_scaled = selected_logprobs_reference(logits, token_ids, temperature=0.25)
+
+    assert not torch.allclose(actual, wrongly_temperature_scaled)
+
+
+def test_teacher_forced_logprobs_preserve_dtype_contract():
+    logits = torch.randn(2, 3, 5)
+    token_ids = torch.tensor([[0, 1, 2], [3, 4, 0]])
+
+    actual = teacher_forced_logprobs_reference(
+        logits,
+        token_ids,
+        output_dtype=torch.float16,
+    )
+
+    assert actual.dtype == torch.float16
 
 
 def test_masked_reductions_ignore_inactive_tokens():

--- a/tests/test_training_contract.py
+++ b/tests/test_training_contract.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+import torch
+
+from rl_engine.executors.training_contract import (
+    RolloutBatchMixin,
+    TorchRLTrainingConfig,
+    extract_rollout_token_groups,
+    make_rollout_result,
+)
+from rl_engine.testing import teacher_forced_logprobs_reference
+
+
+class _BatchBuilder(RolloutBatchMixin):
+    def __init__(self):
+        self.config = TorchRLTrainingConfig(
+            prompt_len=2,
+            completion_len=3,
+            vocab_size=8,
+            dtype=torch.float32,
+            seed=17,
+        )
+        self.device = torch.device("cpu")
+
+
+def _rollout_payload(*, token_groups: list[list[int]], sampling_params: dict) -> dict:
+    return {
+        "sampling_params": dict(sampling_params),
+        "normalized_outputs": [
+            [
+                {
+                    "token_ids": list(token_ids),
+                    "sampling_params": dict(sampling_params),
+                    "text": f"sample-{index}",
+                }
+            ]
+            for index, token_ids in enumerate(token_groups)
+        ],
+    }
+
+
+def test_rollout_token_extraction_ignores_sampling_params():
+    token_groups = [[2, 1, 3], [4, 0, 2]]
+    payloads = [
+        _rollout_payload(token_groups=token_groups, sampling_params={"temperature": 0.1}),
+        _rollout_payload(
+            token_groups=token_groups,
+            sampling_params={"temperature": 1.8, "top_p": 0.4, "top_k": 8},
+        ),
+    ]
+
+    assert [extract_rollout_token_groups(payload) for payload in payloads] == [
+        token_groups,
+        token_groups,
+    ]
+
+
+def test_same_sampled_tokens_score_the_same_under_different_sampling_params():
+    token_groups = [[2, 1, 3], [4, 0, 2]]
+    logits = torch.tensor(
+        [
+            [[0.0, 0.5, 2.0, -1.0, 1.0, 0.2, -0.4, 0.1]] * 3,
+            [[1.5, -0.5, 0.25, 0.75, 2.0, -1.0, 0.0, 0.3]] * 3,
+        ]
+    )
+    builder = _BatchBuilder()
+
+    scored_batches = []
+    for sampling_params in (
+        {"temperature": 0.1, "top_p": 0.95},
+        {"temperature": 1.6, "top_p": 0.4, "top_k": 5},
+    ):
+        batch, metrics = builder._batch_from_rollout_or_synthetic(
+            make_rollout_result(
+                iteration=3,
+                weight_version=1,
+                payload=_rollout_payload(
+                    token_groups=token_groups,
+                    sampling_params=sampling_params,
+                ),
+            )
+        )
+
+        assert metrics["training_data_source"] == "rollout_payload"
+        assert metrics["logprob_scoring_mode"] == "teacher_forcing"
+        assert batch.metadata["logprob_scoring_mode"] == "teacher_forcing"
+        scored_batches.append(
+            teacher_forced_logprobs_reference(
+                logits,
+                batch.token_ids,
+                mask=batch.completion_mask,
+            )
+        )
+
+    assert torch.equal(scored_batches[0], scored_batches[1])
+
+
+def test_teacher_forced_score_changes_when_fixed_token_sequence_changes():
+    logits = torch.tensor(
+        [
+            [[0.0, 0.5, 2.0, -1.0, 1.0, 0.2, -0.4, 0.1]] * 3,
+            [[1.5, -0.5, 0.25, 0.75, 2.0, -1.0, 0.0, 0.3]] * 3,
+        ]
+    )
+    builder = _BatchBuilder()
+
+    first, _ = builder._batch_from_rollout_or_synthetic(
+        make_rollout_result(
+            iteration=3,
+            weight_version=1,
+            payload=_rollout_payload(
+                token_groups=[[2, 1, 3], [4, 0, 2]],
+                sampling_params={"temperature": 0.7},
+            ),
+        )
+    )
+    second, _ = builder._batch_from_rollout_or_synthetic(
+        make_rollout_result(
+            iteration=3,
+            weight_version=1,
+            payload=_rollout_payload(
+                token_groups=[[2, 1, 3], [0, 4, 2]],
+                sampling_params={"temperature": 0.7},
+            ),
+        )
+    )
+
+    first_score = teacher_forced_logprobs_reference(
+        logits,
+        first.token_ids,
+        mask=first.completion_mask,
+    )
+    second_score = teacher_forced_logprobs_reference(
+        logits,
+        second.token_ids,
+        mask=second.completion_mask,
+    )
+
+    assert not torch.equal(first_score, second_score)


### PR DESCRIPTION
## Summary

- Add `teacher_forced_logprobs_reference` as the explicit reference path for scoring fixed token sequences.
- Mark rollout-derived training batches with `logprob_scoring_mode=teacher_forcing` so sampling params stay scoped to generation.
- Update the DeepSpeed worker and single-GPU GRPO example to use the teacher-forced scoring helper.
- Add tests proving the same sampled tokens score identically under different temperature/top-p/top-k settings, while changed token sequences change the score.
- Document the teacher-forced logprob testing contract.

Closes #135

## Validation

- `python3 -m pytest tests/test_reference_ops.py tests/test_training_contract.py -v`
- `python3 -m pytest tests/test_reference_ops.py tests/test_training_contract.py tests/test_deepspeed_training_worker.py tests/test_grpo_single_gpu_example.py -q`
- `/tmp/rl-kernel-test-venv/bin/python -m pytest tests/ rl_engine/tests/ -q`
- `uvx ruff check rl_engine/testing/reference_ops.py rl_engine/testing/__init__.py rl_engine/executors/training_contract.py rl_engine/executors/deepspeed_trainer.py examples/grpo_single_gpu.py tests/test_reference_ops.py tests/test_training_contract.py`
- `uvx mypy --ignore-missing-imports rl_engine/`
- `uvx pre-commit run --files rl_engine/testing/reference_ops.py rl_engine/testing/__init__.py rl_engine/executors/training_contract.py rl_engine/executors/deepspeed_trainer.py examples/grpo_single_gpu.py tests/test_reference_ops.py tests/test_training_contract.py docs/contributing/testing.md`
- `/tmp/rl-kernel-docs-venv/bin/mkdocs build --strict -f mkdocs.yaml`
- `python3 examples/grpo_single_gpu.py --device cpu --steps 2 --num-prompts 1 --samples-per-prompt 2 --prompt-len 2 --completion-len 3 --vocab-size 16 --hidden-dim 8`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance with instructions on verifying teacher-forced log-probability checks for consistency and benchmarking.

* **Tests**
  * Added comprehensive test coverage for training batch scoring and reference operations to validate consistency across different configurations.

* **Improvements**
  * Updated log-probability computation methodology across training components for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->