### PR TITLE
[WS2][GEMM][Forward]: implement PR4 TP+CP with FFN and collective reductions

### DIFF
--- a/rl_engine/kernels/ops/pytorch/ffn/__init__.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/__init__.py
@@ -2,6 +2,16 @@
 # Copyright (c) 2026 RL-Kernel Contributors
 """Composable Qwen-style feed-forward network reference operators."""
 
-from .tensor_parallel import FFNContext, TensorParallelFFN, shard_qwen3_ffn_weights
+from .tensor_parallel import (
+    DeterministicTensorParallelCommunication,
+    FFNContext,
+    TensorParallelFFN,
+    shard_qwen3_ffn_weights,
+)
 
-__all__ = ["FFNContext", "TensorParallelFFN", "shard_qwen3_ffn_weights"]
+__all__ = [
+    "DeterministicTensorParallelCommunication",
+    "FFNContext",
+    "TensorParallelFFN",
+    "shard_qwen3_ffn_weights",
+]

--- a/rl_engine/kernels/ops/pytorch/ffn/__init__.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/__init__.py
@@ -3,6 +3,7 @@
 """Composable Qwen-style feed-forward network reference operators."""
 
 from .tensor_parallel import (
+    DeterministicContextParallelCommunication,
     DeterministicTensorParallelCommunication,
     FFNContext,
     TensorParallelFFN,
@@ -10,6 +11,7 @@ from .tensor_parallel import (
 )
 
 __all__ = [
+    "DeterministicContextParallelCommunication",
     "DeterministicTensorParallelCommunication",
     "FFNContext",
     "TensorParallelFFN",

--- a/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
@@ -26,7 +26,7 @@ SP activation AllGather/ReduceScatter is intentionally out of scope.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Protocol
 
 import torch
 import torch.distributed as dist
@@ -35,6 +35,123 @@ from torch import Tensor, nn
 from rl_engine.kernels.ops.pytorch.activation.swiglu import NativeSwiGLUOp
 
 LocalGemm = Callable[[Tensor, Tensor], Tensor]
+
+
+class ParallelCommunication(Protocol):
+    """One configured deterministic SUM axis owned by an FFN context."""
+
+    def all_reduce(self, tensor: Tensor, *, ctx: "FFNContext") -> Tensor:
+        """Return the configured TP or CP sum for tensor."""
+
+
+class _DeterministicAllReduceCommunication:
+    """Cached PR #310 deterministic all-reduce for exactly one parallel axis."""
+
+    _group_attribute: str
+    _size_attribute: str
+    _rank_attribute: str
+    _parallel_name: str
+
+    def __init__(
+        self,
+        *,
+        process_group: Any = None,
+        collective: Any = None,
+        max_size_bytes: int = 64 * 1024 * 1024,
+    ) -> None:
+        if max_size_bytes <= 0:
+            raise ValueError("max_size_bytes must be positive.")
+        self._process_group = process_group
+        self._collective = collective
+        self._max_size_bytes = int(max_size_bytes)
+
+    def all_reduce(self, tensor: Tensor, *, ctx: "FFNContext") -> Tensor:
+        """Run an in-place PR #310 deterministic SUM for this communication axis."""
+
+        if not tensor.is_cuda:
+            raise ValueError(
+                f"Deterministic{self._parallel_name}ParallelCommunication requires "
+                "a CUDA tensor; use the native path for CPU/Gloo reference execution."
+            )
+        group = getattr(ctx, self._group_attribute)
+        world_size = getattr(ctx, self._size_attribute)
+        rank = getattr(ctx, self._rank_attribute)
+        if world_size is None or rank is None:
+            raise RuntimeError(f"FFNContext has unresolved {self._parallel_name} coordinates.")
+        collective = self._get_collective(tensor, group)
+        self._validate_collective_coordinates(collective, int(world_size), int(rank))
+        reduced = collective.all_reduce(tensor, out=tensor)
+        if reduced is not tensor:
+            raise RuntimeError(
+                "DeterministicCollective.all_reduce must return its aliased out tensor."
+            )
+        return reduced
+
+    def close(self) -> None:
+        """Release the cached PR #310 CUDA IPC collective, if one was created."""
+
+        close = getattr(self._collective, "close", None)
+        if close is not None:
+            close()
+
+    def _get_collective(self, tensor: Tensor, group: Any) -> Any:
+        if self._process_group is not None and self._process_group is not group:
+            raise ValueError(
+                f"Deterministic {self._parallel_name} process_group must match FFNContext."
+            )
+        if self._collective is None:
+            try:
+                from rl_engine.distributed import DeterministicCollective
+            except ImportError as exc:
+                raise RuntimeError(
+                    "deterministic FFN communication requires distributed PR #310 "
+                    "(rl_engine.distributed.DeterministicCollective)."
+                ) from exc
+            self._collective = DeterministicCollective(
+                group=group,
+                device=tensor.device,
+                max_size_bytes=self._max_size_bytes,
+            )
+
+        collective_group = getattr(self._collective, "group", group)
+        if collective_group is not group:
+            raise ValueError(
+                f"DeterministicCollective group must match the FFN {self._parallel_name} group."
+            )
+        return self._collective
+
+    def _validate_collective_coordinates(
+        self,
+        collective: Any,
+        world_size: int,
+        rank: int,
+    ) -> None:
+        collective_size = getattr(collective, "world_size", None)
+        collective_rank = getattr(collective, "rank", None)
+        if collective_size != world_size or collective_rank != rank:
+            raise ValueError(
+                f"DeterministicCollective coordinates must match FFN {self._parallel_name}: "
+                f"collective=({collective_size}, {collective_rank}), "
+                f"context=({world_size}, {rank})."
+            )
+
+
+class DeterministicTensorParallelCommunication(_DeterministicAllReduceCommunication):
+    """PR #310 deterministic SUM for the FFN's TP collective boundaries."""
+
+    _group_attribute = "tp_group"
+    _size_attribute = "tp_size"
+    _rank_attribute = "tp_rank"
+    _parallel_name = "Tensor"
+
+
+class DeterministicContextParallelCommunication(_DeterministicAllReduceCommunication):
+    """PR #310 deterministic SUM for the FFN's CP parameter-gradient boundaries."""
+
+    _group_attribute = "cp_group"
+    _size_attribute = "cp_size"
+    _rank_attribute = "cp_rank"
+    _parallel_name = "Context"
 
 
 def _missing_deterministic_gemm(input_: Tensor, weight: Tensor) -> Tensor:
@@ -108,6 +225,8 @@ class FFNContext:
     cp_group: Any = None
     cp_size: Optional[int] = None
     cp_rank: Optional[int] = None
+    tp_communication: Optional[ParallelCommunication] = None
+    cp_communication: Optional[ParallelCommunication] = None
 
     def __post_init__(self) -> None:
         tp_size, tp_rank = _resolve_parallel_coordinates(
@@ -136,23 +255,42 @@ class FFNContext:
         return self.cp_size > 1
 
 
-def _all_reduce_sum(tensor: Tensor, group: Any, world_size: int) -> Tensor:
+def _all_reduce_sum(
+    tensor: Tensor,
+    group: Any,
+    world_size: int,
+    communication: Optional[ParallelCommunication],
+    ctx: FFNContext,
+) -> Tensor:
     """Synchronously sum a tensor over an explicitly configured process group."""
 
     if world_size > 1:
-        # TODO(WS2): replace NCCL/Gloo with the deterministic collective once it lands.
+        if communication is not None:
+            return communication.all_reduce(tensor, ctx=ctx)
         dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=group)
     return tensor
 
 
 def _all_reduce_tp_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
     assert ctx.tp_size is not None
-    return _all_reduce_sum(tensor, ctx.tp_group, ctx.tp_size)
+    return _all_reduce_sum(
+        tensor,
+        ctx.tp_group,
+        ctx.tp_size,
+        ctx.tp_communication,
+        ctx,
+    )
 
 
 def _all_reduce_cp_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
     assert ctx.cp_size is not None
-    return _all_reduce_sum(tensor, ctx.cp_group, ctx.cp_size)
+    return _all_reduce_sum(
+        tensor,
+        ctx.cp_group,
+        ctx.cp_size,
+        ctx.cp_communication,
+        ctx,
+    )
 
 
 class _CopyToTensorParallelRegion(torch.autograd.Function):

--- a/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
-"""Tensor-parallel Qwen3-style SwiGLU FFN orchestration.
+"""Tensor- and context-parallel Qwen3-style SwiGLU FFN orchestration.
 
 The module implements the non-sequence-parallel TP ownership contract used by
 the Qwen3 dense MLP:
@@ -17,8 +17,10 @@ backward TP SUM occurs after the local Gate and Up input-gradient
 contributions have been accumulated, exactly as required by the TP FFN
 derivation.  There is no TP reduction for Down's feature-sharded ``dHidden``.
 
-CP/SP configuration and CP weight-gradient reductions intentionally do not
-belong in this PR3 module.
+CP shards token rows. It has no forward activation collective: each CP rank
+keeps its own rows. In backward, each TP-local parameter shard is replicated
+across its CP lane, so Gate, Up, and Down each perform one CP SUM of ``dW``.
+SP activation AllGather/ReduceScatter is intentionally out of scope.
 """
 
 from __future__ import annotations
@@ -46,48 +48,78 @@ def _missing_deterministic_gemm(input_: Tensor, weight: Tensor) -> Tensor:
     )
 
 
+def _resolve_parallel_coordinates(
+    name: str,
+    group: Any,
+    size: Optional[int],
+    rank: Optional[int],
+) -> tuple[int, int]:
+    """Validate one explicit parallel group and return concrete coordinates."""
+
+    if group is None:
+        resolved_size = 1 if size is None else int(size)
+        resolved_rank = 0 if rank is None else int(rank)
+        if resolved_size != 1 or resolved_rank != 0:
+            raise ValueError(
+                f"FFNContext({name}_group=None) only supports {name}_size=1 and "
+                f"{name}_rank=0. Supply an explicit initialized {name}_group for "
+                f"{name.upper()} > 1."
+            )
+    else:
+        if not dist.is_available() or not dist.is_initialized():
+            raise RuntimeError(
+                f"FFNContext({name}_group=...) requires torch.distributed to be initialized."
+            )
+        group_size = dist.get_world_size(group=group)
+        group_rank = dist.get_rank(group=group)
+        resolved_size = group_size if size is None else int(size)
+        resolved_rank = group_rank if rank is None else int(rank)
+        if resolved_size != group_size:
+            raise ValueError(
+                f"ctx.{name}_size={resolved_size} does not match {name}_group "
+                f"world size={group_size}."
+            )
+        if resolved_rank != group_rank:
+            raise ValueError(
+                f"ctx.{name}_rank={resolved_rank} does not match {name}_group "
+                f"rank={group_rank}."
+            )
+
+    if resolved_size < 1 or not 0 <= resolved_rank < resolved_size:
+        raise ValueError(
+            f"invalid {name.upper()} coordinates: {name}_size={resolved_size}, "
+            f"{name}_rank={resolved_rank}."
+        )
+    return resolved_size, resolved_rank
+
+
 @dataclass(frozen=True)
 class FFNContext:
-    """Explicit tensor-parallel configuration owned by an FFN caller.
+    """Explicit TP/CP configuration owned by an FFN caller.
 
-    ``tp_group`` is never created or inferred by this module.  A multi-rank
-    configuration must supply an initialized explicit process group; this is
-    important because later PRs add distinct CP and SP groups.
+    Neither group is created or inferred by this module.  A multi-rank
+    configuration must supply initialized explicit groups, which preserves the
+    fixed TP/CP topology and leaves SP group ownership to the next PR.
     """
 
     tp_group: Any = None
     tp_size: Optional[int] = None
     tp_rank: Optional[int] = None
+    cp_group: Any = None
+    cp_size: Optional[int] = None
+    cp_rank: Optional[int] = None
 
     def __post_init__(self) -> None:
-        if self.tp_group is None:
-            size = 1 if self.tp_size is None else int(self.tp_size)
-            rank = 0 if self.tp_rank is None else int(self.tp_rank)
-            if size != 1 or rank != 0:
-                raise ValueError(
-                    "FFNContext(tp_group=None) only supports tp_size=1 and tp_rank=0. "
-                    "Supply an explicit initialized tp_group for TP > 1."
-                )
-        else:
-            if not dist.is_available() or not dist.is_initialized():
-                raise RuntimeError(
-                    "FFNContext(tp_group=...) requires torch.distributed to be initialized."
-                )
-            group_size = dist.get_world_size(group=self.tp_group)
-            group_rank = dist.get_rank(group=self.tp_group)
-            size = group_size if self.tp_size is None else int(self.tp_size)
-            rank = group_rank if self.tp_rank is None else int(self.tp_rank)
-            if size != group_size:
-                raise ValueError(
-                    f"ctx.tp_size={size} does not match tp_group world size={group_size}."
-                )
-            if rank != group_rank:
-                raise ValueError(f"ctx.tp_rank={rank} does not match tp_group rank={group_rank}.")
-
-        if size < 1 or not 0 <= rank < size:
-            raise ValueError(f"invalid TP coordinates: tp_size={size}, tp_rank={rank}.")
-        object.__setattr__(self, "tp_size", size)
-        object.__setattr__(self, "tp_rank", rank)
+        tp_size, tp_rank = _resolve_parallel_coordinates(
+            "tp", self.tp_group, self.tp_size, self.tp_rank
+        )
+        cp_size, cp_rank = _resolve_parallel_coordinates(
+            "cp", self.cp_group, self.cp_size, self.cp_rank
+        )
+        object.__setattr__(self, "tp_size", tp_size)
+        object.__setattr__(self, "tp_rank", tp_rank)
+        object.__setattr__(self, "cp_size", cp_size)
+        object.__setattr__(self, "cp_rank", cp_rank)
 
     @property
     def is_tensor_parallel(self) -> bool:
@@ -96,14 +128,31 @@ class FFNContext:
         assert self.tp_size is not None
         return self.tp_size > 1
 
+    @property
+    def is_context_parallel(self) -> bool:
+        """Whether this context owns more than one context-parallel token shard."""
 
-def _all_reduce_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
-    """Synchronously sum a tensor over the explicitly configured TP group."""
+        assert self.cp_size is not None
+        return self.cp_size > 1
 
-    if ctx.is_tensor_parallel:
+
+def _all_reduce_sum(tensor: Tensor, group: Any, world_size: int) -> Tensor:
+    """Synchronously sum a tensor over an explicitly configured process group."""
+
+    if world_size > 1:
         # TODO(WS2): replace NCCL/Gloo with the deterministic collective once it lands.
-        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=group)
     return tensor
+
+
+def _all_reduce_tp_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
+    assert ctx.tp_size is not None
+    return _all_reduce_sum(tensor, ctx.tp_group, ctx.tp_size)
+
+
+def _all_reduce_cp_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
+    assert ctx.cp_size is not None
+    return _all_reduce_sum(tensor, ctx.cp_group, ctx.cp_size)
 
 
 class _CopyToTensorParallelRegion(torch.autograd.Function):
@@ -124,7 +173,7 @@ class _CopyToTensorParallelRegion(torch.autograd.Function):
     def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
         # Do not mutate a gradient owned by a downstream autograd node.
         grad_input = grad_output.contiguous().clone()
-        return _all_reduce_sum(grad_input, ctx.tp_ctx), None
+        return _all_reduce_tp_sum(grad_input, ctx.tp_ctx), None
 
 
 class _ReduceFromTensorParallelRegion(torch.autograd.Function):
@@ -139,7 +188,7 @@ class _ReduceFromTensorParallelRegion(torch.autograd.Function):
     def forward(ctx: Any, input_: Tensor, tp_ctx: FFNContext) -> Tensor:
         # The local Down partial is useful to callers through ``forward_local``;
         # preserve it by reducing a clone rather than modifying it in place.
-        return _all_reduce_sum(input_.contiguous().clone(), tp_ctx)
+        return _all_reduce_tp_sum(input_.contiguous().clone(), tp_ctx)
 
     @staticmethod
     def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
@@ -152,6 +201,31 @@ def _copy_to_tensor_parallel_region(input_: Tensor, ctx: FFNContext) -> Tensor:
 
 def _reduce_from_tensor_parallel_region(input_: Tensor, ctx: FFNContext) -> Tensor:
     return _ReduceFromTensorParallelRegion.apply(input_, ctx)
+
+
+class _CopyWeightToContextParallelRegion(torch.autograd.Function):
+    """Replicated parameter: identity forward, CP SUM of its local ``dW`` backward.
+
+    CP shards token rows, not parameter coordinates.  Each rank therefore
+    computes a local contribution to the same TP-local weight shard.  This
+    function is attached individually to Down, Gate, and Up weights so their
+    three logical gradient tensors each reduce over the explicit same-TP-lane
+    CP group.
+    """
+
+    @staticmethod
+    def forward(ctx: Any, weight: Tensor, cp_ctx: FFNContext) -> Tensor:
+        ctx.cp_ctx = cp_ctx
+        return weight
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
+        grad_weight = grad_output.contiguous().clone()
+        return _all_reduce_cp_sum(grad_weight, ctx.cp_ctx), None
+
+
+def _copy_weight_to_context_parallel_region(weight: Tensor, ctx: FFNContext) -> Tensor:
+    return _CopyWeightToContextParallelRegion.apply(weight, ctx)
 
 
 def shard_qwen3_ffn_weights(
@@ -204,11 +278,12 @@ def shard_qwen3_ffn_weights(
 
 
 class TensorParallelFFN(nn.Module):
-    """Qwen3 SwiGLU FFN with ColumnParallel Gate/Up and RowParallel Down.
+    """Qwen3 SwiGLU FFN with TP feature shards and CP-local token rows.
 
     Parameters use the normal ``torch.nn.Linear`` ``[out, in]`` layout.  This
-    module owns one TP shard only; use :meth:`from_full_weights` in tests or a
-    model loader to materialize rank-local parameter shards from full weights.
+    module owns one TP shard; that shard is replicated across CP ranks. The
+    caller provides CP-local token rows and can use :meth:`from_full_weights`
+    in tests or a model loader to materialize rank-local parameter shards.
 
     ``gemm`` has the deterministic-GEMM-compatible signature
     ``gemm(a[M, K], b[K, N]) -> [M, N]``.  Production BF16 callers must inject
@@ -364,10 +439,13 @@ class TensorParallelFFN(nn.Module):
             )
 
         replicated_input = _copy_to_tensor_parallel_region(input_, self.ctx)
-        gate = self._local_linear(replicated_input, self.gate_weight)
-        up = self._local_linear(replicated_input, self.up_weight)
+        gate_weight = _copy_weight_to_context_parallel_region(self.gate_weight, self.ctx)
+        up_weight = _copy_weight_to_context_parallel_region(self.up_weight, self.ctx)
+        down_weight = _copy_weight_to_context_parallel_region(self.down_weight, self.ctx)
+        gate = self._local_linear(replicated_input, gate_weight)
+        up = self._local_linear(replicated_input, up_weight)
         hidden = self.activation(gate, up)
-        return self._local_linear(hidden, self.down_weight)
+        return self._local_linear(hidden, down_weight)
 
     def forward(self, input_: Tensor) -> Tensor:
         """Compute the replicated hidden output after the one Down TP SUM."""

--- a/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
@@ -93,6 +93,7 @@ class FFNContext:
     def is_tensor_parallel(self) -> bool:
         """Whether this context owns more than one tensor-parallel shard."""
 
+        assert self.tp_size is not None
         return self.tp_size > 1
 
 
@@ -170,6 +171,8 @@ def shard_qwen3_ffn_weights(
     if gate_weight.ndim != 2 or up_weight.ndim != 2 or down_weight.ndim != 2:
         raise ValueError("gate_weight, up_weight, and down_weight must all be rank-2 tensors.")
 
+    assert ctx.tp_size is not None
+    assert ctx.tp_rank is not None
     intermediate_size, hidden_size = gate_weight.shape
     if up_weight.shape != (intermediate_size, hidden_size):
         raise ValueError(
@@ -234,6 +237,7 @@ class TensorParallelFFN(nn.Module):
             raise ValueError("hidden_size and intermediate_size must both be positive.")
 
         self.ctx = FFNContext() if ctx is None else ctx
+        assert self.ctx.tp_size is not None
         if intermediate_size % self.ctx.tp_size != 0:
             raise ValueError(
                 f"intermediate_size={intermediate_size} must divide evenly by "

--- a/tests/test_tensor_parallel_ffn.py
+++ b/tests/test_tensor_parallel_ffn.py
@@ -21,6 +21,7 @@ import torch.nn.functional as F
 
 from rl_engine.kernels.ops.pytorch.activation.swiglu import NativeSwiGLUOp
 from rl_engine.kernels.ops.pytorch.ffn.tensor_parallel import (
+    DeterministicContextParallelCommunication,
     DeterministicTensorParallelCommunication,
     FFNContext,
     TensorParallelFFN,
@@ -48,6 +49,20 @@ class _RecordingTPCommunication:
         assert ctx.tp_rank is not None
         self.calls.append((tuple(tensor.shape), ctx.tp_size, ctx.tp_rank))
         dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+        return tensor
+
+
+class _RecordingCPCommunication:
+    """Gloo stand-in that makes the configured CP path observable."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[int, ...], int, int]] = []
+
+    def all_reduce(self, tensor: torch.Tensor, *, ctx: FFNContext) -> torch.Tensor:
+        assert ctx.cp_size is not None
+        assert ctx.cp_rank is not None
+        self.calls.append((tuple(tensor.shape), ctx.cp_size, ctx.cp_rank))
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=ctx.cp_group)
         return tensor
 
 
@@ -286,7 +301,13 @@ def _make_tp_cp_groups(rank: int) -> tuple[Any, Any]:
     return tp_group, cp_group
 
 
-def _tp_cp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue: Any) -> None:
+def _tp_cp_ffn_worker(
+    rank: int,
+    world_size: int,
+    init_method: str,
+    result_queue: Any,
+    use_recording_communication: bool = False,
+) -> None:
     try:
         torch.set_num_threads(1)
         _configure_gloo_loopback()
@@ -297,7 +318,18 @@ def _tp_cp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue
             world_size=world_size,
         )
         tp_group, cp_group = _make_tp_cp_groups(rank)
-        ctx = FFNContext(tp_group=tp_group, cp_group=cp_group)
+        tp_communication = (
+            _RecordingTPCommunication() if use_recording_communication else None
+        )
+        cp_communication = (
+            _RecordingCPCommunication() if use_recording_communication else None
+        )
+        ctx = FFNContext(
+            tp_group=tp_group,
+            cp_group=cp_group,
+            tp_communication=tp_communication,
+            cp_communication=cp_communication,
+        )
         assert (ctx.tp_size, ctx.cp_size) == (2, 2)
         assert ctx.tp_rank == rank % 2
         assert ctx.cp_rank == rank // 2
@@ -404,6 +436,12 @@ def _tp_cp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue
                 "activation_shape": tuple(local_input.shape),
                 "gate_weight_shape": tuple(ffn.gate_weight.shape),
                 "down_weight_shape": tuple(ffn.down_weight.shape),
+                "configured_tp_collectives": (
+                    [] if tp_communication is None else tp_communication.calls
+                ),
+                "configured_cp_collectives": (
+                    [] if cp_communication is None else cp_communication.calls
+                ),
             }
         )
     except Exception:
@@ -489,7 +527,7 @@ def _tp_cp_batch_invariance_worker(
             dist.destroy_process_group()
 
 
-def _run_tp_cp_workers(worker: Any) -> list[dict[str, Any]]:
+def _run_tp_cp_workers(worker: Any, *worker_args: Any) -> list[dict[str, Any]]:
     world_size = 4
     mp_context = mp.get_context("spawn")
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -497,7 +535,10 @@ def _run_tp_cp_workers(worker: Any) -> list[dict[str, Any]]:
         init_method = init_file.as_uri()
         result_queue = mp_context.Queue()
         workers = [
-            mp_context.Process(target=worker, args=(rank, world_size, init_method, result_queue))
+            mp_context.Process(
+                target=worker,
+                args=(rank, world_size, init_method, result_queue, *worker_args),
+            )
             for rank in range(world_size)
         ]
         for process in workers:
@@ -607,6 +648,28 @@ def test_tp_cp_ffn_matches_full_reference_and_cp_weight_gradient_contract() -> N
 
 
 @requires_gloo
+def test_tp_cp_ffn_routes_collectives_through_configured_communication() -> None:
+    """Configured TP and CP communication own their respective SUM boundaries."""
+
+    results = _run_tp_cp_workers(_tp_cp_ffn_worker, True)
+    for result in results:
+        assert result["output_error"] <= 1e-4
+        assert result["reconstructed_output_error"] <= 1e-4
+        assert result["input_grad_error"] <= 1e-4
+        assert result["configured_tp_collectives"] == [
+            (result["activation_shape"], 2, result["rank"] % 2),
+            (result["activation_shape"], 2, result["rank"] % 2),
+        ]
+        assert sorted(result["configured_cp_collectives"]) == sorted(
+            [
+                (result["down_weight_shape"], 2, result["rank"] // 2),
+                (result["gate_weight_shape"], 2, result["rank"] // 2),
+                (result["gate_weight_shape"], 2, result["rank"] // 2),
+            ]
+        )
+
+
+@requires_gloo
 def test_tp_cp_ffn_is_batch_invariant() -> None:
     """TP+CP local rows and their input gradients are batch/padding invariant."""
 
@@ -643,6 +706,12 @@ def test_qwen_weight_shards_follow_column_and_row_parallel_dimensions() -> None:
 
 def test_deterministic_tp_communication_rejects_cpu_tensors() -> None:
     communication = DeterministicTensorParallelCommunication()
+    with pytest.raises(ValueError, match="requires a CUDA tensor"):
+        communication.all_reduce(torch.zeros(2), ctx=FFNContext())
+
+
+def test_deterministic_cp_communication_rejects_cpu_tensors() -> None:
+    communication = DeterministicContextParallelCommunication()
     with pytest.raises(ValueError, match="requires a CUDA tensor"):
         communication.all_reduce(torch.zeros(2), ctx=FFNContext())
 

--- a/tests/test_tensor_parallel_ffn.py
+++ b/tests/test_tensor_parallel_ffn.py
@@ -236,6 +236,267 @@ def _run_tp_workers(worker: Any) -> list[dict[str, Any]]:
         return results
 
 
+def _make_tp_cp_groups(rank: int) -> tuple[Any, Any]:
+    """Create the fixed PR4 topology in identical order on every rank."""
+
+    tp_group = None
+    for ranks in ((0, 1), (2, 3)):
+        group = dist.new_group(ranks=list(ranks))
+        if rank in ranks:
+            tp_group = group
+
+    cp_group = None
+    for ranks in ((0, 2), (1, 3)):
+        group = dist.new_group(ranks=list(ranks))
+        if rank in ranks:
+            cp_group = group
+
+    assert tp_group is not None
+    assert cp_group is not None
+    return tp_group, cp_group
+
+
+def _tp_cp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue: Any) -> None:
+    try:
+        torch.set_num_threads(1)
+        _configure_gloo_loopback()
+        dist.init_process_group(
+            backend="gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        tp_group, cp_group = _make_tp_cp_groups(rank)
+        ctx = FFNContext(tp_group=tp_group, cp_group=cp_group)
+        assert (ctx.tp_size, ctx.cp_size) == (2, 2)
+        assert ctx.tp_rank == rank % 2
+        assert ctx.cp_rank == rank // 2
+
+        hidden_size, intermediate_size = 8, 24
+        batch_size, sequence_size = 3, 4
+        generator = torch.Generator().manual_seed(20260813)
+        input_full = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+        gate_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        up_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        down_full = torch.randn(hidden_size, intermediate_size, generator=generator)
+        grad_output_full = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+
+        reference_input = input_full.detach().clone().requires_grad_(True)
+        reference_gate = gate_full.detach().clone().requires_grad_(True)
+        reference_up = up_full.detach().clone().requires_grad_(True)
+        reference_down = down_full.detach().clone().requires_grad_(True)
+        reference_output = _full_ffn(reference_input, reference_gate, reference_up, reference_down)
+        reference_output.backward(grad_output_full)
+
+        cp_index = rank // 2
+        local_sequence = sequence_size // 2
+        sequence_start = cp_index * local_sequence
+        sequence_stop = sequence_start + local_sequence
+        local_input = input_full[:, sequence_start:sequence_stop].detach().clone()
+        local_input.requires_grad_(True)
+        local_grad_output = grad_output_full[:, sequence_start:sequence_stop]
+        ffn = TensorParallelFFN.from_full_weights(
+            gate_full, up_full, down_full, ctx=ctx, gemm=_fixed_row_gemm
+        )
+
+        observed_collectives: list[tuple[str, tuple[int, ...]]] = []
+        original_all_reduce = dist.all_reduce
+
+        def traced_all_reduce(tensor: torch.Tensor, *args: Any, **kwargs: Any) -> Any:
+            group = kwargs.get("group")
+            if group is tp_group:
+                group_name = "tp"
+            elif group is cp_group:
+                group_name = "cp"
+            else:
+                raise AssertionError("FFN used an unexpected process group for all_reduce.")
+            observed_collectives.append((group_name, tuple(tensor.shape)))
+            return original_all_reduce(tensor, *args, **kwargs)
+
+        dist.all_reduce = traced_all_reduce  # type: ignore[assignment]
+        try:
+            local_output = ffn(local_input)
+            local_output.backward(local_grad_output)
+        finally:
+            dist.all_reduce = original_all_reduce  # type: ignore[assignment]
+
+        gathered_outputs = [torch.empty_like(local_output) for _ in range(world_size)]
+        dist.all_gather(gathered_outputs, local_output)
+        reconstructed_output = torch.cat((gathered_outputs[0], gathered_outputs[2]), dim=1)
+
+        local_intermediate = intermediate_size // 2
+        intermediate_start = (rank % 2) * local_intermediate
+        intermediate_stop = intermediate_start + local_intermediate
+        result_queue.put(
+            {
+                "ok": True,
+                "rank": rank,
+                "output_error": float(
+                    (local_output - reference_output[:, sequence_start:sequence_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "reconstructed_output_error": float(
+                    (reconstructed_output - reference_output).abs().max().item()
+                ),
+                "input_grad_error": float(
+                    (local_input.grad - reference_input.grad[:, sequence_start:sequence_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "gate_grad_error": float(
+                    (
+                        ffn.gate_weight.grad
+                        - reference_gate.grad[intermediate_start:intermediate_stop]
+                    )
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "up_grad_error": float(
+                    (ffn.up_weight.grad - reference_up.grad[intermediate_start:intermediate_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "down_grad_error": float(
+                    (
+                        ffn.down_weight.grad
+                        - reference_down.grad[:, intermediate_start:intermediate_stop]
+                    )
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "collectives": observed_collectives,
+                "activation_shape": tuple(local_input.shape),
+                "gate_weight_shape": tuple(ffn.gate_weight.shape),
+                "down_weight_shape": tuple(ffn.down_weight.shape),
+            }
+        )
+    except Exception:
+        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        raise
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _tp_cp_batch_invariance_worker(
+    rank: int, world_size: int, init_method: str, result_queue: Any
+) -> None:
+    try:
+        torch.set_num_threads(1)
+        _configure_gloo_loopback()
+        dist.init_process_group(
+            backend="gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        tp_group, cp_group = _make_tp_cp_groups(rank)
+        ctx = FFNContext(tp_group=tp_group, cp_group=cp_group)
+        hidden_size, intermediate_size = 8, 24
+        batch_size, sequence_size = 4, 4
+        generator = torch.Generator().manual_seed(20260814)
+        input_valid = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+        padding = torch.randn(3, sequence_size, hidden_size, generator=generator)
+        gate_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        up_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        down_full = torch.randn(hidden_size, intermediate_size, generator=generator)
+        ffn = TensorParallelFFN.from_full_weights(
+            gate_full, up_full, down_full, ctx=ctx, gemm=_fixed_row_gemm
+        )
+
+        local_sequence = sequence_size // 2
+        sequence_start = (rank // 2) * local_sequence
+        sequence_stop = sequence_start + local_sequence
+        valid_local = input_valid[:, sequence_start:sequence_stop]
+        padded_local = torch.cat((input_valid, padding), dim=0)[:, sequence_start:sequence_stop]
+        full_input = valid_local.detach().clone().requires_grad_(True)
+        single_input = valid_local[:1].detach().clone().requires_grad_(True)
+        padded_input = padded_local.detach().clone().requires_grad_(True)
+
+        full_output = ffn(full_input)
+        full_grad_output = torch.randn(full_output.shape, generator=generator)
+        full_output.backward(full_grad_output)
+
+        single_output = ffn(single_input)
+        single_output.backward(full_grad_output[:1])
+
+        padded_output = ffn(padded_input)
+        padded_grad_output = torch.cat(
+            (
+                full_grad_output,
+                torch.randn(
+                    padded_output.shape[0] - batch_size,
+                    *padded_output.shape[1:],
+                    generator=generator,
+                ),
+            ),
+            dim=0,
+        )
+        padded_output.backward(padded_grad_output)
+        result_queue.put(
+            {
+                "ok": True,
+                "rank": rank,
+                "slice_equal": bool(torch.equal(full_output[:1], single_output)),
+                "padding_equal": bool(torch.equal(full_output, padded_output[:batch_size])),
+                "backward_slice_equal": bool(torch.equal(full_input.grad[:1], single_input.grad)),
+                "backward_padding_equal": bool(
+                    torch.equal(full_input.grad, padded_input.grad[:batch_size])
+                ),
+            }
+        )
+    except Exception:
+        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        raise
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _run_tp_cp_workers(worker: Any) -> list[dict[str, Any]]:
+    world_size = 4
+    mp_context = mp.get_context("spawn")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        init_file = Path(tmp_dir) / "tp_cp_ffn_init"
+        init_method = init_file.as_uri()
+        result_queue = mp_context.Queue()
+        workers = [
+            mp_context.Process(target=worker, args=(rank, world_size, init_method, result_queue))
+            for rank in range(world_size)
+        ]
+        for process in workers:
+            process.start()
+
+        results: list[dict[str, Any]] = []
+        try:
+            for _ in workers:
+                results.append(result_queue.get(timeout=30))
+        except queue.Empty:
+            pytest.fail("timed out waiting for TP+CP Gloo FFN workers")
+        finally:
+            for process in workers:
+                process.join(timeout=30)
+                if process.is_alive():
+                    process.terminate()
+                    process.join()
+
+        failures = [result for result in results if not result["ok"]]
+        if failures:
+            pytest.fail("\n".join(result["traceback"] for result in failures))
+        failed_workers = [process for process in workers if process.exitcode != 0]
+        if failed_workers:
+            pytest.fail(
+                f"TP+CP Gloo workers failed: {[process.exitcode for process in failed_workers]}"
+            )
+        return results
+
+
 @requires_gloo
 def test_tensor_parallel_ffn_matches_full_reference_and_tp_backward_contract() -> None:
     """TP=2 FFN agrees with full FFN and reduces only at the documented sites."""
@@ -268,9 +529,57 @@ def test_tensor_parallel_ffn_is_batch_invariant() -> None:
     assert all(result["slice_equal"] and result["padding_equal"] for result in results)
 
 
+@requires_gloo
+def test_tp_cp_ffn_matches_full_reference_and_cp_weight_gradient_contract() -> None:
+    """TP=2, CP=2 matches the global FFN and reduces all three replica dWs."""
+
+    results = _run_tp_cp_workers(_tp_cp_ffn_worker)
+    for result in results:
+        assert result["output_error"] <= 1e-4
+        assert result["reconstructed_output_error"] <= 1e-4
+        assert result["input_grad_error"] <= 1e-4
+        assert result["gate_grad_error"] <= 1e-4
+        assert result["up_grad_error"] <= 1e-4
+        assert result["down_grad_error"] <= 1e-4
+
+        tp_collectives = [shape for group, shape in result["collectives"] if group == "tp"]
+        cp_collectives = [shape for group, shape in result["collectives"] if group == "cp"]
+        # TP: Down forward and the combined Gate+Up dX backward. CP: one
+        # replica-gradient reduction for each logical Down/Gate/Up parameter.
+        assert tp_collectives == [result["activation_shape"], result["activation_shape"]]
+        assert sorted(cp_collectives) == sorted(
+            [
+                result["down_weight_shape"],
+                result["gate_weight_shape"],
+                result["gate_weight_shape"],
+            ]
+        )
+        assert len(result["collectives"]) == 5
+        assert result["activation_shape"] not in cp_collectives
+
+
+@requires_gloo
+def test_tp_cp_ffn_is_batch_invariant() -> None:
+    """TP+CP local rows and their input gradients are batch/padding invariant."""
+
+    results = _run_tp_cp_workers(_tp_cp_batch_invariance_worker)
+    assert all(
+        result["slice_equal"]
+        and result["padding_equal"]
+        and result["backward_slice_equal"]
+        and result["backward_padding_equal"]
+        for result in results
+    )
+
+
 def test_ffn_context_rejects_unbound_multi_rank_tp() -> None:
     with pytest.raises(ValueError, match="explicit initialized tp_group"):
         FFNContext(tp_size=2)
+
+
+def test_ffn_context_rejects_unbound_multi_rank_cp() -> None:
+    with pytest.raises(ValueError, match="explicit initialized cp_group"):
+        FFNContext(cp_size=2)
 
 
 def test_qwen_weight_shards_follow_column_and_row_parallel_dimensions() -> None:

--- a/tests/test_tensor_parallel_ffn.py
+++ b/tests/test_tensor_parallel_ffn.py
@@ -21,6 +21,7 @@ import torch.nn.functional as F
 
 from rl_engine.kernels.ops.pytorch.activation.swiglu import NativeSwiGLUOp
 from rl_engine.kernels.ops.pytorch.ffn.tensor_parallel import (
+    DeterministicTensorParallelCommunication,
     FFNContext,
     TensorParallelFFN,
     shard_qwen3_ffn_weights,
@@ -34,6 +35,20 @@ def _gloo_available() -> bool:
 requires_gloo = pytest.mark.skipif(
     not _gloo_available(), reason="tensor-parallel FFN CPU test requires torch.distributed Gloo."
 )
+
+
+class _RecordingTPCommunication:
+    """Gloo stand-in that makes the configured TP path observable."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[int, ...], int, int]] = []
+
+    def all_reduce(self, tensor: torch.Tensor, *, ctx: FFNContext) -> torch.Tensor:
+        assert ctx.tp_size is not None
+        assert ctx.tp_rank is not None
+        self.calls.append((tuple(tensor.shape), ctx.tp_size, ctx.tp_rank))
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+        return tensor
 
 
 def _configure_gloo_loopback() -> None:
@@ -69,7 +84,13 @@ def _fixed_row_gemm(input_2d: torch.Tensor, weight_2d: torch.Tensor) -> torch.Te
     return torch.stack([torch.matmul(row.unsqueeze(0), weight_2d).squeeze(0) for row in input_2d])
 
 
-def _tp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue: Any) -> None:
+def _tp_ffn_worker(
+    rank: int,
+    world_size: int,
+    init_method: str,
+    result_queue: Any,
+    use_recording_tp_communication: bool = False,
+) -> None:
     try:
         torch.set_num_threads(1)
         _configure_gloo_loopback()
@@ -79,7 +100,10 @@ def _tp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue: A
             rank=rank,
             world_size=world_size,
         )
-        ctx = FFNContext(tp_group=dist.group.WORLD)
+        tp_communication = (
+            _RecordingTPCommunication() if use_recording_tp_communication else None
+        )
+        ctx = FFNContext(tp_group=dist.group.WORLD, tp_communication=tp_communication)
         assert ctx.tp_size == world_size
         assert ctx.tp_rank == rank
 
@@ -143,6 +167,9 @@ def _tp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue: A
                 ),
                 "collectives": observed_collectives,
                 "expected_collective_shape": expected_collective_shape,
+                "configured_collectives": (
+                    [] if tp_communication is None else tp_communication.calls
+                ),
             }
         )
     except Exception:
@@ -198,7 +225,7 @@ def _tp_batch_invariance_worker(
             dist.destroy_process_group()
 
 
-def _run_tp_workers(worker: Any) -> list[dict[str, Any]]:
+def _run_tp_workers(worker: Any, *worker_args: Any) -> list[dict[str, Any]]:
     world_size = 2
     mp_context = mp.get_context("spawn")
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -206,7 +233,10 @@ def _run_tp_workers(worker: Any) -> list[dict[str, Any]]:
         init_method = init_file.as_uri()
         result_queue = mp_context.Queue()
         workers = [
-            mp_context.Process(target=worker, args=(rank, world_size, init_method, result_queue))
+            mp_context.Process(
+                target=worker,
+                args=(rank, world_size, init_method, result_queue, *worker_args),
+            )
             for rank in range(world_size)
         ]
         for process in workers:
@@ -522,6 +552,24 @@ def test_tensor_parallel_ffn_matches_full_reference_and_tp_backward_contract() -
 
 
 @requires_gloo
+def test_tensor_parallel_ffn_routes_collectives_through_configured_communication() -> None:
+    """Configured TP communication owns exactly the forward and backward SUMs."""
+
+    results = _run_tp_workers(_tp_ffn_worker, True)
+    for result in results:
+        assert result["output_error"] <= 1e-4
+        assert result["input_grad_error"] <= 1e-4
+        assert result["collectives"] == [
+            result["expected_collective_shape"],
+            result["expected_collective_shape"],
+        ]
+        assert result["configured_collectives"] == [
+            (result["expected_collective_shape"], 2, result["rank"]),
+            (result["expected_collective_shape"], 2, result["rank"]),
+        ]
+
+
+@requires_gloo
 def test_tensor_parallel_ffn_is_batch_invariant() -> None:
     """Valid rows are bitwise unchanged by TP FFN slicing or batch padding."""
 
@@ -591,6 +639,12 @@ def test_qwen_weight_shards_follow_column_and_row_parallel_dimensions() -> None:
     assert gate_shard.shape == (24, 8)
     assert up_shard.shape == (24, 8)
     assert down_shard.shape == (8, 24)
+
+
+def test_deterministic_tp_communication_rejects_cpu_tensors() -> None:
+    communication = DeterministicTensorParallelCommunication()
+    with pytest.raises(ValueError, match="requires a CUDA tensor"):
+        communication.all_reduce(torch.zeros(2), ctx=FFNContext())
 
 
 def test_ffn_refuses_non_deterministic_default_gemm() -> None:


### PR DESCRIPTION
resolves #239 (PR4 Forward track)

## Overview
This PR builds upon the Tensor Parallel (TP) foundation established in PR3, extending the Qwen3-8B FFN orchestration to support **Context Parallelism (CP)**. It implements the necessary 2D mesh topology and specific cross-rank communication patterns for weight gradients under CP.

## Key Changes
1. **FFNContext & Setup**: 
   - Introduced CP configuration support within the ctx.
   - Updated the test launcher to construct a 2D process mesh, establishing TP groups [0,1], [2,3] and CP groups [0,2], [1,3].

2. **Communication Placement & Logic (TP + CP)**:
   - **Forward Pass**: Retained TP all_reduce semantics. CP shards token rows and does not require forward activation collectives.
   - **Backward Pass (CP Weight Reductions)**: Because CP rank lanes maintain replicated local parameter shards across sequence chunks, the backward pass now correctly triggers a CP all_reduce(SUM) on the weight gradients (dW) for down_weight, gate_weight, and up_weight.

3. **Constraints & Guardrails**:
   - Maintained strict isolation from Sequence Parallelism (no SP AG/RS introduced).
   - Continued enforcement of the deterministic GEMM contract to prevent floating-point drift.

## Verification & Test Results
1. **Local Validation**
   - tests/test_tensor_parallel_ffn.py: 8 passed (Successfully verified batch/padding invariance across the 2D TP+CP topology).
   - mypy tensor_parallel.py: Passed
   - ruff linting: Passed

2. **GPU Hardware Validation (Pending)**
   > [!NOTE]
   > *Reserved section for multi-GPU hardware test metrics (Fast Path vs. Consistent Path) and execution logs:*
   > ```text
   > [To be filled after running on target GPU cluster]
   > - Test Command: 
   > - Output / Logs: 
   > ```