### PR TITLE
[WS1][CI] Pin Transformers 5.13.1 for Torch 2.4 GPU CI

### DIFF
--- a/ci/run_gpu_ci.sh
+++ b/ci/run_gpu_ci.sh
@@ -186,7 +186,7 @@ TORCH_INDEX_URL="${TORCH_INDEX_URL:-https://download.pytorch.org/whl/cu124}"
 # --no-build-isolation: torch must be visible to setup.py, else the extension is silently skipped.
 # --no-deps: keep the pinned torch; do not let the editable install re-resolve it.
 "$PY" -m pip install --no-build-isolation --no-deps -e .
-"$PY" -m pip install --no-cache-dir numpy tabulate accelerate transformers pytest
+"$PY" -m pip install --no-cache-dir numpy tabulate accelerate "transformers==5.13.1" pytest
 nvidia-smi
 # Fail fast if _C did not build or cannot launch, instead of silently using native fallbacks.
 "$PY" scripts/ci_smoke.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "tabulate",
     "numpy",
     "accelerate",
-    "transformers",
+    "transformers==5.13.1",
 ]
 
 [project.optional-dependencies]

--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,7 @@ setup(
         "tabulate",
         "numpy",
         "accelerate",
-        "transformers",
+        "transformers==5.13.1",
     ],
     ext_modules=get_extensions(),
     cmdclass=get_cmdclass(),


### PR DESCRIPTION
## Summary

Pin Transformers to `5.13.1` so the GPU CI dependency set remains compatible with the existing `torch==2.4.1` / CUDA 12.4 environment.

The previously unconstrained install resolved to Transformers 5.14.1, which fails during pytest collection because it imports `DTensor` from a location not exported by Torch 2.4.1. This prevents the GPU test suite from reaching the operator tests even though the CUDA extension builds and its SM90 smoke test succeeds.

Fixes #227.

## Root cause

`ci/run_gpu_ci.sh` deliberately pins Torch to `2.4.1` to keep the CUDA extension build ABI deterministic, but it installed the latest unconstrained Transformers release afterward:

```bash
TORCH_SPEC="${TORCH_SPEC:-torch==2.4.1}"
"$PY" -m pip install --no-cache-dir "$TORCH_SPEC" --index-url "$TORCH_INDEX_URL"

"$PY" -m pip install --no-build-isolation --no-deps -e .
"$PY" -m pip install --no-cache-dir numpy tabulate accelerate transformers pytest
```

In the affected H100 job, this produced:

```text
torch 2.4.1+cu124
transformers 5.14.1
```

Pytest then failed while collecting `tests/test_stateless_hf_integration.py`:

```text
transformers/distributed/sharding_utils.py:28: in <module>
    from torch.distributed.tensor import DTensor

ImportError: cannot import name 'DTensor' from 'torch.distributed.tensor'
```

Affected workflow job:

https://github.com/RL-Align/RL-Kernel/actions/runs/29518774291/job/87690353599?pr=199

## Changes

- Pin `transformers==5.13.1` in `ci/run_gpu_ci.sh` so the RunPod environment is reproducible.
- Apply the same constraint in `pyproject.toml`.
- Apply the same constraint in `setup.py`.
- Keep the existing Torch 2.4.1 and CUDA 12.4 toolchain unchanged.
- Do not change the stateless executor or its existing test expectations.

## Version selection

The version was selected through direct compatibility testing with the same Python, Torch, and CUDA versions used by GPU CI.

| Transformers | Result with Torch 2.4.1 |
| --- | --- |
| `5.14.1` | Model import fails with the `DTensor` ImportError during pytest collection. |
| `4.57.6` | Model imports succeed, but the existing HF integration contract has one attention fallback failure. |
| `4.46.3` | Model imports succeed, but the existing HF integration contract has three attention fallback failures. |
| `5.13.1` | Model imports succeed and all existing HF integration tests pass. |

`5.13.1` is the tested version that preserves the repository's current behavior without modifying executor or test logic.

## Validation

Validated in WSL with:

```text
Python 3.11.15
Torch 2.4.1+cu124
CUDA 12.4
Transformers 5.13.1
```

Commands:

```bash
uv venv --python 3.11 --seed rl-kernel-ci-check
source rl-kernel-ci-check/bin/activate

uv pip install \
  "torch==2.4.1" \
  --index-url https://download.pytorch.org/whl/cu124

uv pip install \
  numpy \
  tabulate \
  accelerate \
  "transformers==5.13.1" \
  pytest

PYTHONDONTWRITEBYTECODE=1 \
PYTHONPATH="$PWD" \
python -m pytest \
  -p no:cacheprovider \
  tests/test_stateless_hf_integration.py \
  -q

uv pip check
```

Results:

```text
3 passed in 39.01s
All installed packages are compatible
```

Additional checks:

```text
ci/run_gpu_ci.sh: bash syntax passed
pyproject.toml: TOML parsing passed
setup.py: Python syntax passed
git diff --check: passed
```

## GPU CI validation note

GPU CI uses `pull_request_target` and checks out the CI orchestrator from the PR's base SHA. As a result, this PR's modification to `ci/run_gpu_ci.sh` will not automatically be used by its own GPU CI run.

The dependency combination has been reproduced and validated locally. A maintainer-controlled validation may be used before merge; after the fix reaches `main`, a new GPU workflow run should be triggered to confirm the RunPod path end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the Transformers package to version 5.13.1 across project and GPU CI installations.
  * Improved build and testing consistency by preventing unexpected dependency version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->