### PR TITLE
fix: update flashinfer package name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-cuda = ["flashinfer>=0.1.6", "nvidia-ml-py"]
+cuda = ["flashinfer-python>=0.1.6", "nvidia-ml-py"]
 rocm = ["aiter"]
 vllm = ["vllm>=0.6.0"]
 dev = ["pytest", "black", "isort", "ruff", "mypy", "pre-commit"]


### PR DESCRIPTION
 ## Summary

  Updates the CUDA optional dependency from `flashinfer` to `flashinfer-python`, matching the published
  PyPI package name for FlashInfer.

  This fixes dependency resolution when installing the CUDA extra:

  ```bash
pip install -e .\[cuda\] 
  ```
or
  ```bash
uv sync
  ```
<img width="2266" height="556" alt="image" src="https://github.com/user-attachments/assets/b0a2b062-3851-404e-a1cb-7e816fea98cc" />

  The previous package name, flashinfer, is not available on PyPI, so installs that include the CUDA
  extra can fail before RL-Kernel's CUDA dependencies are set up.

  ## Changes

  - Replace flashinfer>=0.1.6 with flashinfer-python>=0.1.6 in pyproject.toml.
  - Keep the existing nvidia-ml-py CUDA dependency unchanged.
  - No runtime code paths, kernels, tests, or documentation are changed.

  ## Validation

  - Checked PyPI package metadata:
      - flashinfer-python is available.
      - flashinfer returns Not Found.

  - Not run: unit tests or GPU tests, because this is a packaging metadata-only change.

  ## Compatibility

  This change only affects dependency resolution for the cuda optional extra. Runtime behavior is
  unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the optional CUDA-related installation package to a newer compatible version.
  * Kept the existing GPU monitoring dependency unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->