### PR TITLE
docs: add hardware benchmark dashboard template

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -24,6 +24,7 @@ nav:
       - design/*
   - Benchmarking:
     - benchmarking/README.md
+    - benchmarking/hardware-dashboard.md
   - API Reference:
     - api/README.md
   - CLI Reference:

--- a/docs/benchmarking/README.md
+++ b/docs/benchmarking/README.md
@@ -2,6 +2,9 @@
 
 RL-Kernel benchmarks track operator latency, memory behavior, and dispatch overhead.
 
+See the [Hardware Benchmark Dashboard](hardware-dashboard.md) for the
+cross-hardware reporting template and result-status rules.
+
 Current benchmark entry points:
 
 ```bash

--- a/docs/benchmarking/hardware-dashboard.md
+++ b/docs/benchmarking/hardware-dashboard.md
@@ -1,0 +1,63 @@
+# Hardware Benchmark Dashboard
+
+This page defines the reporting format for reproducible RL-Kernel hardware benchmarks.
+Entries marked `pending` have not yet been measured and are not performance claims.
+
+## Reporting Rules
+
+Every published result must record:
+
+- hardware and software environment;
+- RL-Kernel commit;
+- exact reproduction command;
+- workload shape and dtype;
+- selected backend;
+- latency, throughput, and peak VRAM;
+- status and any limitation.
+
+A fallback backend result must not be presented as a fused-kernel result.
+
+## Status Definitions
+
+| Status | Meaning |
+| --- | --- |
+| `pass` | The workload completed. Verify the selected backend separately before reporting an optimized result. |
+| `blocked` | The workload could not run because of unavailable hardware, dependencies, or compiled extensions. |
+| `oom` | The workload exceeded available GPU memory. |
+| `pending` | No measurement has been collected yet. |
+
+## Environment Matrix
+
+| Environment ID | GPU | Architecture | Driver | Runtime | PyTorch | RL-Kernel Commit | Date |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `h100-template` | H100 SXM5 | Hopper | pending | CUDA pending | pending | pending | pending |
+| `mi300-template` | MI300X | CDNA 3 | pending | ROCm pending | pending | pending | pending |
+
+## Selected LogP Results
+
+| Environment | Backend | Batch | Sequence Length | Vocabulary | Dtype | Latency (ms) | Tokens/s | Peak VRAM (GB) | Status | Command |
+| --- | --- | ---: | ---: | ---: | --- | ---: | ---: | ---: | --- | --- |
+| `h100-template` | pending | pending | pending | pending | pending | pending | pending | pending | pending | pending |
+| `mi300-template` | pending | pending | pending | pending | pending | pending | pending | pending | pending | pending |
+
+## Sampling Results
+
+| Environment | Backend | Batch | Vocabulary | Top-k | Top-p | Temperature | Latency (ms) | Tokens/s | Peak VRAM (GB) | Status | Command |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| `h100-template` | pending | pending | pending | pending | pending | pending | pending | pending | pending | pending | pending |
+| `mi300-template` | pending | pending | pending | pending | pending | pending | pending | pending | pending | pending | pending |
+
+## Reproduction
+
+Run the profiler from the repository root:
+
+```bash
+python scripts/run_profile_suite.py \
+  --device cuda \
+  --dtype float16 \
+  --batch-sizes 8,16,32 \
+  --seq-lens 128,512 \
+  --vocab-sizes 4096,128256 \
+  --workloads logp-native,logp-fused \
+  --output reports/logp_profile.csv
+  ```

--- a/docs/benchmarking/hardware-dashboard.md
+++ b/docs/benchmarking/hardware-dashboard.md
@@ -60,4 +60,4 @@ python scripts/run_profile_suite.py \
   --vocab-sizes 4096,128256 \
   --workloads logp-native,logp-fused \
   --output reports/logp_profile.csv
-  ```
+```


### PR DESCRIPTION
## Summary

- Add a hardware benchmark dashboard template.
- Define environment, workload, backend, metric, status, and reproduction fields.
- Document that fallback results must not be presented as fused-kernel benchmarks.

## Scope

This PR establishes the documentation template and reporting rules only.
It does not add measured H100 or MI300 benchmark results.

## Validation

- `git diff --cached --check`
- `mkdocs build --strict -f mkdocs.yaml`

Part of #20


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Hardware Benchmark Dashboard” page with standardized, cross-hardware reporting templates, required benchmark fields, and a status taxonomy (pass/blocked/oom/pending).
  * Included guidance and an example reproduction command for generating benchmark outputs.
  * Updated the documentation navigation and benchmarking README to reference the new dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->