### PR TITLE
[FEAT][kernels] Add fused ratio-clip-aggregate loss primitive

### DIFF
--- a/benchmarks/benchmark_ratio_clip_aggregate.py
+++ b/benchmarks/benchmark_ratio_clip_aggregate.py
@@ -1,0 +1,220 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Benchmark fused ratio clipping and aggregation against the PyTorch reference.
+
+Usage:
+    python benchmarks/benchmark_ratio_clip_aggregate.py
+    python benchmarks/benchmark_ratio_clip_aggregate.py \
+        --configs "32,256;128,1024;256,4096"
+"""
+
+import argparse
+
+import torch
+from tabulate import tabulate
+
+from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import (
+    NativeRatioClipAggregateOp,
+)
+from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import (
+    TritonRatioClipAggregateOp,
+)
+
+DEFAULT_CONFIGS = [
+    (32, 256),
+    (128, 1024),
+    (256, 4096),
+    (256, 16384),
+]
+
+
+def _make_inputs(batch, tokens, *, density, device):
+    generator = torch.Generator(device=device).manual_seed(batch * 100000 + tokens)
+    ratio = torch.exp(torch.randn(batch, tokens, generator=generator, device=device) * 0.3)
+    advantages = torch.randn(batch, generator=generator, device=device)
+    mask = torch.rand(batch, tokens, generator=generator, device=device) < density
+    penalty = torch.rand(batch, tokens, generator=generator, device=device) * 0.1
+    return ratio, advantages, mask, penalty
+
+
+def _time_ms(fn, warmup, iterations):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+def _peak_vram_mb(fn, warmup=3, iterations=5):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    torch.cuda.empty_cache()
+    baseline = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    for _ in range(iterations):
+        fn()
+    torch.cuda.synchronize()
+    return (torch.cuda.max_memory_allocated() - baseline) / (1024**2)
+
+
+def run_benchmark(args):
+    if not torch.cuda.is_available():
+        raise RuntimeError("ratio-clip-aggregate benchmark requires a CUDA GPU.")
+
+    native = NativeRatioClipAggregateOp()
+    fused = TritonRatioClipAggregateOp()
+    kwargs = dict(
+        clip_low=args.clip_low,
+        clip_high=args.clip_high,
+        penalty_coef=args.penalty_coef,
+    )
+    rows = []
+
+    for batch, tokens in args.configs:
+        ratio, advantages, mask, penalty = _make_inputs(
+            batch,
+            tokens,
+            density=args.mask_density,
+            device="cuda",
+        )
+
+        def native_forward(
+            ratio=ratio,
+            advantages=advantages,
+            mask=mask,
+            penalty=penalty,
+        ):
+            with torch.no_grad():
+                native(
+                    ratio,
+                    advantages,
+                    mask,
+                    penalty_terms=penalty,
+                    **kwargs,
+                )
+
+        def fused_forward(
+            ratio=ratio,
+            advantages=advantages,
+            mask=mask,
+            penalty=penalty,
+        ):
+            with torch.no_grad():
+                fused(
+                    ratio,
+                    advantages,
+                    mask,
+                    penalty_terms=penalty,
+                    **kwargs,
+                )
+
+        ratio_grad = ratio.clone().requires_grad_(True)
+        penalty_grad = penalty.clone().requires_grad_(True)
+
+        def native_forward_backward(
+            ratio_grad=ratio_grad,
+            advantages=advantages,
+            mask=mask,
+            penalty_grad=penalty_grad,
+        ):
+            loss = native(
+                ratio_grad,
+                advantages,
+                mask,
+                penalty_terms=penalty_grad,
+                **kwargs,
+            )[0]
+            torch.autograd.grad(loss, (ratio_grad, penalty_grad))
+
+        def fused_forward_backward(
+            ratio_grad=ratio_grad,
+            advantages=advantages,
+            mask=mask,
+            penalty_grad=penalty_grad,
+        ):
+            loss = fused(
+                ratio_grad,
+                advantages,
+                mask,
+                penalty_terms=penalty_grad,
+                **kwargs,
+            )[0]
+            torch.autograd.grad(loss, (ratio_grad, penalty_grad))
+
+        native_forward_ms = _time_ms(native_forward, args.warmup, args.iterations)
+        fused_forward_ms = _time_ms(fused_forward, args.warmup, args.iterations)
+        native_fb_ms = _time_ms(native_forward_backward, args.warmup, args.iterations)
+        fused_fb_ms = _time_ms(fused_forward_backward, args.warmup, args.iterations)
+        native_vram = _peak_vram_mb(native_forward)
+        fused_vram = _peak_vram_mb(fused_forward)
+        rows.append(
+            [
+                f"{batch}x{tokens}",
+                f"{batch * tokens / 1e6:.2f}M",
+                f"{native_forward_ms:.3f}",
+                f"{fused_forward_ms:.3f}",
+                f"{native_forward_ms / fused_forward_ms:.2f}x",
+                f"{native_fb_ms:.3f}",
+                f"{fused_fb_ms:.3f}",
+                f"{native_fb_ms / fused_fb_ms:.2f}x",
+                f"{native_vram:.1f}",
+                f"{fused_vram:.1f}",
+                f"{native_vram / max(fused_vram, 1e-9):.2f}x",
+            ]
+        )
+
+    print(
+        tabulate(
+            rows,
+            headers=[
+                "shape (B x T)",
+                "tokens",
+                "PyTorch fwd ms",
+                "Triton fwd ms",
+                "fwd speedup",
+                "PyTorch f+b ms",
+                "Triton f+b ms",
+                "f+b speedup",
+                "PyTorch MB",
+                "Triton MB",
+                "memory reduction",
+            ],
+            tablefmt="github",
+        )
+    )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--clip-low", type=float, default=0.2)
+    parser.add_argument("--clip-high", type=float, default=0.2)
+    parser.add_argument("--penalty-coef", type=float, default=0.04)
+    parser.add_argument("--mask-density", type=float, default=0.9)
+    parser.add_argument(
+        "--configs",
+        type=str,
+        default=None,
+        help="Semicolon-separated batch,tokens pairs.",
+    )
+    args = parser.parse_args()
+    if args.configs:
+        args.configs = [
+            tuple(int(value) for value in config.split(",")) for config in args.configs.split(";")
+        ]
+    else:
+        args.configs = DEFAULT_CONFIGS
+    return args
+
+
+if __name__ == "__main__":
+    run_benchmark(parse_args())

--- a/benchmarks/benchmark_ratio_clip_aggregate.py
+++ b/benchmarks/benchmark_ratio_clip_aggregate.py
@@ -14,12 +14,8 @@ import argparse
 import torch
 from tabulate import tabulate
 
-from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import (
-    NativeRatioClipAggregateOp,
-)
-from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import (
-    TritonRatioClipAggregateOp,
-)
+from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import NativeRatioClipAggregateOp
+from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import TritonRatioClipAggregateOp
 
 DEFAULT_CONFIGS = [
     (32, 256),

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -23,6 +23,7 @@ nav:
       - operators/grpo-loss.md
       - operators/lm_head.md
       - operators/ratio-kl.md
+      - operators/ratio-clip-aggregate.md
       - operators/pack-and-pad.md
       - operators/sampling.md
       - operators/det-gemm.md

--- a/docs/operators/README.md
+++ b/docs/operators/README.md
@@ -28,6 +28,7 @@ Every operator page should include:
 - [RoPE](rope.md)
 - [LM Head](lm_head.md)
 - [Policy Ratio + KL Penalty](ratio-kl.md)
+- [Ratio Clip Aggregate](ratio-clip-aggregate.md)
 - [Pack and Pad](pack-and-pad.md)
 - [Matmul](matmul.md)
 - [Sampling](sampling.md)

--- a/docs/operators/grpo-loss.md
+++ b/docs/operators/grpo-loss.md
@@ -8,11 +8,13 @@ allocates several broadcasted `[batch, completion_len]` intermediates and a per-
 advantage tensor.
 
 The operator consumes **logits** directly and builds on the [Policy Ratio + KL
-Penalty](ratio-kl.md) operator: the per-token `policy_ratio` and `kl_penalty` come from the
-fused ratio/KL kernel (logits → ratio/KL via online softmax), and the group-normalized advantages + clipped surrogate are applied on top:
+Penalty](ratio-kl.md) and [Ratio Clip Aggregate](ratio-clip-aggregate.md)
+operators: the per-token `policy_ratio` and `kl_penalty` come from the fused
+ratio/KL kernel (logits → ratio/KL via online softmax), and the group-normalized
+advantages feed the fused clip/reduction stage:
 
 ```
-logits --[ratio_kl op]--> (ratio, kl) --[group adv + clipped surrogate]--> loss
+logits --[ratio_kl]--> (ratio, kl) --[ratio_clip_aggregate + group adv]--> loss
 ```
 
 ## Entry Point
@@ -50,14 +52,16 @@ Provide **exactly one** of:
 
 | Backend | Wrapper | Native symbol | Status |
 | --- | --- | --- | --- |
-| CUDA / ROCm | `TritonGRPOLossOp` | `ratio_kl` + `_group_norm_kernel` | Fused ratio/KL + analytic backward. |
+| CUDA / ROCm | `TritonGRPOLossOp` | `ratio_kl` + `_group_norm_kernel` + `ratio_clip_aggregate` | Fused forward and analytic backward. |
 | PyTorch fallback | `NativeGRPOLossOp` | None | Reference path; CPU and Triton-less GPUs. |
 
 The Triton op composes the [`ratio_kl`](ratio-kl.md) kernel (per-token `ratio`/`kl` from
 logits, with the analytic backward into `policy_logits`) with the `_group_norm_kernel`
-(per-group reward mean/std in registers). The clipped surrogate + reference-KL reduction is
-a thin autograd-friendly PyTorch layer — no bespoke GRPO loss kernel is needed. The native
-op mirrors this using `NativeRatioKLOp`.
+(per-group reward mean/std in registers) and
+[`ratio_clip_aggregate`](ratio-clip-aggregate.md). The final operator fuses the
+clipped surrogate, active-token mask, KL reduction, and analytical backward
+without expanding per-sequence advantages to `[B, T]`. The native op mirrors
+this composition with PyTorch reference operators.
 
 ## Tensor Contract
 
@@ -70,7 +74,7 @@ op mirrors this using `NativeRatioKLOp`.
 | `rewards` | `[B]` | float | One scalar per sequence. |
 | `completion_mask` | `[B, T]` | bool / {0,1} | 2-D; `True` marks active tokens. |
 | `loss` (output) | scalar | float32 | `policy_loss + beta * kl`. |
-| `policy_loss`, `kl` (output) | scalar | float32 | Detached reporting values. |
+| `policy_loss`, `kl` (output) | scalar | float32 | Component values. |
 
 Gradients flow into `policy_logits` only (`ref_logits` is frozen; `old_logps` is cached).
 
@@ -130,6 +134,9 @@ skip without CUDA + Triton.
 - `rl_engine/kernels/ops/pytorch/loss/grpo_loss.py`
 - `rl_engine/kernels/ops/triton/loss/grpo_loss.py`
 - `rl_engine/kernels/ops/triton/loss/ratio_kl.py`, `rl_engine/kernels/ops/pytorch/loss/ratio_kl.py`
+- `rl_engine/kernels/ops/triton/loss/ratio_clip_aggregate.py`
+- `rl_engine/kernels/ops/pytorch/loss/ratio_clip_aggregate.py`
 - `rl_engine/kernels/registry.py`
 - `tests/test_grpo_loss.py`
 - `benchmarks/benchmark_ratio_kl.py`
+- `benchmarks/benchmark_ratio_clip_aggregate.py`

--- a/docs/operators/ratio-clip-aggregate.md
+++ b/docs/operators/ratio-clip-aggregate.md
@@ -1,0 +1,127 @@
+# Ratio Clip Aggregate
+
+`ratio_clip_aggregate` fuses the policy-ratio clipping, active-token masking,
+loss reduction, optional penalty reduction, and clip-fraction metric used by
+PPO and GRPO training. It is the downstream companion to `ratio_kl`: the latter
+produces per-token ratios and KL terms from logits, while this operator consumes
+those compact tensors without materializing broadcast advantages or surrogate
+loss tensors.
+
+## Public entry point
+
+```python
+from rl_engine.kernels.registry import kernel_registry
+
+op = kernel_registry.get_op("ratio_clip_aggregate", device=ratio.device)
+loss, policy_loss, mean_penalty, clip_fraction = op(
+    ratio,
+    advantages,
+    completion_mask,
+    clip_low=0.2,
+    clip_high=0.2,
+    penalty_terms=kl_terms,
+    penalty_coef=0.04,
+)
+```
+
+## Contract
+
+| Input | Shape | Dtype | Notes |
+| --- | --- | --- | --- |
+| `ratio` | `[B, T]` or `[N]` | FP16, BF16, FP32 | Per-token policy importance ratio |
+| `advantages` | `[B, T]`, `[N]`, or `[B]` | floating point | Detached target; `[B]` is supported only with `[B, T]` ratios |
+| `mask` | same as `ratio` | bool or integer | Nonzero entries participate in the reduction |
+| `penalty_terms` | same as `ratio` | floating point | Optional per-token KL or other additive penalty |
+| `clip_low` | scalar | Python float | Lower bound is `1 - clip_low`; must satisfy `0 <= clip_low < 1` |
+| `clip_high` | scalar | Python float | Upper bound is `1 + clip_high`; must be non-negative |
+| `penalty_coef` | scalar | Python float | Multiplier applied to `mean_penalty` |
+
+All tensor inputs must be on the same device. Inputs may be non-contiguous; each
+backend normalizes layout internally. Advantages are RL targets and must not
+require gradients.
+
+The four scalar FP32 outputs are:
+
+1. `loss = policy_loss + penalty_coef * mean_penalty`;
+2. the masked mean clipped policy loss;
+3. the masked mean optional penalty, or zero when no penalty is supplied;
+4. the fraction of active ratios outside the clip interval.
+
+An all-false mask returns finite zeros for every output and produces zero input
+gradients.
+
+## Semantics
+
+For every active token:
+
+```python
+clipped_ratio = ratio.clamp(1 - clip_low, 1 + clip_high)
+policy_term = -torch.minimum(
+    ratio * advantage,
+    clipped_ratio * advantage,
+)
+```
+
+The Triton backward computes analytical gradients for `ratio` and
+`penalty_terms`. `policy_loss` and `mean_penalty` remain independently
+differentiable outputs; `clip_fraction` is a metric and is non-differentiable.
+
+## Backends and fallback
+
+| Device | Preferred backend | Fallback |
+| --- | --- | --- |
+| NVIDIA CUDA | `TritonRatioClipAggregateOp` | `NativeRatioClipAggregateOp` |
+| AMD ROCm | `TritonRatioClipAggregateOp` | `NativeRatioClipAggregateOp` |
+| CPU | `NativeRatioClipAggregateOp` | N/A |
+
+For up to 65,536 tokens, the Triton implementation uses a tuned single-program
+reduction. Larger inputs use fixed 256-token tiles followed by a fixed-order
+final reduction. Neither path uses `atomicAdd` or copies the active-token count
+to the CPU. Per-sequence advantages are gathered directly in the kernel, so no
+`[B, T]` broadcast tensor is allocated.
+
+## Integration
+
+`TritonGRPOLossOp` composes:
+
+```text
+logits -> ratio_kl -> ratio_clip_aggregate -> scalar loss
+```
+
+Group reward normalization remains separate because it reduces over generation
+groups rather than tokens. The ratio/KL online-softmax work from `ratio_kl` is
+not duplicated.
+
+## Validation and benchmark
+
+- Correctness and gradients: `tests/test_ratio_clip_aggregate.py`
+- GRPO integration: `tests/test_grpo_loss.py`
+- Performance and peak memory:
+  `python benchmarks/benchmark_ratio_clip_aggregate.py`
+
+The native backend is the semantic reference. FP16/BF16 comparisons use FP32
+accumulation and dtype-appropriate tolerances.
+
+Indicative results on an NVIDIA RTX PRO 5000 Blackwell with PyTorch 2.11,
+CUDA 12.9, and Triton 3.6 are below. Inputs are FP32 with 90% active tokens,
+per-sequence advantages, and a penalty tensor; timings use 100 warmups and 500
+iterations.
+
+| Shape | PyTorch fwd | Triton fwd | Speedup | PyTorch fwd+bwd | Triton fwd+bwd | Speedup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 32 × 256 | 0.143 ms | 0.036 ms | 4.02× | 0.416 ms | 0.178 ms | 2.34× |
+| 128 × 1024 | 0.153 ms | 0.050 ms | 3.04× | 0.429 ms | 0.201 ms | 2.14× |
+| 256 × 4096 | 0.154 ms | 0.050 ms | 3.05× | 0.432 ms | 0.200 ms | 2.16× |
+| 256 × 16384 | 0.317 ms | 0.051 ms | 6.28× | 0.664 ms | 0.200 ms | 3.32× |
+
+Peak forward intermediates at 4.19M tokens fall from 64.0 MiB to 0.3 MiB.
+Results are workload- and device-specific; rerun the benchmark for deployment
+hardware.
+
+## Limitations
+
+- V1 implements PPO/GRPO clipped-surrogate semantics. It does not claim GSPO,
+  DAPO, CISPO, or Dr. GRPO objective support.
+- Advantages are intentionally non-differentiable targets.
+- The deterministic staged reduction supports at most 16,777,216 tokens per
+  invocation; larger inputs must be chunked by the caller.

--- a/rl_engine/executors/deepspeed_trainer.py
+++ b/rl_engine/executors/deepspeed_trainer.py
@@ -29,7 +29,7 @@ from rl_engine.executors.training_contract import (
 )
 from rl_engine.kernels.ops.pytorch.loss.linear_logp import NativeLinearLogpOp
 from rl_engine.kernels.registry import kernel_registry
-from rl_engine.testing import compute_policy_ratio, compute_reference_kl, masked_mean
+from rl_engine.testing import compute_policy_ratio, compute_reference_kl
 
 _TDestination = TypeVar("_TDestination", bound=dict[str, Any])
 
@@ -125,6 +125,9 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
         if engine_device is not None:
             self.device = torch.device(engine_device)
         self._linear_logp = _linear_logp_op_for_device(self.device)
+        self._ratio_clip_aggregate = kernel_registry.get_op(
+            "ratio_clip_aggregate", device=self.device
+        )
 
     def train(self, rollout: RolloutStageResult) -> TrainingStageResult:
         started_at = time.perf_counter()
@@ -161,11 +164,16 @@ class DeepSpeedTrainingWorker(RolloutBatchMixin):
             old_logps = current_logps.detach() - 0.01
             ref_logps = objective_reference_logps(current_logps, batch)
             ratio = compute_policy_ratio(current_logps, old_logps, batch.completion_mask)
-            unclipped = ratio * batch.advantages.float()
-            clipped = torch.clamp(ratio, 0.8, 1.2) * batch.advantages.float()
-            policy_loss = -torch.minimum(unclipped, clipped)
             kl = compute_reference_kl(current_logps, ref_logps, batch.completion_mask)
-            loss = masked_mean(policy_loss + 0.01 * kl, batch.completion_mask)
+            loss = self._ratio_clip_aggregate(
+                ratio,
+                batch.advantages,
+                batch.completion_mask,
+                clip_low=0.2,
+                clip_high=0.2,
+                penalty_terms=kl,
+                penalty_coef=0.01,
+            )[0]
             self.engine.backward(loss)
         self.engine.step()
 

--- a/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
+++ b/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
@@ -8,6 +8,9 @@ from typing import Optional, Sequence, Tuple
 import torch
 
 from rl_engine.kernels.ops.pytorch.loss.ratio_kl import NativeRatioKLOp
+from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import (
+    NativeRatioClipAggregateOp,
+)
 
 
 class NativeGRPOLossOp:
@@ -20,6 +23,7 @@ class NativeGRPOLossOp:
 
     def __init__(self) -> None:
         self._ratio_kl = NativeRatioKLOp()
+        self._ratio_clip_aggregate = NativeRatioClipAggregateOp()
 
     def __call__(
         self,
@@ -114,15 +118,16 @@ class NativeGRPOLossOp:
         ratio, kl_terms = self._ratio_kl(
             policy_logits, ref_logits, action_ids, completion_mask, old_logps
         )
-        bool_mask = completion_mask.bool()
-        adv = self.expand_advantages(sample_advantages, completion_mask).float()
-        unclipped = ratio * adv
-        clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * adv
-        policy_loss_terms = -torch.minimum(unclipped, clipped)
-
-        policy_loss = self._masked_mean(policy_loss_terms, bool_mask)
-        kl = self._masked_mean(kl_terms, bool_mask)
-        return policy_loss + beta * kl, policy_loss, kl
+        loss, policy_loss, kl, _ = self._ratio_clip_aggregate(
+            ratio,
+            sample_advantages,
+            completion_mask,
+            clip_low=clip_eps,
+            clip_high=clip_eps,
+            penalty_terms=kl_terms,
+            penalty_coef=beta,
+        )
+        return loss, policy_loss, kl
 
     def forward(
         self,

--- a/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
+++ b/rl_engine/kernels/ops/pytorch/loss/grpo_loss.py
@@ -7,10 +7,8 @@ from typing import Optional, Sequence, Tuple
 
 import torch
 
+from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import NativeRatioClipAggregateOp
 from rl_engine.kernels.ops.pytorch.loss.ratio_kl import NativeRatioKLOp
-from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import (
-    NativeRatioClipAggregateOp,
-)
 
 
 class NativeGRPOLossOp:

--- a/rl_engine/kernels/ops/pytorch/loss/ratio_clip_aggregate.py
+++ b/rl_engine/kernels/ops/pytorch/loss/ratio_clip_aggregate.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+
+
+def _validate_ratio_clip_inputs(
+    ratio: torch.Tensor,
+    advantages: torch.Tensor,
+    mask: torch.Tensor,
+    penalty_terms: Optional[torch.Tensor],
+    clip_low: float,
+    clip_high: float,
+) -> bool:
+    """Validate the shared contract and return whether advantages are per-token."""
+    if ratio.ndim not in (1, 2):
+        raise ValueError(f"ratio must be 1D or 2D; got shape {tuple(ratio.shape)}.")
+    if ratio.numel() == 0:
+        raise ValueError("ratio must contain at least one element.")
+    if not ratio.is_floating_point() or not advantages.is_floating_point():
+        raise TypeError("ratio and advantages must be floating-point tensors.")
+    if mask.shape != ratio.shape:
+        raise ValueError(
+            f"mask shape {tuple(mask.shape)} must match ratio shape {tuple(ratio.shape)}."
+        )
+    if mask.is_floating_point() or mask.is_complex():
+        raise TypeError("mask must have boolean or integer dtype.")
+    if ratio.device != advantages.device or ratio.device != mask.device:
+        raise ValueError("ratio, advantages, and mask must be on the same device.")
+    if advantages.requires_grad:
+        raise ValueError("advantages must be detached RL targets (requires_grad=False).")
+
+    per_token_advantages = advantages.shape == ratio.shape
+    per_sequence_advantages = ratio.ndim == 2 and advantages.shape == ratio.shape[:-1]
+    if not (per_token_advantages or per_sequence_advantages):
+        raise ValueError(
+            "advantages must be per-token with ratio.shape or per-sequence "
+            f"with ratio.shape[:-1]; got {tuple(advantages.shape)} for "
+            f"ratio shape {tuple(ratio.shape)}."
+        )
+
+    if penalty_terms is not None:
+        if not penalty_terms.is_floating_point():
+            raise TypeError("penalty_terms must be a floating-point tensor.")
+        if penalty_terms.shape != ratio.shape:
+            raise ValueError(
+                f"penalty_terms shape {tuple(penalty_terms.shape)} must match "
+                f"ratio shape {tuple(ratio.shape)}."
+            )
+        if penalty_terms.device != ratio.device:
+            raise ValueError("penalty_terms must be on the same device as ratio.")
+
+    if not 0.0 <= float(clip_low) < 1.0:
+        raise ValueError(f"clip_low must satisfy 0 <= clip_low < 1; got {clip_low}.")
+    if float(clip_high) < 0.0:
+        raise ValueError(f"clip_high must be non-negative; got {clip_high}.")
+    return per_token_advantages
+
+
+class NativeRatioClipAggregateOp:
+    """PyTorch reference for the ratio-clip-aggregate policy loss primitive."""
+
+    def __call__(
+        self,
+        ratio: torch.Tensor,
+        advantages: torch.Tensor,
+        mask: torch.Tensor,
+        *,
+        clip_low: float = 0.2,
+        clip_high: float = 0.2,
+        penalty_terms: Optional[torch.Tensor] = None,
+        penalty_coef: float = 0.0,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self.forward(
+            ratio,
+            advantages,
+            mask,
+            clip_low=clip_low,
+            clip_high=clip_high,
+            penalty_terms=penalty_terms,
+            penalty_coef=penalty_coef,
+        )
+
+    def forward(
+        self,
+        ratio: torch.Tensor,
+        advantages: torch.Tensor,
+        mask: torch.Tensor,
+        *,
+        clip_low: float = 0.2,
+        clip_high: float = 0.2,
+        penalty_terms: Optional[torch.Tensor] = None,
+        penalty_coef: float = 0.0,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        per_token_advantages = _validate_ratio_clip_inputs(
+            ratio, advantages, mask, penalty_terms, clip_low, clip_high
+        )
+        bool_mask = mask.to(torch.bool)
+        if per_token_advantages:
+            token_advantages = advantages
+        else:
+            token_advantages = advantages[:, None]
+        ratio_fp32 = ratio.float()
+        advantages_fp32 = token_advantages.float()
+        clipped_ratio = ratio_fp32.clamp(1.0 - clip_low, 1.0 + clip_high)
+        policy_terms = -torch.minimum(ratio_fp32 * advantages_fp32, clipped_ratio * advantages_fp32)
+
+        count = bool_mask.sum().to(torch.float32).clamp_min(1.0)
+        policy_loss = policy_terms.masked_fill(~bool_mask, 0.0).sum() / count
+        if penalty_terms is None:
+            mean_penalty = policy_loss.new_zeros(())
+        else:
+            mean_penalty = penalty_terms.masked_fill(~bool_mask, 0.0).float().sum() / count
+        clip_fraction = (
+            (ratio_fp32 < 1.0 - clip_low) | (ratio_fp32 > 1.0 + clip_high)
+        ).masked_fill(~bool_mask, False).float().sum() / count
+        total = policy_loss + float(penalty_coef) * mean_penalty
+        return total, policy_loss, mean_penalty, clip_fraction

--- a/rl_engine/kernels/ops/triton/loss/grpo_loss.py
+++ b/rl_engine/kernels/ops/triton/loss/grpo_loss.py
@@ -8,10 +8,8 @@ import torch
 import triton
 import triton.language as tl
 
+from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import TritonRatioClipAggregateOp
 from rl_engine.kernels.ops.triton.loss.ratio_kl import TritonRatioKLOp
-from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import (
-    TritonRatioClipAggregateOp,
-)
 
 
 def _next_pow2(x: int) -> int:

--- a/rl_engine/kernels/ops/triton/loss/grpo_loss.py
+++ b/rl_engine/kernels/ops/triton/loss/grpo_loss.py
@@ -9,6 +9,9 @@ import triton
 import triton.language as tl
 
 from rl_engine.kernels.ops.triton.loss.ratio_kl import TritonRatioKLOp
+from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import (
+    TritonRatioClipAggregateOp,
+)
 
 
 def _next_pow2(x: int) -> int:
@@ -61,13 +64,14 @@ class TritonGRPOLossOp:
     The per-token ``policy_ratio`` / ``kl_penalty`` are produced by the fused
     ``ratio_kl`` Triton kernel (logits -> ratio/KL via online softmax, with an
     analytic backward into ``policy_logits``); reward normalization runs in the
-    ``_group_norm_kernel``; the clipped surrogate + reference-KL reduction are a
-    thin autograd-friendly PyTorch layer on top. ``forward`` takes raw rewards;
-    ``apply`` takes the per-sequence advantage vector directly.
+    ``_group_norm_kernel``; and ``ratio_clip_aggregate`` fuses the clipped
+    surrogate, reference-KL reduction, and analytical backward. ``forward`` takes
+    raw rewards; ``apply`` takes the per-sequence advantage vector directly.
     """
 
     def __init__(self) -> None:
         self._ratio_kl = TritonRatioKLOp()
+        self._ratio_clip_aggregate = TritonRatioClipAggregateOp()
 
     def __call__(
         self,
@@ -203,15 +207,16 @@ class TritonGRPOLossOp:
         ratio, kl_terms = self._ratio_kl(
             policy_logits, ref_logits, action_ids, completion_mask, old_logps
         )
-        bool_mask = completion_mask.bool()
-        adv = self.expand_advantages(sample_advantages, completion_mask).float()
-        unclipped = ratio * adv
-        clipped = torch.clamp(ratio, 1.0 - clip_eps, 1.0 + clip_eps) * adv
-        policy_loss_terms = -torch.minimum(unclipped, clipped)
-
-        policy_loss = self._masked_mean(policy_loss_terms, bool_mask)
-        kl = self._masked_mean(kl_terms, bool_mask)
-        return policy_loss + beta * kl, policy_loss, kl
+        loss, policy_loss, kl, _ = self._ratio_clip_aggregate(
+            ratio,
+            sample_advantages,
+            completion_mask,
+            clip_low=clip_eps,
+            clip_high=clip_eps,
+            penalty_terms=kl_terms,
+            penalty_coef=beta,
+        )
+        return loss, policy_loss, kl
 
     def forward(
         self,

--- a/rl_engine/kernels/ops/triton/loss/ratio_clip_aggregate.py
+++ b/rl_engine/kernels/ops/triton/loss/ratio_clip_aggregate.py
@@ -11,9 +11,7 @@ import torch
 import triton
 import triton.language as tl
 
-from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import (
-    _validate_ratio_clip_inputs,
-)
+from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import _validate_ratio_clip_inputs
 
 _BLOCK = 256
 _NUM_WARPS = 4

--- a/rl_engine/kernels/ops/triton/loss/ratio_clip_aggregate.py
+++ b/rl_engine/kernels/ops/triton/loss/ratio_clip_aggregate.py
@@ -1,0 +1,428 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Fused ratio clipping, masking, and deterministic loss aggregation."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import (
+    _validate_ratio_clip_inputs,
+)
+
+_BLOCK = 256
+_NUM_WARPS = 4
+_SINGLE_PASS_MAX = 65536
+_SINGLE_PASS_NUM_WARPS = 8
+_MAX_PARTIALS = 65536
+
+
+@triton.jit
+def _ratio_clip_single_pass_kernel(
+    ratio_ptr,
+    advantage_ptr,
+    mask_ptr,
+    penalty_ptr,
+    outputs_ptr,
+    n_elements,
+    tokens_per_sequence,
+    clip_low,
+    clip_high,
+    penalty_coef,
+    HAS_PENALTY: tl.constexpr,
+    ADV_PER_TOKEN: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, BLOCK)
+    in_bounds = offsets < n_elements
+    active = in_bounds & (tl.load(mask_ptr + offsets, mask=in_bounds, other=0) != 0)
+
+    ratio = tl.load(ratio_ptr + offsets, mask=in_bounds, other=1.0).to(tl.float32)
+    if ADV_PER_TOKEN:
+        advantage = tl.load(advantage_ptr + offsets, mask=in_bounds, other=0.0).to(tl.float32)
+    else:
+        sequence_ids = offsets // tokens_per_sequence
+        advantage = tl.load(advantage_ptr + sequence_ids, mask=in_bounds, other=0.0).to(tl.float32)
+
+    lower = 1.0 - clip_low
+    upper = 1.0 + clip_high
+    clipped_ratio = tl.minimum(tl.maximum(ratio, lower), upper)
+    policy_term = -tl.minimum(ratio * advantage, clipped_ratio * advantage)
+    policy_sum = tl.sum(tl.where(active, policy_term, 0.0), axis=0)
+
+    if HAS_PENALTY:
+        penalty = tl.load(penalty_ptr + offsets, mask=in_bounds, other=0.0).to(tl.float32)
+        penalty_sum = tl.sum(tl.where(active, penalty, 0.0), axis=0)
+    else:
+        penalty_sum = 0.0
+
+    clipped_sum = tl.sum(
+        (((ratio < lower) | (ratio > upper)) & active).to(tl.float32),
+        axis=0,
+    )
+    active_count = tl.sum(active.to(tl.float32), axis=0)
+    denominator = tl.maximum(active_count, 1.0)
+    policy_loss = policy_sum / denominator
+    mean_penalty = penalty_sum / denominator
+
+    tl.store(outputs_ptr, policy_loss + penalty_coef * mean_penalty)
+    tl.store(outputs_ptr + 1, policy_loss)
+    tl.store(outputs_ptr + 2, mean_penalty)
+    tl.store(outputs_ptr + 3, clipped_sum / denominator)
+    tl.store(outputs_ptr + 4, active_count)
+
+
+@triton.jit
+def _ratio_clip_partial_kernel(
+    ratio_ptr,
+    advantage_ptr,
+    mask_ptr,
+    penalty_ptr,
+    partials_ptr,
+    n_elements,
+    partial_count,
+    tokens_per_sequence,
+    clip_low,
+    clip_high,
+    HAS_PENALTY: tl.constexpr,
+    ADV_PER_TOKEN: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    block_id = tl.program_id(0)
+    offsets = block_id * BLOCK + tl.arange(0, BLOCK)
+    in_bounds = offsets < n_elements
+    active = in_bounds & (tl.load(mask_ptr + offsets, mask=in_bounds, other=0) != 0)
+
+    ratio = tl.load(ratio_ptr + offsets, mask=in_bounds, other=1.0).to(tl.float32)
+    if ADV_PER_TOKEN:
+        advantage = tl.load(advantage_ptr + offsets, mask=in_bounds, other=0.0).to(tl.float32)
+    else:
+        sequence_ids = offsets // tokens_per_sequence
+        advantage = tl.load(advantage_ptr + sequence_ids, mask=in_bounds, other=0.0).to(tl.float32)
+
+    lower = 1.0 - clip_low
+    upper = 1.0 + clip_high
+    clipped_ratio = tl.minimum(tl.maximum(ratio, lower), upper)
+    policy_term = -tl.minimum(ratio * advantage, clipped_ratio * advantage)
+    policy_term = tl.where(active, policy_term, 0.0)
+
+    if HAS_PENALTY:
+        penalty = tl.load(penalty_ptr + offsets, mask=in_bounds, other=0.0).to(tl.float32)
+        penalty = tl.where(active, penalty, 0.0)
+    else:
+        penalty = tl.zeros((BLOCK,), dtype=tl.float32)
+
+    clipped = ((ratio < lower) | (ratio > upper)) & active
+    count = active.to(tl.float32)
+    tl.store(partials_ptr + block_id, tl.sum(policy_term, axis=0))
+    tl.store(partials_ptr + partial_count + block_id, tl.sum(penalty, axis=0))
+    tl.store(
+        partials_ptr + 2 * partial_count + block_id,
+        tl.sum(clipped.to(tl.float32), axis=0),
+    )
+    tl.store(partials_ptr + 3 * partial_count + block_id, tl.sum(count, axis=0))
+
+
+@triton.jit
+def _ratio_clip_finalize_kernel(
+    partials_ptr,
+    outputs_ptr,
+    partial_count,
+    penalty_coef,
+    REDUCE_BLOCK: tl.constexpr,
+):
+    offsets = tl.arange(0, REDUCE_BLOCK)
+    keep = offsets < partial_count
+    policy_sum = tl.sum(tl.load(partials_ptr + offsets, mask=keep, other=0.0), axis=0)
+    penalty_sum = tl.sum(
+        tl.load(partials_ptr + partial_count + offsets, mask=keep, other=0.0),
+        axis=0,
+    )
+    clipped_sum = tl.sum(
+        tl.load(partials_ptr + 2 * partial_count + offsets, mask=keep, other=0.0),
+        axis=0,
+    )
+    active_count = tl.sum(
+        tl.load(partials_ptr + 3 * partial_count + offsets, mask=keep, other=0.0),
+        axis=0,
+    )
+    denominator = tl.maximum(active_count, 1.0)
+    policy_loss = policy_sum / denominator
+    mean_penalty = penalty_sum / denominator
+
+    tl.store(outputs_ptr, policy_loss + penalty_coef * mean_penalty)
+    tl.store(outputs_ptr + 1, policy_loss)
+    tl.store(outputs_ptr + 2, mean_penalty)
+    tl.store(outputs_ptr + 3, clipped_sum / denominator)
+    tl.store(outputs_ptr + 4, active_count)
+
+
+@triton.jit
+def _ratio_clip_backward_kernel(
+    ratio_ptr,
+    advantage_ptr,
+    mask_ptr,
+    outputs_ptr,
+    grad_total_ptr,
+    grad_policy_ptr,
+    grad_mean_penalty_ptr,
+    grad_ratio_ptr,
+    grad_penalty_ptr,
+    n_elements,
+    tokens_per_sequence,
+    clip_low,
+    clip_high,
+    penalty_coef,
+    HAS_PENALTY: tl.constexpr,
+    ADV_PER_TOKEN: tl.constexpr,
+    HAS_GRAD_TOTAL: tl.constexpr,
+    HAS_GRAD_POLICY: tl.constexpr,
+    HAS_GRAD_MEAN_PENALTY: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    block_id = tl.program_id(0)
+    offsets = block_id * BLOCK + tl.arange(0, BLOCK)
+    in_bounds = offsets < n_elements
+    active = in_bounds & (tl.load(mask_ptr + offsets, mask=in_bounds, other=0) != 0)
+
+    ratio = tl.load(ratio_ptr + offsets, mask=in_bounds, other=1.0).to(tl.float32)
+    if ADV_PER_TOKEN:
+        advantage = tl.load(advantage_ptr + offsets, mask=in_bounds, other=0.0).to(tl.float32)
+    else:
+        sequence_ids = offsets // tokens_per_sequence
+        advantage = tl.load(advantage_ptr + sequence_ids, mask=in_bounds, other=0.0).to(tl.float32)
+
+    lower = 1.0 - clip_low
+    upper = 1.0 + clip_high
+    clipped_ratio = tl.minimum(tl.maximum(ratio, lower), upper)
+    unclipped_term = ratio * advantage
+    clipped_term = clipped_ratio * advantage
+    use_unclipped = unclipped_term <= clipped_term
+    clipped_derivative = tl.where((ratio >= lower) & (ratio <= upper), advantage, 0.0)
+    policy_derivative = -tl.where(use_unclipped, advantage, clipped_derivative)
+
+    active_count = tl.load(outputs_ptr + 4)
+    denominator = tl.maximum(active_count, 1.0)
+    if HAS_GRAD_TOTAL:
+        grad_total = tl.load(grad_total_ptr)
+    else:
+        grad_total = 0.0
+    if HAS_GRAD_POLICY:
+        grad_policy_output = tl.load(grad_policy_ptr)
+    else:
+        grad_policy_output = 0.0
+    policy_scale = (grad_total + grad_policy_output) / denominator
+    grad_ratio = tl.where(active, policy_scale * policy_derivative, 0.0)
+    tl.store(grad_ratio_ptr + offsets, grad_ratio, mask=in_bounds)
+
+    if HAS_PENALTY:
+        if HAS_GRAD_MEAN_PENALTY:
+            grad_mean_penalty = tl.load(grad_mean_penalty_ptr)
+        else:
+            grad_mean_penalty = 0.0
+        penalty_scale = (grad_total * penalty_coef + grad_mean_penalty) / denominator
+        grad_penalty = tl.where(active, penalty_scale, 0.0)
+        tl.store(grad_penalty_ptr + offsets, grad_penalty, mask=in_bounds)
+
+
+class _RatioClipAggregateFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        ratio,
+        advantages,
+        mask,
+        penalty_terms,
+        clip_low,
+        clip_high,
+        penalty_coef,
+    ):
+        if not ratio.is_cuda:
+            raise RuntimeError("TritonRatioClipAggregateOp requires CUDA/ROCm tensors.")
+        per_token_advantages = _validate_ratio_clip_inputs(
+            ratio, advantages, mask, penalty_terms, clip_low, clip_high
+        )
+        if not ratio.is_floating_point() or not advantages.is_floating_point():
+            raise TypeError("ratio and advantages must be floating-point tensors.")
+        if penalty_terms is not None and not penalty_terms.is_floating_point():
+            raise TypeError("penalty_terms must be a floating-point tensor.")
+
+        ratio_flat = ratio.contiguous().view(-1)
+        advantages_flat = advantages.contiguous().view(-1)
+        mask_flat = mask.contiguous().view(-1)
+        has_penalty = penalty_terms is not None
+        penalty_flat = penalty_terms.contiguous().view(-1) if has_penalty else ratio_flat
+        n_elements = ratio_flat.numel()
+        if n_elements == 0:
+            raise ValueError("ratio must contain at least one element.")
+
+        outputs = torch.empty(5, device=ratio.device, dtype=torch.float32)
+        tokens_per_sequence = ratio.shape[-1] if ratio.ndim == 2 else n_elements
+
+        if n_elements <= _SINGLE_PASS_MAX:
+            single_block = triton.next_power_of_2(n_elements)
+            _ratio_clip_single_pass_kernel[(1,)](
+                ratio_flat,
+                advantages_flat,
+                mask_flat,
+                penalty_flat,
+                outputs,
+                n_elements,
+                tokens_per_sequence,
+                float(clip_low),
+                float(clip_high),
+                float(penalty_coef),
+                HAS_PENALTY=has_penalty,
+                ADV_PER_TOKEN=per_token_advantages,
+                BLOCK=single_block,
+                num_warps=_SINGLE_PASS_NUM_WARPS,
+            )
+        else:
+            partial_count = triton.cdiv(n_elements, _BLOCK)
+            if partial_count > _MAX_PARTIALS:
+                raise ValueError(
+                    f"ratio has {n_elements} elements, exceeding the deterministic "
+                    f"reduction limit of {_MAX_PARTIALS * _BLOCK}."
+                )
+            partials = torch.empty((4, partial_count), device=ratio.device, dtype=torch.float32)
+            _ratio_clip_partial_kernel[(partial_count,)](
+                ratio_flat,
+                advantages_flat,
+                mask_flat,
+                penalty_flat,
+                partials,
+                n_elements,
+                partial_count,
+                tokens_per_sequence,
+                float(clip_low),
+                float(clip_high),
+                HAS_PENALTY=has_penalty,
+                ADV_PER_TOKEN=per_token_advantages,
+                BLOCK=_BLOCK,
+                num_warps=_NUM_WARPS,
+            )
+            reduce_block = triton.next_power_of_2(partial_count)
+            _ratio_clip_finalize_kernel[(1,)](
+                partials,
+                outputs,
+                partial_count,
+                float(penalty_coef),
+                REDUCE_BLOCK=reduce_block,
+                num_warps=min(8, max(1, reduce_block // 128)),
+            )
+
+        ctx.save_for_backward(ratio_flat, advantages_flat, mask_flat, outputs)
+        ctx.has_penalty = has_penalty
+        ctx.per_token_advantages = per_token_advantages
+        ctx.tokens_per_sequence = tokens_per_sequence
+        ctx.clip_low = float(clip_low)
+        ctx.clip_high = float(clip_high)
+        ctx.penalty_coef = float(penalty_coef)
+        ctx.ratio_shape = tuple(ratio.shape)
+        ctx.ratio_dtype = ratio.dtype
+        ctx.penalty_shape = tuple(penalty_terms.shape) if penalty_terms is not None else None
+        ctx.penalty_dtype = penalty_terms.dtype if penalty_terms is not None else None
+
+        total, policy, mean_penalty, clip_fraction = outputs[:4].unbind()
+        ctx.set_materialize_grads(False)
+        ctx.mark_non_differentiable(clip_fraction)
+        return total, policy, mean_penalty, clip_fraction
+
+    @staticmethod
+    def backward(ctx, grad_total, grad_policy, grad_mean_penalty, grad_clip_fraction):
+        ratio, advantages, mask, outputs = ctx.saved_tensors
+        grad_ratio = torch.empty_like(ratio)
+        grad_penalty = (
+            torch.empty(ctx.penalty_shape, device=ratio.device, dtype=ctx.penalty_dtype).view(-1)
+            if ctx.has_penalty
+            else ratio
+        )
+
+        has_grad_total = grad_total is not None
+        has_grad_policy = grad_policy is not None
+        has_grad_mean_penalty = grad_mean_penalty is not None
+        grad_total = outputs if grad_total is None else grad_total.contiguous()
+        grad_policy = outputs if grad_policy is None else grad_policy.contiguous()
+        grad_mean_penalty = outputs if grad_mean_penalty is None else grad_mean_penalty.contiguous()
+        grid = (triton.cdiv(ratio.numel(), _BLOCK),)
+        _ratio_clip_backward_kernel[grid](
+            ratio,
+            advantages,
+            mask,
+            outputs,
+            grad_total,
+            grad_policy,
+            grad_mean_penalty,
+            grad_ratio,
+            grad_penalty,
+            ratio.numel(),
+            ctx.tokens_per_sequence,
+            ctx.clip_low,
+            ctx.clip_high,
+            ctx.penalty_coef,
+            HAS_PENALTY=ctx.has_penalty,
+            ADV_PER_TOKEN=ctx.per_token_advantages,
+            HAS_GRAD_TOTAL=has_grad_total,
+            HAS_GRAD_POLICY=has_grad_policy,
+            HAS_GRAD_MEAN_PENALTY=has_grad_mean_penalty,
+            BLOCK=_BLOCK,
+            num_warps=_NUM_WARPS,
+        )
+
+        grad_ratio = grad_ratio.view(ctx.ratio_shape).to(ctx.ratio_dtype)
+        if ctx.has_penalty:
+            grad_penalty = grad_penalty.view(ctx.penalty_shape).to(ctx.penalty_dtype)
+        else:
+            grad_penalty = None
+        return grad_ratio, None, None, grad_penalty, None, None, None
+
+
+class TritonRatioClipAggregateOp:
+    """Triton ratio-clip-aggregate operator for PPO/GRPO policy losses."""
+
+    def __call__(
+        self,
+        ratio: torch.Tensor,
+        advantages: torch.Tensor,
+        mask: torch.Tensor,
+        *,
+        clip_low: float = 0.2,
+        clip_high: float = 0.2,
+        penalty_terms: Optional[torch.Tensor] = None,
+        penalty_coef: float = 0.0,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        return self.forward(
+            ratio,
+            advantages,
+            mask,
+            clip_low=clip_low,
+            clip_high=clip_high,
+            penalty_terms=penalty_terms,
+            penalty_coef=penalty_coef,
+        )
+
+    def forward(
+        self,
+        ratio: torch.Tensor,
+        advantages: torch.Tensor,
+        mask: torch.Tensor,
+        *,
+        clip_low: float = 0.2,
+        clip_high: float = 0.2,
+        penalty_terms: Optional[torch.Tensor] = None,
+        penalty_coef: float = 0.0,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        return _RatioClipAggregateFunction.apply(
+            ratio,
+            advantages,
+            mask,
+            penalty_terms,
+            clip_low,
+            clip_high,
+            penalty_coef,
+        )

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -55,6 +55,13 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     # Fused policy-ratio + KL-penalty front-end (PPO/GRPO), logits -> (ratio, kl)
     TRITON_RATIO_KL = "rl_engine.kernels.ops.triton.loss.ratio_kl.TritonRatioKLOp"
     PYTORCH_RATIO_KL = "rl_engine.kernels.ops.pytorch.loss.ratio_kl.NativeRatioKLOp"
+    # Fused PPO/GRPO ratio clipping + masked loss/penalty aggregation
+    TRITON_RATIO_CLIP_AGGREGATE = (
+        "rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate.TritonRatioClipAggregateOp"
+    )
+    PYTORCH_RATIO_CLIP_AGGREGATE = (
+        "rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate.NativeRatioClipAggregateOp"
+    )
 
     # Variable-length packing (pack-and-pad), [B,S,...] -> [Total_Active,...]
     PYTORCH_PACK = "rl_engine.kernels.ops.pytorch.packing.pack.NativePackOp"
@@ -204,6 +211,10 @@ class KernelRegistry:
                     OpBackend.PYTORCH_LINEAR_LOGP,
                 ],
                 "ratio_kl": [OpBackend.TRITON_RATIO_KL, OpBackend.PYTORCH_RATIO_KL],
+                "ratio_clip_aggregate": [
+                    OpBackend.TRITON_RATIO_CLIP_AGGREGATE,
+                    OpBackend.PYTORCH_RATIO_CLIP_AGGREGATE,
+                ],
                 "pack": [OpBackend.PYTORCH_PACK],
                 "det_gemm": [OpBackend.CUDA_DET_GEMM, OpBackend.TRITON_DET_GEMM],
                 "batch_invariant_logp": [
@@ -242,6 +253,10 @@ class KernelRegistry:
                 "rope": [OpBackend.TRITON_ROPE, OpBackend.PYTORCH_NATIVE_ROPE],
                 "linear_logp": [OpBackend.TRITON_LINEAR_LOGP, OpBackend.PYTORCH_LINEAR_LOGP],
                 "ratio_kl": [OpBackend.TRITON_RATIO_KL, OpBackend.PYTORCH_RATIO_KL],
+                "ratio_clip_aggregate": [
+                    OpBackend.TRITON_RATIO_CLIP_AGGREGATE,
+                    OpBackend.PYTORCH_RATIO_CLIP_AGGREGATE,
+                ],
                 "pack": [OpBackend.PYTORCH_PACK],
                 "det_gemm": [OpBackend.TRITON_DET_GEMM],
                 "batch_invariant_logp": [
@@ -266,6 +281,7 @@ class KernelRegistry:
                 "rope": [OpBackend.PYTORCH_NATIVE_ROPE],
                 "linear_logp": [OpBackend.PYTORCH_LINEAR_LOGP],
                 "ratio_kl": [OpBackend.PYTORCH_RATIO_KL],
+                "ratio_clip_aggregate": [OpBackend.PYTORCH_RATIO_CLIP_AGGREGATE],
                 "pack": [OpBackend.PYTORCH_PACK],
                 "batch_invariant_logp": [OpBackend.PYTORCH_BATCH_INVARIANT_LOGP],
                 "matmul": [OpBackend.PYTORCH_NATIVE_MATMUL],

--- a/tests/test_ratio_clip_aggregate.py
+++ b/tests/test_ratio_clip_aggregate.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+import pytest
+import torch
+
+from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import (
+    NativeRatioClipAggregateOp,
+)
+from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import (
+    TritonRatioClipAggregateOp,
+)
+
+try:
+    import triton  # noqa: F401
+
+    _HAS_TRITON = True
+except ImportError:  # pragma: no cover
+    _HAS_TRITON = False
+
+requires_triton_cuda = pytest.mark.skipif(
+    not (_HAS_TRITON and torch.cuda.is_available()),
+    reason="Triton ratio-clip-aggregate requires a CUDA device and Triton.",
+)
+
+
+def test_native_matches_asymmetric_clip_reference():
+    ratio = torch.tensor([[0.60, 0.85, 1.10], [1.25, 1.50, 0.95]])
+    advantages = torch.tensor([[1.0, -2.0, 0.5], [-1.5, 2.0, -0.25]])
+    mask = torch.tensor([[True, True, False], [True, True, True]])
+    penalty = torch.tensor([[0.1, 0.2, 9.0], [0.3, 0.4, 0.5]])
+    clip_low, clip_high, penalty_coef = 0.15, 0.25, 0.07
+
+    total, policy, mean_penalty, clip_fraction = NativeRatioClipAggregateOp()(
+        ratio,
+        advantages,
+        mask,
+        clip_low=clip_low,
+        clip_high=clip_high,
+        penalty_terms=penalty,
+        penalty_coef=penalty_coef,
+    )
+
+    clipped_ratio = ratio.clamp(1.0 - clip_low, 1.0 + clip_high)
+    terms = -torch.minimum(ratio * advantages, clipped_ratio * advantages)
+    expected_policy = terms[mask].mean()
+    expected_penalty = penalty[mask].mean()
+    expected_clip_fraction = (
+        ((ratio < 1.0 - clip_low) | (ratio > 1.0 + clip_high))[mask].float().mean()
+    )
+
+    torch.testing.assert_close(policy, expected_policy)
+    torch.testing.assert_close(mean_penalty, expected_penalty)
+    torch.testing.assert_close(total, expected_policy + penalty_coef * expected_penalty)
+    torch.testing.assert_close(clip_fraction, expected_clip_fraction)
+
+
+def test_native_accepts_per_sequence_advantages_without_expansion():
+    ratio = torch.tensor([[0.70, 1.10, 1.30], [0.80, 1.00, 1.40]])
+    sequence_advantages = torch.tensor([2.0, -3.0])
+    mask = torch.tensor([[True, False, True], [True, True, True]])
+
+    _, policy, _, _ = NativeRatioClipAggregateOp()(
+        ratio,
+        sequence_advantages,
+        mask,
+        clip_low=0.1,
+        clip_high=0.2,
+    )
+
+    token_advantages = sequence_advantages[:, None].expand_as(ratio)
+    expected_terms = -torch.minimum(
+        ratio * token_advantages,
+        ratio.clamp(0.9, 1.2) * token_advantages,
+    )
+    torch.testing.assert_close(policy, expected_terms[mask].mean())
+
+
+def test_native_total_loss_gradients_match_reference():
+    ratio = torch.tensor([[0.70, 0.95, 1.30], [0.75, 1.05, 1.45]], requires_grad=True)
+    ratio_ref = ratio.detach().clone().requires_grad_(True)
+    advantages = torch.tensor([[2.0, -1.0, 0.5], [-3.0, 1.5, -0.25]])
+    mask = torch.tensor([[True, True, False], [True, True, True]])
+    penalty = torch.tensor([[0.2, 0.3, 0.4], [0.5, 0.6, 0.7]], requires_grad=True)
+    penalty_ref = penalty.detach().clone().requires_grad_(True)
+
+    total, _, _, _ = NativeRatioClipAggregateOp()(
+        ratio,
+        advantages,
+        mask,
+        clip_low=0.1,
+        clip_high=0.2,
+        penalty_terms=penalty,
+        penalty_coef=0.05,
+    )
+    total.backward()
+
+    reference_terms = -torch.minimum(
+        ratio_ref * advantages,
+        ratio_ref.clamp(0.9, 1.2) * advantages,
+    )
+    reference_total = reference_terms[mask].mean() + 0.05 * penalty_ref[mask].mean()
+    reference_total.backward()
+
+    torch.testing.assert_close(ratio.grad, ratio_ref.grad)
+    torch.testing.assert_close(penalty.grad, penalty_ref.grad)
+
+
+def test_native_empty_mask_returns_finite_zeros_and_zero_gradients():
+    ratio = torch.tensor([[0.5, 1.5]], requires_grad=True)
+    penalty = torch.tensor([[2.0, 3.0]], requires_grad=True)
+
+    outputs = NativeRatioClipAggregateOp()(
+        ratio,
+        torch.tensor([1.0]),
+        torch.zeros_like(ratio, dtype=torch.bool),
+        penalty_terms=penalty,
+        penalty_coef=0.2,
+    )
+
+    for output in outputs:
+        torch.testing.assert_close(output, torch.zeros_like(output))
+    outputs[0].backward()
+    torch.testing.assert_close(ratio.grad, torch.zeros_like(ratio))
+    torch.testing.assert_close(penalty.grad, torch.zeros_like(penalty))
+
+
+def test_native_rejects_invalid_public_contract():
+    op = NativeRatioClipAggregateOp()
+    ratio = torch.ones(2, 3)
+    advantages = torch.ones(2)
+    mask = torch.ones(2, 3, dtype=torch.bool)
+
+    with pytest.raises(ValueError, match="mask shape"):
+        op(ratio, advantages, mask[:, :2])
+    with pytest.raises(ValueError, match="penalty_terms shape"):
+        op(ratio, advantages, mask, penalty_terms=torch.ones(2, 2))
+    with pytest.raises(ValueError, match="clip_low"):
+        op(ratio, advantages, mask, clip_low=1.0)
+    with pytest.raises(TypeError, match="mask"):
+        op(ratio, advantages, mask.float())
+    with pytest.raises(ValueError, match="detached"):
+        op(ratio, advantages.requires_grad_(True), mask)
+    with pytest.raises(TypeError, match="floating-point"):
+        op(ratio.to(torch.int64), advantages, mask)
+    with pytest.raises(ValueError, match="at least one"):
+        op(torch.empty(0), torch.empty(0), torch.empty(0, dtype=torch.bool))
+
+
+@requires_triton_cuda
+def test_triton_forward_matches_native_with_sequence_advantages_and_penalty():
+    generator = torch.Generator(device="cuda").manual_seed(17)
+    ratio = torch.exp(torch.randn(37, 129, generator=generator, device="cuda") * 0.3)
+    advantages = torch.randn(37, generator=generator, device="cuda")
+    mask = torch.rand(37, 129, generator=generator, device="cuda") > 0.2
+    penalty = torch.rand(37, 129, generator=generator, device="cuda")
+    kwargs = dict(
+        clip_low=0.1,
+        clip_high=0.25,
+        penalty_terms=penalty,
+        penalty_coef=0.07,
+    )
+
+    expected = NativeRatioClipAggregateOp()(ratio, advantages, mask, **kwargs)
+    actual = TritonRatioClipAggregateOp()(ratio, advantages, mask, **kwargs)
+
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(got, want, atol=1e-5, rtol=1e-5)
+
+
+@requires_triton_cuda
+def test_triton_backward_matches_native_for_all_differentiable_outputs():
+    generator = torch.Generator(device="cuda").manual_seed(23)
+    base_ratio = torch.exp(torch.randn(19, 257, generator=generator, device="cuda") * 0.4)
+    advantages = torch.randn(19, 257, generator=generator, device="cuda")
+    mask = torch.rand(19, 257, generator=generator, device="cuda") > 0.25
+    base_penalty = torch.rand(19, 257, generator=generator, device="cuda")
+    kwargs = dict(clip_low=0.12, clip_high=0.28, penalty_coef=0.03)
+
+    native_ratio = base_ratio.clone().requires_grad_(True)
+    native_penalty = base_penalty.clone().requires_grad_(True)
+    native_outputs = NativeRatioClipAggregateOp()(
+        native_ratio,
+        advantages,
+        mask,
+        penalty_terms=native_penalty,
+        **kwargs,
+    )
+    (1.7 * native_outputs[0] + 0.3 * native_outputs[1] - 0.2 * native_outputs[2]).backward()
+
+    triton_ratio = base_ratio.clone().requires_grad_(True)
+    triton_penalty = base_penalty.clone().requires_grad_(True)
+    triton_outputs = TritonRatioClipAggregateOp()(
+        triton_ratio,
+        advantages,
+        mask,
+        penalty_terms=triton_penalty,
+        **kwargs,
+    )
+    (1.7 * triton_outputs[0] + 0.3 * triton_outputs[1] - 0.2 * triton_outputs[2]).backward()
+
+    torch.testing.assert_close(triton_ratio.grad, native_ratio.grad, atol=1e-6, rtol=1e-6)
+    torch.testing.assert_close(triton_penalty.grad, native_penalty.grad, atol=1e-7, rtol=1e-6)
+
+
+@requires_triton_cuda
+def test_triton_backward_supports_policy_output_without_materialized_grads():
+    ratio = torch.tensor([[0.7, 0.95, 1.3]], device="cuda", requires_grad=True)
+    ratio_ref = ratio.detach().clone().requires_grad_(True)
+    advantages = torch.tensor([[2.0, -1.0, 0.5]], device="cuda")
+    mask = torch.tensor([[True, True, True]], device="cuda")
+
+    TritonRatioClipAggregateOp()(ratio, advantages, mask)[1].backward()
+    NativeRatioClipAggregateOp()(ratio_ref, advantages, mask)[1].backward()
+
+    torch.testing.assert_close(ratio.grad, ratio_ref.grad)
+
+
+@requires_triton_cuda
+def test_triton_backward_preserves_mixed_input_gradient_dtypes():
+    ratio = torch.tensor([[0.7, 0.95, 1.3]], device="cuda", requires_grad=True)
+    penalty = torch.tensor(
+        [[0.2, 0.3, 0.4]], device="cuda", dtype=torch.float16, requires_grad=True
+    )
+    advantages = torch.tensor([[2.0, -1.0, 0.5]], device="cuda")
+    mask = torch.tensor([[True, True, True]], device="cuda")
+
+    TritonRatioClipAggregateOp()(
+        ratio,
+        advantages,
+        mask,
+        penalty_terms=penalty,
+        penalty_coef=0.04,
+    )[0].backward()
+
+    assert ratio.grad.dtype == ratio.dtype
+    assert penalty.grad.dtype == penalty.dtype
+    torch.testing.assert_close(
+        penalty.grad,
+        torch.full_like(penalty, 0.04 / penalty.numel()),
+    )
+
+
+@requires_triton_cuda
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_triton_matches_native_without_penalty_for_supported_dtypes(dtype):
+    if dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("GPU does not support BF16")
+    generator = torch.Generator(device="cuda").manual_seed(29)
+    ratio_storage = torch.exp(torch.randn(11, 258, generator=generator, device="cuda") * 0.25).to(
+        dtype
+    )
+    advantage_storage = torch.randn(11, 258, generator=generator, device="cuda").to(dtype)
+    mask_storage = torch.rand(11, 258, generator=generator, device="cuda") > 0.15
+    ratio = ratio_storage[:, ::2]
+    advantages = advantage_storage[:, ::2]
+    mask = mask_storage[:, ::2]
+
+    expected = NativeRatioClipAggregateOp()(
+        ratio,
+        advantages,
+        mask,
+        clip_low=0.2,
+        clip_high=0.3,
+    )
+    actual = TritonRatioClipAggregateOp()(
+        ratio,
+        advantages,
+        mask,
+        clip_low=0.2,
+        clip_high=0.3,
+    )
+
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(got, want, atol=2e-5, rtol=2e-5)
+
+
+@requires_triton_cuda
+def test_triton_empty_mask_returns_finite_zeros_and_zero_gradients():
+    ratio = torch.tensor([[0.5, 1.5]], device="cuda", requires_grad=True)
+    penalty = torch.tensor([[2.0, 3.0]], device="cuda", requires_grad=True)
+    outputs = TritonRatioClipAggregateOp()(
+        ratio,
+        torch.tensor([1.0], device="cuda"),
+        torch.zeros_like(ratio, dtype=torch.bool),
+        penalty_terms=penalty,
+        penalty_coef=0.2,
+    )
+
+    for output in outputs:
+        torch.testing.assert_close(output, torch.zeros_like(output))
+    outputs[0].backward()
+    torch.testing.assert_close(ratio.grad, torch.zeros_like(ratio))
+    torch.testing.assert_close(penalty.grad, torch.zeros_like(penalty))
+
+
+@requires_triton_cuda
+@pytest.mark.parametrize("elements", [65536, 65537])
+def test_triton_matches_native_at_single_and_staged_reduction_boundary(elements):
+    generator = torch.Generator(device="cuda").manual_seed(elements)
+    ratio = torch.exp(torch.randn(elements, generator=generator, device="cuda") * 0.3)
+    advantages = torch.randn(elements, generator=generator, device="cuda")
+    mask = torch.rand(elements, generator=generator, device="cuda") > 0.1
+    penalty = torch.rand(elements, generator=generator, device="cuda")
+    kwargs = dict(
+        clip_low=0.15,
+        clip_high=0.25,
+        penalty_terms=penalty,
+        penalty_coef=0.04,
+    )
+
+    expected = NativeRatioClipAggregateOp()(ratio, advantages, mask, **kwargs)
+    actual = TritonRatioClipAggregateOp()(ratio, advantages, mask, **kwargs)
+
+    for got, want in zip(actual, expected, strict=True):
+        torch.testing.assert_close(got, want, atol=2e-5, rtol=2e-5)
+
+
+@requires_triton_cuda
+def test_triton_staged_reduction_is_bitwise_deterministic():
+    generator = torch.Generator(device="cuda").manual_seed(41)
+    elements = 65537
+    ratio = torch.exp(torch.randn(elements, generator=generator, device="cuda") * 0.3)
+    advantages = torch.randn(elements, generator=generator, device="cuda")
+    mask = torch.rand(elements, generator=generator, device="cuda") > 0.1
+    penalty = torch.rand(elements, generator=generator, device="cuda")
+    op = TritonRatioClipAggregateOp()
+
+    expected = op(ratio, advantages, mask, penalty_terms=penalty, penalty_coef=0.04)
+    for _ in range(5):
+        actual = op(ratio, advantages, mask, penalty_terms=penalty, penalty_coef=0.04)
+        assert all(torch.equal(got, want) for got, want in zip(actual, expected, strict=True))
+
+
+def test_registry_dispatches_ratio_clip_aggregate():
+    from rl_engine.kernels.registry import kernel_registry
+
+    op = kernel_registry.get_op("ratio_clip_aggregate")
+    if _HAS_TRITON and torch.cuda.is_available():
+        assert isinstance(op, TritonRatioClipAggregateOp)
+    else:
+        assert isinstance(op, NativeRatioClipAggregateOp)

--- a/tests/test_ratio_clip_aggregate.py
+++ b/tests/test_ratio_clip_aggregate.py
@@ -4,12 +4,8 @@
 import pytest
 import torch
 
-from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import (
-    NativeRatioClipAggregateOp,
-)
-from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import (
-    TritonRatioClipAggregateOp,
-)
+from rl_engine.kernels.ops.pytorch.loss.ratio_clip_aggregate import NativeRatioClipAggregateOp
+from rl_engine.kernels.ops.triton.loss.ratio_clip_aggregate import TritonRatioClipAggregateOp
 
 try:
     import triton  # noqa: F401


### PR DESCRIPTION
Closes #252.

## What changed

- Add native PyTorch and Triton `ratio_clip_aggregate` backends for PPO/GRPO clipped-surrogate loss.
- Fuse asymmetric ratio clipping, active-token masking, optional penalty reduction, clip-fraction reporting, and analytical backward.
- Accept per-sequence advantages directly, avoiding a broadcast `[B, T]` tensor.
- Use a tuned single-program reduction through 65,536 tokens and a deterministic two-stage reduction for larger inputs; neither path uses `atomicAdd` or CPU synchronization.
- Register CUDA, ROCm, and CPU backends and integrate the operator into GRPO and the DeepSpeed training worker.
- Add correctness, gradient, dtype, non-contiguous input, empty-mask, reduction-boundary, determinism, registry, benchmark, and operator documentation coverage.

## Performance

Measured on NVIDIA RTX PRO 5000 Blackwell, PyTorch 2.11, CUDA 12.9, Triton 3.6, FP32 inputs, 90% mask density, 100 warmups, and 500 iterations.

| Shape | PyTorch fwd | Triton fwd | Speedup | PyTorch fwd+bwd | Triton fwd+bwd | Speedup |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 32 x 256 | 0.143 ms | 0.036 ms | 4.02x | 0.416 ms | 0.178 ms | 2.34x |
| 128 x 1024 | 0.153 ms | 0.050 ms | 3.04x | 0.429 ms | 0.201 ms | 2.14x |
| 256 x 4096 | 0.154 ms | 0.050 ms | 3.05x | 0.432 ms | 0.200 ms | 2.16x |
| 256 x 16384 | 0.317 ms | 0.051 ms | 6.28x | 0.664 ms | 0.200 ms | 3.32x |

At 4.19M tokens, measured forward intermediates decrease from 64.0 MiB to 0.3 MiB.

## Validation

- `pytest -q tests/test_ratio_clip_aggregate.py tests/test_grpo_loss.py tests/test_deepspeed_training_worker.py` — 58 passed
- `pytest -q tests/test_kernel_registry.py tests/test_rl_kernel_loss_step.py tests/test_ratio_kl.py tests/test_grpo_single_gpu_example.py` — 29 passed, 1 skipped
- `ruff check` and `ruff format --check` on every changed Python file
- `mkdocs build --strict -f mkdocs.yaml`
- `python benchmarks/benchmark_ratio_clip_aggregate.py --iterations 500 --warmup 100`

The disposable full-suite container did not include the repository's deterministic-attention CUDA extension, so its extension-dependent tests were not a valid signal; the affected operator and integration suites above are green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fused ratio clipping and masked loss aggregation for PPO/GRPO training.
  * Supports optional penalty terms, sequence- or token-level advantages, clipping metrics, and gradient computation.
  * Added optimized CUDA/ROCm execution with CPU fallback.

* **Documentation**
  * Added operator documentation, usage details, backend information, and benchmark results.
  * Updated GRPO Loss documentation to describe the new operator integration.

* **Tests**
  * Added comprehensive coverage for forward/backward behavior, validation, reductions, masking, and backend dispatch.

* **Benchmarks**
  * Added configurable performance and memory benchmarks for native and optimized implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->