### PR TITLE
[WS2][GEMM][Forward]: implement PR4 TP+CP+SP with FFN and sequence collectives

### DIFF
--- a/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
-"""Tensor-parallel Qwen3-style SwiGLU FFN orchestration.
+"""Tensor- and context-parallel Qwen3-style SwiGLU FFN orchestration.
 
 The module implements the non-sequence-parallel TP ownership contract used by
 the Qwen3 dense MLP:
@@ -17,8 +17,10 @@ backward TP SUM occurs after the local Gate and Up input-gradient
 contributions have been accumulated, exactly as required by the TP FFN
 derivation.  There is no TP reduction for Down's feature-sharded ``dHidden``.
 
-CP/SP configuration and CP weight-gradient reductions intentionally do not
-belong in this PR3 module.
+CP shards token rows. It has no forward activation collective: each CP rank
+keeps its own rows. In backward, each TP-local parameter shard is replicated
+across its CP lane, so Gate, Up, and Down each perform one CP SUM of ``dW``.
+SP activation AllGather/ReduceScatter is intentionally out of scope.
 """
 
 from __future__ import annotations
@@ -46,48 +48,78 @@ def _missing_deterministic_gemm(input_: Tensor, weight: Tensor) -> Tensor:
     )
 
 
+def _resolve_parallel_coordinates(
+    name: str,
+    group: Any,
+    size: Optional[int],
+    rank: Optional[int],
+) -> tuple[int, int]:
+    """Validate one explicit parallel group and return concrete coordinates."""
+
+    if group is None:
+        resolved_size = 1 if size is None else int(size)
+        resolved_rank = 0 if rank is None else int(rank)
+        if resolved_size != 1 or resolved_rank != 0:
+            raise ValueError(
+                f"FFNContext({name}_group=None) only supports {name}_size=1 and "
+                f"{name}_rank=0. Supply an explicit initialized {name}_group for "
+                f"{name.upper()} > 1."
+            )
+    else:
+        if not dist.is_available() or not dist.is_initialized():
+            raise RuntimeError(
+                f"FFNContext({name}_group=...) requires torch.distributed to be initialized."
+            )
+        group_size = dist.get_world_size(group=group)
+        group_rank = dist.get_rank(group=group)
+        resolved_size = group_size if size is None else int(size)
+        resolved_rank = group_rank if rank is None else int(rank)
+        if resolved_size != group_size:
+            raise ValueError(
+                f"ctx.{name}_size={resolved_size} does not match {name}_group "
+                f"world size={group_size}."
+            )
+        if resolved_rank != group_rank:
+            raise ValueError(
+                f"ctx.{name}_rank={resolved_rank} does not match {name}_group "
+                f"rank={group_rank}."
+            )
+
+    if resolved_size < 1 or not 0 <= resolved_rank < resolved_size:
+        raise ValueError(
+            f"invalid {name.upper()} coordinates: {name}_size={resolved_size}, "
+            f"{name}_rank={resolved_rank}."
+        )
+    return resolved_size, resolved_rank
+
+
 @dataclass(frozen=True)
 class FFNContext:
-    """Explicit tensor-parallel configuration owned by an FFN caller.
+    """Explicit TP/CP configuration owned by an FFN caller.
 
-    ``tp_group`` is never created or inferred by this module.  A multi-rank
-    configuration must supply an initialized explicit process group; this is
-    important because later PRs add distinct CP and SP groups.
+    Neither group is created or inferred by this module.  A multi-rank
+    configuration must supply initialized explicit groups, which preserves the
+    fixed TP/CP topology and leaves SP group ownership to the next PR.
     """
 
     tp_group: Any = None
     tp_size: Optional[int] = None
     tp_rank: Optional[int] = None
+    cp_group: Any = None
+    cp_size: Optional[int] = None
+    cp_rank: Optional[int] = None
 
     def __post_init__(self) -> None:
-        if self.tp_group is None:
-            size = 1 if self.tp_size is None else int(self.tp_size)
-            rank = 0 if self.tp_rank is None else int(self.tp_rank)
-            if size != 1 or rank != 0:
-                raise ValueError(
-                    "FFNContext(tp_group=None) only supports tp_size=1 and tp_rank=0. "
-                    "Supply an explicit initialized tp_group for TP > 1."
-                )
-        else:
-            if not dist.is_available() or not dist.is_initialized():
-                raise RuntimeError(
-                    "FFNContext(tp_group=...) requires torch.distributed to be initialized."
-                )
-            group_size = dist.get_world_size(group=self.tp_group)
-            group_rank = dist.get_rank(group=self.tp_group)
-            size = group_size if self.tp_size is None else int(self.tp_size)
-            rank = group_rank if self.tp_rank is None else int(self.tp_rank)
-            if size != group_size:
-                raise ValueError(
-                    f"ctx.tp_size={size} does not match tp_group world size={group_size}."
-                )
-            if rank != group_rank:
-                raise ValueError(f"ctx.tp_rank={rank} does not match tp_group rank={group_rank}.")
-
-        if size < 1 or not 0 <= rank < size:
-            raise ValueError(f"invalid TP coordinates: tp_size={size}, tp_rank={rank}.")
-        object.__setattr__(self, "tp_size", size)
-        object.__setattr__(self, "tp_rank", rank)
+        tp_size, tp_rank = _resolve_parallel_coordinates(
+            "tp", self.tp_group, self.tp_size, self.tp_rank
+        )
+        cp_size, cp_rank = _resolve_parallel_coordinates(
+            "cp", self.cp_group, self.cp_size, self.cp_rank
+        )
+        object.__setattr__(self, "tp_size", tp_size)
+        object.__setattr__(self, "tp_rank", tp_rank)
+        object.__setattr__(self, "cp_size", cp_size)
+        object.__setattr__(self, "cp_rank", cp_rank)
 
     @property
     def is_tensor_parallel(self) -> bool:
@@ -96,14 +128,31 @@ class FFNContext:
         assert self.tp_size is not None
         return self.tp_size > 1
 
+    @property
+    def is_context_parallel(self) -> bool:
+        """Whether this context owns more than one context-parallel token shard."""
 
-def _all_reduce_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
-    """Synchronously sum a tensor over the explicitly configured TP group."""
+        assert self.cp_size is not None
+        return self.cp_size > 1
 
-    if ctx.is_tensor_parallel:
+
+def _all_reduce_sum(tensor: Tensor, group: Any, world_size: int) -> Tensor:
+    """Synchronously sum a tensor over an explicitly configured process group."""
+
+    if world_size > 1:
         # TODO(WS2): replace NCCL/Gloo with the deterministic collective once it lands.
-        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=group)
     return tensor
+
+
+def _all_reduce_tp_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
+    assert ctx.tp_size is not None
+    return _all_reduce_sum(tensor, ctx.tp_group, ctx.tp_size)
+
+
+def _all_reduce_cp_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
+    assert ctx.cp_size is not None
+    return _all_reduce_sum(tensor, ctx.cp_group, ctx.cp_size)
 
 
 class _CopyToTensorParallelRegion(torch.autograd.Function):
@@ -124,7 +173,7 @@ class _CopyToTensorParallelRegion(torch.autograd.Function):
     def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
         # Do not mutate a gradient owned by a downstream autograd node.
         grad_input = grad_output.contiguous().clone()
-        return _all_reduce_sum(grad_input, ctx.tp_ctx), None
+        return _all_reduce_tp_sum(grad_input, ctx.tp_ctx), None
 
 
 class _ReduceFromTensorParallelRegion(torch.autograd.Function):
@@ -139,7 +188,7 @@ class _ReduceFromTensorParallelRegion(torch.autograd.Function):
     def forward(ctx: Any, input_: Tensor, tp_ctx: FFNContext) -> Tensor:
         # The local Down partial is useful to callers through ``forward_local``;
         # preserve it by reducing a clone rather than modifying it in place.
-        return _all_reduce_sum(input_.contiguous().clone(), tp_ctx)
+        return _all_reduce_tp_sum(input_.contiguous().clone(), tp_ctx)
 
     @staticmethod
     def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
@@ -152,6 +201,31 @@ def _copy_to_tensor_parallel_region(input_: Tensor, ctx: FFNContext) -> Tensor:
 
 def _reduce_from_tensor_parallel_region(input_: Tensor, ctx: FFNContext) -> Tensor:
     return _ReduceFromTensorParallelRegion.apply(input_, ctx)
+
+
+class _CopyWeightToContextParallelRegion(torch.autograd.Function):
+    """Replicated parameter: identity forward, CP SUM of its local ``dW`` backward.
+
+    CP shards token rows, not parameter coordinates.  Each rank therefore
+    computes a local contribution to the same TP-local weight shard.  This
+    function is attached individually to Down, Gate, and Up weights so their
+    three logical gradient tensors each reduce over the explicit same-TP-lane
+    CP group.
+    """
+
+    @staticmethod
+    def forward(ctx: Any, weight: Tensor, cp_ctx: FFNContext) -> Tensor:
+        ctx.cp_ctx = cp_ctx
+        return weight
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
+        grad_weight = grad_output.contiguous().clone()
+        return _all_reduce_cp_sum(grad_weight, ctx.cp_ctx), None
+
+
+def _copy_weight_to_context_parallel_region(weight: Tensor, ctx: FFNContext) -> Tensor:
+    return _CopyWeightToContextParallelRegion.apply(weight, ctx)
 
 
 def shard_qwen3_ffn_weights(
@@ -204,11 +278,12 @@ def shard_qwen3_ffn_weights(
 
 
 class TensorParallelFFN(nn.Module):
-    """Qwen3 SwiGLU FFN with ColumnParallel Gate/Up and RowParallel Down.
+    """Qwen3 SwiGLU FFN with TP feature shards and CP-local token rows.
 
     Parameters use the normal ``torch.nn.Linear`` ``[out, in]`` layout.  This
-    module owns one TP shard only; use :meth:`from_full_weights` in tests or a
-    model loader to materialize rank-local parameter shards from full weights.
+    module owns one TP shard; that shard is replicated across CP ranks. The
+    caller provides CP-local token rows and can use :meth:`from_full_weights`
+    in tests or a model loader to materialize rank-local parameter shards.
 
     ``gemm`` has the deterministic-GEMM-compatible signature
     ``gemm(a[M, K], b[K, N]) -> [M, N]``.  Production BF16 callers must inject
@@ -364,10 +439,13 @@ class TensorParallelFFN(nn.Module):
             )
 
         replicated_input = _copy_to_tensor_parallel_region(input_, self.ctx)
-        gate = self._local_linear(replicated_input, self.gate_weight)
-        up = self._local_linear(replicated_input, self.up_weight)
+        gate_weight = _copy_weight_to_context_parallel_region(self.gate_weight, self.ctx)
+        up_weight = _copy_weight_to_context_parallel_region(self.up_weight, self.ctx)
+        down_weight = _copy_weight_to_context_parallel_region(self.down_weight, self.ctx)
+        gate = self._local_linear(replicated_input, gate_weight)
+        up = self._local_linear(replicated_input, up_weight)
         hidden = self.activation(gate, up)
-        return self._local_linear(hidden, self.down_weight)
+        return self._local_linear(hidden, down_weight)
 
     def forward(self, input_: Tensor) -> Tensor:
         """Compute the replicated hidden output after the one Down TP SUM."""

--- a/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
@@ -93,6 +93,7 @@ class FFNContext:
     def is_tensor_parallel(self) -> bool:
         """Whether this context owns more than one tensor-parallel shard."""
 
+        assert self.tp_size is not None
         return self.tp_size > 1
 
 
@@ -170,6 +171,8 @@ def shard_qwen3_ffn_weights(
     if gate_weight.ndim != 2 or up_weight.ndim != 2 or down_weight.ndim != 2:
         raise ValueError("gate_weight, up_weight, and down_weight must all be rank-2 tensors.")
 
+    assert ctx.tp_size is not None
+    assert ctx.tp_rank is not None
     intermediate_size, hidden_size = gate_weight.shape
     if up_weight.shape != (intermediate_size, hidden_size):
         raise ValueError(
@@ -234,6 +237,7 @@ class TensorParallelFFN(nn.Module):
             raise ValueError("hidden_size and intermediate_size must both be positive.")
 
         self.ctx = FFNContext() if ctx is None else ctx
+        assert self.ctx.tp_size is not None
         if intermediate_size % self.ctx.tp_size != 0:
             raise ValueError(
                 f"intermediate_size={intermediate_size} must divide evenly by "

--- a/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/tensor_parallel.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
-"""Tensor- and context-parallel Qwen3-style SwiGLU FFN orchestration.
+"""Tensor-, context-, and sequence-parallel Qwen3 SwiGLU FFN orchestration.
 
 The module implements the non-sequence-parallel TP ownership contract used by
 the Qwen3 dense MLP:
@@ -10,17 +10,23 @@ the Qwen3 dense MLP:
 * ``down`` is RowParallel (its input/intermediate dimension is sharded); its
   same-coordinate hidden outputs are summed once over the explicit TP group.
 
-The autograd collective mappings are deliberately asymmetric.  A RowParallel
-forward reduction has an identity backward, while the replicated FFN input is
-copied in the forward and reduced in the backward.  Consequently the sole
-backward TP SUM occurs after the local Gate and Up input-gradient
-contributions have been accumulated, exactly as required by the TP FFN
-derivation.  There is no TP reduction for Down's feature-sharded ``dHidden``.
+Without SP, the autograd collective mappings are deliberately asymmetric: a
+RowParallel forward reduction has an identity backward, while the replicated
+FFN input is copied in the forward and reduced in the backward. Consequently
+the sole backward TP SUM occurs after the local Gate and Up input-gradient
+contributions have been accumulated. There is no TP reduction for Down's
+feature-sharded ``dHidden``.
 
 CP shards token rows. It has no forward activation collective: each CP rank
 keeps its own rows. In backward, each TP-local parameter shard is replicated
 across its CP lane, so Gate, Up, and Down each perform one CP SUM of ``dW``.
-SP activation AllGather/ReduceScatter is intentionally out of scope.
+
+SP reuses the two ranks in a TP row but changes activation ownership. The
+input/output residual stream is sequence-sharded; the local FFN body runs on
+the SP AllGather result. Down's SP ReduceScatter(SUM) simultaneously restores
+the sequence shard and sums the RowParallel output partials. Its autograd
+mapping is AllGather, while the input AllGather's mapping is
+ReduceScatter(SUM), so the gradient returned to RMSNorm remains SP-sharded.
 """
 
 from __future__ import annotations
@@ -95,11 +101,11 @@ def _resolve_parallel_coordinates(
 
 @dataclass(frozen=True)
 class FFNContext:
-    """Explicit TP/CP configuration owned by an FFN caller.
+    """Explicit TP/CP/SP configuration owned by an FFN caller.
 
     Neither group is created or inferred by this module.  A multi-rank
     configuration must supply initialized explicit groups, which preserves the
-    fixed TP/CP topology and leaves SP group ownership to the next PR.
+    fixed TP/CP/SP topology.
     """
 
     tp_group: Any = None
@@ -108,6 +114,9 @@ class FFNContext:
     cp_group: Any = None
     cp_size: Optional[int] = None
     cp_rank: Optional[int] = None
+    sp_group: Any = None
+    sp_size: Optional[int] = None
+    sp_rank: Optional[int] = None
 
     def __post_init__(self) -> None:
         tp_size, tp_rank = _resolve_parallel_coordinates(
@@ -116,10 +125,20 @@ class FFNContext:
         cp_size, cp_rank = _resolve_parallel_coordinates(
             "cp", self.cp_group, self.cp_size, self.cp_rank
         )
+        sp_size, sp_rank = _resolve_parallel_coordinates(
+            "sp", self.sp_group, self.sp_size, self.sp_rank
+        )
+        if sp_size > 1 and (sp_size != tp_size or sp_rank != tp_rank):
+            raise ValueError(
+                "SP must align with the TP rank dimension: sp_size/sp_rank must match "
+                "tp_size/tp_rank when sequence parallelism is enabled."
+            )
         object.__setattr__(self, "tp_size", tp_size)
         object.__setattr__(self, "tp_rank", tp_rank)
         object.__setattr__(self, "cp_size", cp_size)
         object.__setattr__(self, "cp_rank", cp_rank)
+        object.__setattr__(self, "sp_size", sp_size)
+        object.__setattr__(self, "sp_rank", sp_rank)
 
     @property
     def is_tensor_parallel(self) -> bool:
@@ -134,6 +153,13 @@ class FFNContext:
 
         assert self.cp_size is not None
         return self.cp_size > 1
+
+    @property
+    def is_sequence_parallel(self) -> bool:
+        """Whether residual-stream activations are split across the SP group."""
+
+        assert self.sp_size is not None
+        return self.sp_size > 1
 
 
 def _all_reduce_sum(tensor: Tensor, group: Any, world_size: int) -> Tensor:
@@ -155,13 +181,72 @@ def _all_reduce_cp_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
     return _all_reduce_sum(tensor, ctx.cp_group, ctx.cp_size)
 
 
+def _all_reduce_sp_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
+    assert ctx.sp_size is not None
+    return _all_reduce_sum(tensor, ctx.sp_group, ctx.sp_size)
+
+
+def _all_gather_sequence(tensor: Tensor, ctx: FFNContext) -> Tensor:
+    """Gather equal sequence shards along the penultimate tensor dimension."""
+
+    if not ctx.is_sequence_parallel:
+        return tensor
+    if tensor.ndim < 2:
+        raise ValueError(
+            f"SP AllGather requires [..., sequence, hidden], got {tuple(tensor.shape)}."
+        )
+
+    assert ctx.sp_size is not None
+    gathered = [torch.empty_like(tensor) for _ in range(ctx.sp_size)]
+    dist.all_gather(gathered, tensor.contiguous(), group=ctx.sp_group)
+    return torch.cat(gathered, dim=-2)
+
+
+def _reduce_scatter_sequence_sum(tensor: Tensor, ctx: FFNContext) -> Tensor:
+    """SUM-reduce equal full-sequence tensors then return this rank's sequence shard.
+
+    NCCL uses its native ``reduce_scatter`` collective. Gloo deployments that
+    do not implement that primitive use an equivalent all-reduce plus local
+    sequence slice solely as a portable test fallback.
+    """
+
+    if not ctx.is_sequence_parallel:
+        return tensor
+    if tensor.ndim < 2:
+        raise ValueError(
+            f"SP ReduceScatter requires [..., sequence, hidden], got {tuple(tensor.shape)}."
+        )
+
+    assert ctx.sp_size is not None
+    assert ctx.sp_rank is not None
+    sequence_size = tensor.shape[-2]
+    if sequence_size % ctx.sp_size != 0:
+        raise ValueError(
+            f"sequence size={sequence_size} must divide evenly by sp_size={ctx.sp_size}."
+        )
+
+    chunks = [chunk.contiguous() for chunk in tensor.chunk(ctx.sp_size, dim=-2)]
+    output = torch.empty_like(chunks[0])
+    try:
+        dist.reduce_scatter(output, chunks, op=dist.ReduceOp.SUM, group=ctx.sp_group)
+        return output
+    except RuntimeError as error:
+        # ProcessGroupGloo lacks reduce_scatter in some supported PyTorch builds.
+        if "does not support reduce_scatter" not in str(error).lower():
+            raise
+        reduced = _all_reduce_sp_sum(tensor.contiguous(), ctx)
+        local_sequence = sequence_size // ctx.sp_size
+        return reduced.narrow(-2, ctx.sp_rank * local_sequence, local_sequence).contiguous()
+
+
 class _CopyToTensorParallelRegion(torch.autograd.Function):
-    """Replicated input: identity forward, TP SUM backward.
+    """Replicated input: identity forward, TP SUM backward when SP is disabled.
 
     The Gate and Up ColumnParallel projections each produce a local
     same-coordinate ``dX`` contribution.  Autograd accumulates those local
     contributions before this function's backward executes, so this is one
-    logical TP all-reduce of their combined ``[... , H]`` gradient.
+    logical TP all-reduce of their combined ``[... , H]`` gradient. With SP,
+    the preceding AllGather's backward owns that SUM via ReduceScatter instead.
     """
 
     @staticmethod
@@ -173,6 +258,10 @@ class _CopyToTensorParallelRegion(torch.autograd.Function):
     def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
         # Do not mutate a gradient owned by a downstream autograd node.
         grad_input = grad_output.contiguous().clone()
+        if ctx.tp_ctx.is_sequence_parallel:
+            # The preceding SP AllGather owns the single necessary dX SUM and
+            # sequence split in its backward ReduceScatter.
+            return grad_input, None
         return _all_reduce_tp_sum(grad_input, ctx.tp_ctx), None
 
 
@@ -201,6 +290,40 @@ def _copy_to_tensor_parallel_region(input_: Tensor, ctx: FFNContext) -> Tensor:
 
 def _reduce_from_tensor_parallel_region(input_: Tensor, ctx: FFNContext) -> Tensor:
     return _ReduceFromTensorParallelRegion.apply(input_, ctx)
+
+
+class _GatherFromSequenceParallelRegion(torch.autograd.Function):
+    """SP AllGather forward; SUM ReduceScatter backward."""
+
+    @staticmethod
+    def forward(ctx: Any, input_: Tensor, sp_ctx: FFNContext) -> Tensor:
+        ctx.sp_ctx = sp_ctx
+        return _all_gather_sequence(input_, sp_ctx)
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
+        return _reduce_scatter_sequence_sum(grad_output, ctx.sp_ctx), None
+
+
+class _ReduceScatterToSequenceParallelRegion(torch.autograd.Function):
+    """SP SUM ReduceScatter forward; AllGather backward."""
+
+    @staticmethod
+    def forward(ctx: Any, input_: Tensor, sp_ctx: FFNContext) -> Tensor:
+        ctx.sp_ctx = sp_ctx
+        return _reduce_scatter_sequence_sum(input_, sp_ctx)
+
+    @staticmethod
+    def backward(ctx: Any, grad_output: Tensor) -> tuple[Tensor, None]:
+        return _all_gather_sequence(grad_output, ctx.sp_ctx), None
+
+
+def _gather_from_sequence_parallel_region(input_: Tensor, ctx: FFNContext) -> Tensor:
+    return _GatherFromSequenceParallelRegion.apply(input_, ctx)
+
+
+def _reduce_scatter_to_sequence_parallel_region(input_: Tensor, ctx: FFNContext) -> Tensor:
+    return _ReduceScatterToSequenceParallelRegion.apply(input_, ctx)
 
 
 class _CopyWeightToContextParallelRegion(torch.autograd.Function):
@@ -417,11 +540,12 @@ class TensorParallelFFN(nn.Module):
         return output_2d.reshape(*input_.shape[:-1], weight.shape[0])
 
     def forward_local(self, input_: Tensor) -> Tensor:
-        """Return the local pre-TP-reduction Down output partial.
+        """Return the local pre-TP/SP-reduction Down output partial.
 
         This method is primarily a validation boundary: its result has shape
         ``[..., hidden_size]`` but represents only this rank's RowParallel
-        contribution.  ``forward`` performs the required TP SUM over it.
+        contribution. ``forward`` performs the required TP SUM or SP
+        ReduceScatter(SUM) ownership conversion over it.
         """
 
         if input_.ndim < 2:
@@ -438,7 +562,8 @@ class TensorParallelFFN(nn.Module):
                 f"{self.gate_weight.dtype}."
             )
 
-        replicated_input = _copy_to_tensor_parallel_region(input_, self.ctx)
+        gathered_input = _gather_from_sequence_parallel_region(input_, self.ctx)
+        replicated_input = _copy_to_tensor_parallel_region(gathered_input, self.ctx)
         gate_weight = _copy_weight_to_context_parallel_region(self.gate_weight, self.ctx)
         up_weight = _copy_weight_to_context_parallel_region(self.up_weight, self.ctx)
         down_weight = _copy_weight_to_context_parallel_region(self.down_weight, self.ctx)
@@ -448,7 +573,11 @@ class TensorParallelFFN(nn.Module):
         return self._local_linear(hidden, down_weight)
 
     def forward(self, input_: Tensor) -> Tensor:
-        """Compute the replicated hidden output after the one Down TP SUM."""
+        """Compute the residual-stream output in the configured TP/SP ownership."""
 
         local_output_partial = self.forward_local(input_)
+        if self.ctx.is_sequence_parallel:
+            # SP RS(SUM) is the TP RowParallel output reduction and restores
+            # the residual stream's local sequence shard in one collective.
+            return _reduce_scatter_to_sequence_parallel_region(local_output_partial, self.ctx)
         return _reduce_from_tensor_parallel_region(local_output_partial, self.ctx)

--- a/tests/test_tensor_parallel_ffn.py
+++ b/tests/test_tensor_parallel_ffn.py
@@ -236,6 +236,267 @@ def _run_tp_workers(worker: Any) -> list[dict[str, Any]]:
         return results
 
 
+def _make_tp_cp_groups(rank: int) -> tuple[Any, Any]:
+    """Create the fixed PR4 topology in identical order on every rank."""
+
+    tp_group = None
+    for ranks in ((0, 1), (2, 3)):
+        group = dist.new_group(ranks=list(ranks))
+        if rank in ranks:
+            tp_group = group
+
+    cp_group = None
+    for ranks in ((0, 2), (1, 3)):
+        group = dist.new_group(ranks=list(ranks))
+        if rank in ranks:
+            cp_group = group
+
+    assert tp_group is not None
+    assert cp_group is not None
+    return tp_group, cp_group
+
+
+def _tp_cp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue: Any) -> None:
+    try:
+        torch.set_num_threads(1)
+        _configure_gloo_loopback()
+        dist.init_process_group(
+            backend="gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        tp_group, cp_group = _make_tp_cp_groups(rank)
+        ctx = FFNContext(tp_group=tp_group, cp_group=cp_group)
+        assert (ctx.tp_size, ctx.cp_size) == (2, 2)
+        assert ctx.tp_rank == rank % 2
+        assert ctx.cp_rank == rank // 2
+
+        hidden_size, intermediate_size = 8, 24
+        batch_size, sequence_size = 3, 4
+        generator = torch.Generator().manual_seed(20260813)
+        input_full = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+        gate_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        up_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        down_full = torch.randn(hidden_size, intermediate_size, generator=generator)
+        grad_output_full = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+
+        reference_input = input_full.detach().clone().requires_grad_(True)
+        reference_gate = gate_full.detach().clone().requires_grad_(True)
+        reference_up = up_full.detach().clone().requires_grad_(True)
+        reference_down = down_full.detach().clone().requires_grad_(True)
+        reference_output = _full_ffn(reference_input, reference_gate, reference_up, reference_down)
+        reference_output.backward(grad_output_full)
+
+        cp_index = rank // 2
+        local_sequence = sequence_size // 2
+        sequence_start = cp_index * local_sequence
+        sequence_stop = sequence_start + local_sequence
+        local_input = input_full[:, sequence_start:sequence_stop].detach().clone()
+        local_input.requires_grad_(True)
+        local_grad_output = grad_output_full[:, sequence_start:sequence_stop]
+        ffn = TensorParallelFFN.from_full_weights(
+            gate_full, up_full, down_full, ctx=ctx, gemm=_fixed_row_gemm
+        )
+
+        observed_collectives: list[tuple[str, tuple[int, ...]]] = []
+        original_all_reduce = dist.all_reduce
+
+        def traced_all_reduce(tensor: torch.Tensor, *args: Any, **kwargs: Any) -> Any:
+            group = kwargs.get("group")
+            if group is tp_group:
+                group_name = "tp"
+            elif group is cp_group:
+                group_name = "cp"
+            else:
+                raise AssertionError("FFN used an unexpected process group for all_reduce.")
+            observed_collectives.append((group_name, tuple(tensor.shape)))
+            return original_all_reduce(tensor, *args, **kwargs)
+
+        dist.all_reduce = traced_all_reduce  # type: ignore[assignment]
+        try:
+            local_output = ffn(local_input)
+            local_output.backward(local_grad_output)
+        finally:
+            dist.all_reduce = original_all_reduce  # type: ignore[assignment]
+
+        gathered_outputs = [torch.empty_like(local_output) for _ in range(world_size)]
+        dist.all_gather(gathered_outputs, local_output)
+        reconstructed_output = torch.cat((gathered_outputs[0], gathered_outputs[2]), dim=1)
+
+        local_intermediate = intermediate_size // 2
+        intermediate_start = (rank % 2) * local_intermediate
+        intermediate_stop = intermediate_start + local_intermediate
+        result_queue.put(
+            {
+                "ok": True,
+                "rank": rank,
+                "output_error": float(
+                    (local_output - reference_output[:, sequence_start:sequence_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "reconstructed_output_error": float(
+                    (reconstructed_output - reference_output).abs().max().item()
+                ),
+                "input_grad_error": float(
+                    (local_input.grad - reference_input.grad[:, sequence_start:sequence_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "gate_grad_error": float(
+                    (
+                        ffn.gate_weight.grad
+                        - reference_gate.grad[intermediate_start:intermediate_stop]
+                    )
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "up_grad_error": float(
+                    (ffn.up_weight.grad - reference_up.grad[intermediate_start:intermediate_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "down_grad_error": float(
+                    (
+                        ffn.down_weight.grad
+                        - reference_down.grad[:, intermediate_start:intermediate_stop]
+                    )
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "collectives": observed_collectives,
+                "activation_shape": tuple(local_input.shape),
+                "gate_weight_shape": tuple(ffn.gate_weight.shape),
+                "down_weight_shape": tuple(ffn.down_weight.shape),
+            }
+        )
+    except Exception:
+        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        raise
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _tp_cp_batch_invariance_worker(
+    rank: int, world_size: int, init_method: str, result_queue: Any
+) -> None:
+    try:
+        torch.set_num_threads(1)
+        _configure_gloo_loopback()
+        dist.init_process_group(
+            backend="gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        tp_group, cp_group = _make_tp_cp_groups(rank)
+        ctx = FFNContext(tp_group=tp_group, cp_group=cp_group)
+        hidden_size, intermediate_size = 8, 24
+        batch_size, sequence_size = 4, 4
+        generator = torch.Generator().manual_seed(20260814)
+        input_valid = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+        padding = torch.randn(3, sequence_size, hidden_size, generator=generator)
+        gate_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        up_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        down_full = torch.randn(hidden_size, intermediate_size, generator=generator)
+        ffn = TensorParallelFFN.from_full_weights(
+            gate_full, up_full, down_full, ctx=ctx, gemm=_fixed_row_gemm
+        )
+
+        local_sequence = sequence_size // 2
+        sequence_start = (rank // 2) * local_sequence
+        sequence_stop = sequence_start + local_sequence
+        valid_local = input_valid[:, sequence_start:sequence_stop]
+        padded_local = torch.cat((input_valid, padding), dim=0)[:, sequence_start:sequence_stop]
+        full_input = valid_local.detach().clone().requires_grad_(True)
+        single_input = valid_local[:1].detach().clone().requires_grad_(True)
+        padded_input = padded_local.detach().clone().requires_grad_(True)
+
+        full_output = ffn(full_input)
+        full_grad_output = torch.randn(full_output.shape, generator=generator)
+        full_output.backward(full_grad_output)
+
+        single_output = ffn(single_input)
+        single_output.backward(full_grad_output[:1])
+
+        padded_output = ffn(padded_input)
+        padded_grad_output = torch.cat(
+            (
+                full_grad_output,
+                torch.randn(
+                    padded_output.shape[0] - batch_size,
+                    *padded_output.shape[1:],
+                    generator=generator,
+                ),
+            ),
+            dim=0,
+        )
+        padded_output.backward(padded_grad_output)
+        result_queue.put(
+            {
+                "ok": True,
+                "rank": rank,
+                "slice_equal": bool(torch.equal(full_output[:1], single_output)),
+                "padding_equal": bool(torch.equal(full_output, padded_output[:batch_size])),
+                "backward_slice_equal": bool(torch.equal(full_input.grad[:1], single_input.grad)),
+                "backward_padding_equal": bool(
+                    torch.equal(full_input.grad, padded_input.grad[:batch_size])
+                ),
+            }
+        )
+    except Exception:
+        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        raise
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _run_tp_cp_workers(worker: Any) -> list[dict[str, Any]]:
+    world_size = 4
+    mp_context = mp.get_context("spawn")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        init_file = Path(tmp_dir) / "tp_cp_ffn_init"
+        init_method = init_file.as_uri()
+        result_queue = mp_context.Queue()
+        workers = [
+            mp_context.Process(target=worker, args=(rank, world_size, init_method, result_queue))
+            for rank in range(world_size)
+        ]
+        for process in workers:
+            process.start()
+
+        results: list[dict[str, Any]] = []
+        try:
+            for _ in workers:
+                results.append(result_queue.get(timeout=30))
+        except queue.Empty:
+            pytest.fail("timed out waiting for TP+CP Gloo FFN workers")
+        finally:
+            for process in workers:
+                process.join(timeout=30)
+                if process.is_alive():
+                    process.terminate()
+                    process.join()
+
+        failures = [result for result in results if not result["ok"]]
+        if failures:
+            pytest.fail("\n".join(result["traceback"] for result in failures))
+        failed_workers = [process for process in workers if process.exitcode != 0]
+        if failed_workers:
+            pytest.fail(
+                f"TP+CP Gloo workers failed: {[process.exitcode for process in failed_workers]}"
+            )
+        return results
+
+
 @requires_gloo
 def test_tensor_parallel_ffn_matches_full_reference_and_tp_backward_contract() -> None:
     """TP=2 FFN agrees with full FFN and reduces only at the documented sites."""
@@ -268,9 +529,57 @@ def test_tensor_parallel_ffn_is_batch_invariant() -> None:
     assert all(result["slice_equal"] and result["padding_equal"] for result in results)
 
 
+@requires_gloo
+def test_tp_cp_ffn_matches_full_reference_and_cp_weight_gradient_contract() -> None:
+    """TP=2, CP=2 matches the global FFN and reduces all three replica dWs."""
+
+    results = _run_tp_cp_workers(_tp_cp_ffn_worker)
+    for result in results:
+        assert result["output_error"] <= 1e-4
+        assert result["reconstructed_output_error"] <= 1e-4
+        assert result["input_grad_error"] <= 1e-4
+        assert result["gate_grad_error"] <= 1e-4
+        assert result["up_grad_error"] <= 1e-4
+        assert result["down_grad_error"] <= 1e-4
+
+        tp_collectives = [shape for group, shape in result["collectives"] if group == "tp"]
+        cp_collectives = [shape for group, shape in result["collectives"] if group == "cp"]
+        # TP: Down forward and the combined Gate+Up dX backward. CP: one
+        # replica-gradient reduction for each logical Down/Gate/Up parameter.
+        assert tp_collectives == [result["activation_shape"], result["activation_shape"]]
+        assert sorted(cp_collectives) == sorted(
+            [
+                result["down_weight_shape"],
+                result["gate_weight_shape"],
+                result["gate_weight_shape"],
+            ]
+        )
+        assert len(result["collectives"]) == 5
+        assert result["activation_shape"] not in cp_collectives
+
+
+@requires_gloo
+def test_tp_cp_ffn_is_batch_invariant() -> None:
+    """TP+CP local rows and their input gradients are batch/padding invariant."""
+
+    results = _run_tp_cp_workers(_tp_cp_batch_invariance_worker)
+    assert all(
+        result["slice_equal"]
+        and result["padding_equal"]
+        and result["backward_slice_equal"]
+        and result["backward_padding_equal"]
+        for result in results
+    )
+
+
 def test_ffn_context_rejects_unbound_multi_rank_tp() -> None:
     with pytest.raises(ValueError, match="explicit initialized tp_group"):
         FFNContext(tp_size=2)
+
+
+def test_ffn_context_rejects_unbound_multi_rank_cp() -> None:
+    with pytest.raises(ValueError, match="explicit initialized cp_group"):
+        FFNContext(cp_size=2)
 
 
 def test_qwen_weight_shards_follow_column_and_row_parallel_dimensions() -> None:

--- a/tests/test_tensor_parallel_ffn.py
+++ b/tests/test_tensor_parallel_ffn.py
@@ -256,6 +256,23 @@ def _make_tp_cp_groups(rank: int) -> tuple[Any, Any]:
     return tp_group, cp_group
 
 
+def _make_tp_cp_sp_groups(rank: int) -> tuple[Any, Any, Any]:
+    """Add explicit SP groups for sequence shards within each TP/CP row."""
+
+    tp_group, cp_group = _make_tp_cp_groups(rank)
+    sp_group = None
+    # SP splits the CP-local sequence across the two TP coordinates. It uses
+    # its own group handle even though this fixed PR topology has identical
+    # membership to the corresponding TP group.
+    for ranks in ((0, 1), (2, 3)):
+        group = dist.new_group(ranks=list(ranks))
+        if rank in ranks:
+            sp_group = group
+
+    assert sp_group is not None
+    return tp_group, cp_group, sp_group
+
+
 def _tp_cp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue: Any) -> None:
     try:
         torch.set_num_threads(1)
@@ -497,6 +514,252 @@ def _run_tp_cp_workers(worker: Any) -> list[dict[str, Any]]:
         return results
 
 
+def _tp_cp_sp_ffn_worker(rank: int, world_size: int, init_method: str, result_queue: Any) -> None:
+    try:
+        torch.set_num_threads(1)
+        _configure_gloo_loopback()
+        dist.init_process_group(
+            backend="gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        tp_group, cp_group, sp_group = _make_tp_cp_sp_groups(rank)
+        ctx = FFNContext(tp_group=tp_group, cp_group=cp_group, sp_group=sp_group)
+        assert (ctx.tp_size, ctx.cp_size, ctx.sp_size) == (2, 2, 2)
+        assert ctx.tp_rank == rank % 2
+        assert ctx.cp_rank == rank // 2
+        assert ctx.sp_rank == rank % 2
+
+        hidden_size, intermediate_size = 8, 24
+        batch_size, sequence_size = 3, 8
+        generator = torch.Generator().manual_seed(20260815)
+        input_full = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+        gate_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        up_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        down_full = torch.randn(hidden_size, intermediate_size, generator=generator)
+        grad_output_full = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+
+        reference_input = input_full.detach().clone().requires_grad_(True)
+        reference_gate = gate_full.detach().clone().requires_grad_(True)
+        reference_up = up_full.detach().clone().requires_grad_(True)
+        reference_down = down_full.detach().clone().requires_grad_(True)
+        reference_output = _full_ffn(reference_input, reference_gate, reference_up, reference_down)
+        reference_output.backward(grad_output_full)
+
+        local_sequence = sequence_size // 4
+        sequence_start = rank * local_sequence
+        sequence_stop = sequence_start + local_sequence
+        local_input = input_full[:, sequence_start:sequence_stop].detach().clone()
+        local_input.requires_grad_(True)
+        local_grad_output = grad_output_full[:, sequence_start:sequence_stop]
+        ffn = TensorParallelFFN.from_full_weights(
+            gate_full, up_full, down_full, ctx=ctx, gemm=_fixed_row_gemm
+        )
+
+        observed_collectives: list[tuple[str, tuple[int, ...]]] = []
+        original_all_reduce = dist.all_reduce
+        original_all_gather = dist.all_gather
+        original_reduce_scatter = dist.reduce_scatter
+
+        def traced_all_reduce(tensor: torch.Tensor, *args: Any, **kwargs: Any) -> Any:
+            group = kwargs.get("group")
+            if group is cp_group:
+                group_name = "cp_all_reduce"
+            elif group is sp_group:
+                group_name = "sp_reduce_scatter_fallback"
+            elif group is tp_group:
+                raise AssertionError("SP must not stack a TP all_reduce with ReduceScatter.")
+            else:
+                raise AssertionError("FFN used an unexpected process group for all_reduce.")
+            observed_collectives.append((group_name, tuple(tensor.shape)))
+            return original_all_reduce(tensor, *args, **kwargs)
+
+        def traced_all_gather(
+            output_tensors: list[torch.Tensor],
+            input_tensor: torch.Tensor,
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
+            group = kwargs.get("group")
+            if group is not sp_group:
+                raise AssertionError("FFN AllGather must use the explicit SP group.")
+            observed_collectives.append(("sp_all_gather", tuple(input_tensor.shape)))
+            return original_all_gather(output_tensors, input_tensor, *args, **kwargs)
+
+        def traced_reduce_scatter(
+            output_tensor: torch.Tensor,
+            input_tensors: list[torch.Tensor],
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
+            group = kwargs.get("group")
+            if group is not sp_group:
+                raise AssertionError("FFN ReduceScatter must use the explicit SP group.")
+            if len(input_tensors) != 2:
+                raise AssertionError("fixed PR topology requires exactly two SP input chunks.")
+            observed_collectives.append(("sp_reduce_scatter", tuple(output_tensor.shape)))
+            return original_reduce_scatter(output_tensor, input_tensors, *args, **kwargs)
+
+        dist.all_reduce = traced_all_reduce  # type: ignore[assignment]
+        dist.all_gather = traced_all_gather  # type: ignore[assignment]
+        dist.reduce_scatter = traced_reduce_scatter  # type: ignore[assignment]
+        try:
+            local_output = ffn(local_input)
+            local_output.backward(local_grad_output)
+        finally:
+            dist.all_reduce = original_all_reduce  # type: ignore[assignment]
+            dist.all_gather = original_all_gather  # type: ignore[assignment]
+            dist.reduce_scatter = original_reduce_scatter  # type: ignore[assignment]
+
+        gathered_outputs = [torch.empty_like(local_output) for _ in range(world_size)]
+        dist.all_gather(gathered_outputs, local_output)
+        reconstructed_output = torch.cat(gathered_outputs, dim=1)
+
+        local_intermediate = intermediate_size // 2
+        intermediate_start = (rank % 2) * local_intermediate
+        intermediate_stop = intermediate_start + local_intermediate
+        result_queue.put(
+            {
+                "ok": True,
+                "rank": rank,
+                "output_error": float(
+                    (local_output - reference_output[:, sequence_start:sequence_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "reconstructed_output_error": float(
+                    (reconstructed_output - reference_output).abs().max().item()
+                ),
+                "input_grad_error": float(
+                    (local_input.grad - reference_input.grad[:, sequence_start:sequence_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "gate_grad_error": float(
+                    (
+                        ffn.gate_weight.grad
+                        - reference_gate.grad[intermediate_start:intermediate_stop]
+                    )
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "up_grad_error": float(
+                    (ffn.up_weight.grad - reference_up.grad[intermediate_start:intermediate_stop])
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "down_grad_error": float(
+                    (
+                        ffn.down_weight.grad
+                        - reference_down.grad[:, intermediate_start:intermediate_stop]
+                    )
+                    .abs()
+                    .max()
+                    .item()
+                ),
+                "collectives": observed_collectives,
+                "local_activation_shape": tuple(local_input.shape),
+                "gathered_activation_shape": (
+                    batch_size,
+                    sequence_size // 2,
+                    hidden_size,
+                ),
+                "gate_weight_shape": tuple(ffn.gate_weight.shape),
+                "down_weight_shape": tuple(ffn.down_weight.shape),
+            }
+        )
+    except Exception:
+        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        raise
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _tp_cp_sp_batch_invariance_worker(
+    rank: int, world_size: int, init_method: str, result_queue: Any
+) -> None:
+    try:
+        torch.set_num_threads(1)
+        _configure_gloo_loopback()
+        dist.init_process_group(
+            backend="gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        tp_group, cp_group, sp_group = _make_tp_cp_sp_groups(rank)
+        ctx = FFNContext(tp_group=tp_group, cp_group=cp_group, sp_group=sp_group)
+        hidden_size, intermediate_size = 8, 24
+        batch_size, sequence_size = 4, 8
+        generator = torch.Generator().manual_seed(20260816)
+        input_valid = torch.randn(batch_size, sequence_size, hidden_size, generator=generator)
+        padding = torch.randn(3, sequence_size, hidden_size, generator=generator)
+        gate_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        up_full = torch.randn(intermediate_size, hidden_size, generator=generator)
+        down_full = torch.randn(hidden_size, intermediate_size, generator=generator)
+        ffn = TensorParallelFFN.from_full_weights(
+            gate_full, up_full, down_full, ctx=ctx, gemm=_fixed_row_gemm
+        )
+
+        local_sequence = sequence_size // 4
+        sequence_start = rank * local_sequence
+        sequence_stop = sequence_start + local_sequence
+        valid_local = input_valid[:, sequence_start:sequence_stop]
+        padded_local = torch.cat((input_valid, padding), dim=0)[:, sequence_start:sequence_stop]
+        full_input = valid_local.detach().clone().requires_grad_(True)
+        single_input = valid_local[:1].detach().clone().requires_grad_(True)
+        padded_input = padded_local.detach().clone().requires_grad_(True)
+
+        full_output = ffn(full_input)
+        full_grad_output = torch.randn(full_output.shape, generator=generator)
+        full_output.backward(full_grad_output)
+
+        single_output = ffn(single_input)
+        single_output.backward(full_grad_output[:1])
+
+        padded_output = ffn(padded_input)
+        padded_grad_output = torch.cat(
+            (
+                full_grad_output,
+                torch.randn(
+                    padded_output.shape[0] - batch_size,
+                    *padded_output.shape[1:],
+                    generator=generator,
+                ),
+            ),
+            dim=0,
+        )
+        padded_output.backward(padded_grad_output)
+        result_queue.put(
+            {
+                "ok": True,
+                "rank": rank,
+                "slice_equal": bool(torch.equal(full_output[:1], single_output)),
+                "padding_equal": bool(torch.equal(full_output, padded_output[:batch_size])),
+                "backward_slice_equal": bool(torch.equal(full_input.grad[:1], single_input.grad)),
+                "backward_padding_equal": bool(
+                    torch.equal(full_input.grad, padded_input.grad[:batch_size])
+                ),
+            }
+        )
+    except Exception:
+        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        raise
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _run_tp_cp_sp_workers(worker: Any) -> list[dict[str, Any]]:
+    return _run_tp_cp_workers(worker)
+
+
 @requires_gloo
 def test_tensor_parallel_ffn_matches_full_reference_and_tp_backward_contract() -> None:
     """TP=2 FFN agrees with full FFN and reduces only at the documented sites."""
@@ -572,6 +835,72 @@ def test_tp_cp_ffn_is_batch_invariant() -> None:
     )
 
 
+@requires_gloo
+def test_tp_cp_sp_ffn_matches_full_reference_and_sequence_parallel_contract() -> None:
+    """TP=2, CP=2, SP=2 returns the correct S/4 output and gradient shards."""
+
+    results = _run_tp_cp_sp_workers(_tp_cp_sp_ffn_worker)
+    for result in results:
+        assert result["output_error"] <= 1e-4
+        assert result["reconstructed_output_error"] <= 1e-4
+        assert result["input_grad_error"] <= 1e-4
+        assert result["gate_grad_error"] <= 1e-4
+        assert result["up_grad_error"] <= 1e-4
+        assert result["down_grad_error"] <= 1e-4
+
+        events = result["collectives"]
+        names = [name for name, _ in events]
+        sp_all_gathers = [shape for name, shape in events if name == "sp_all_gather"]
+        sp_reduce_scatters = [shape for name, shape in events if name == "sp_reduce_scatter"]
+        cp_all_reduces = [shape for name, shape in events if name == "cp_all_reduce"]
+        sp_fallbacks = [shape for name, shape in events if name == "sp_reduce_scatter_fallback"]
+        gather_positions = [index for index, name in enumerate(names) if name == "sp_all_gather"]
+        scatter_positions = [
+            index for index, name in enumerate(names) if name == "sp_reduce_scatter"
+        ]
+
+        # The forward begins with AG before Gate/Up and ends its FFN body with
+        # RS(SUM). Their backward mappings are respectively RS(SUM) and AG.
+        assert sp_all_gathers == [
+            result["local_activation_shape"],
+            result["local_activation_shape"],
+        ]
+        assert sp_reduce_scatters == [
+            result["local_activation_shape"],
+            result["local_activation_shape"],
+        ]
+        assert (
+            gather_positions[0] < scatter_positions[0] < gather_positions[1] < scatter_positions[1]
+        )
+
+        # No TP all-reduce may be stacked onto an SP ReduceScatter; RS(SUM)
+        # already combines the two TP feature partials while sharding sequence.
+        assert "tp_all_reduce" not in names
+        assert sorted(cp_all_reduces) == sorted(
+            [
+                result["down_weight_shape"],
+                result["gate_weight_shape"],
+                result["gate_weight_shape"],
+            ]
+        )
+        assert len(sp_fallbacks) in (0, 2)
+        assert all(shape == result["gathered_activation_shape"] for shape in sp_fallbacks)
+
+
+@requires_gloo
+def test_tp_cp_sp_ffn_is_batch_invariant() -> None:
+    """TP+CP+SP output and input-gradient shards are batch/padding invariant."""
+
+    results = _run_tp_cp_sp_workers(_tp_cp_sp_batch_invariance_worker)
+    assert all(
+        result["slice_equal"]
+        and result["padding_equal"]
+        and result["backward_slice_equal"]
+        and result["backward_padding_equal"]
+        for result in results
+    )
+
+
 def test_ffn_context_rejects_unbound_multi_rank_tp() -> None:
     with pytest.raises(ValueError, match="explicit initialized tp_group"):
         FFNContext(tp_size=2)
@@ -580,6 +909,11 @@ def test_ffn_context_rejects_unbound_multi_rank_tp() -> None:
 def test_ffn_context_rejects_unbound_multi_rank_cp() -> None:
     with pytest.raises(ValueError, match="explicit initialized cp_group"):
         FFNContext(cp_size=2)
+
+
+def test_ffn_context_rejects_unbound_multi_rank_sp() -> None:
+    with pytest.raises(ValueError, match="explicit initialized sp_group"):
+        FFNContext(sp_size=2)
 
 
 def test_qwen_weight_shards_follow_column_and_row_parallel_dimensions() -> None:


### PR DESCRIPTION
resolves #239 (PR4 Forward track - CP & SP integration)

## Overview
This PR completes the 3D parallelism integration for the Qwen3-8B FFN orchestration by introducing both **Context Parallelism (CP)** and **Sequence Parallelism (SP)** on top of the existing TP foundation. It handles the necessary 2D mesh topology, weight gradient reductions for CP, and activation collectives (AllGather / ReduceScatter) for SP.

## Key Changes
1. **FFNContext & Topology Setup**: 
   - Initialized CP and SP communication groups and required configurations within ctx.
   - Updated the test launcher to explicitly define TP, CP, and SP process groups.

2. **Sequence Collectives (SP)**:
   - **Forward**: Introduced SP AllGather before the Gate/Up projections to collect sequence chunks. The Down operator subsequently uses an SP ReduceScatter(SUM) to output sliced activations.
   - **Backward**: The Down output gradient first undergoes SP AllGather. The local dX from Gate/Up is passed into SP ReduceScatter(SUM).

3. **Weight Reductions (CP)**:
   - Implemented CP all_reduce(SUM) on the weight gradients (dW) for down_weight, gate_weight, and up_weight during the backward pass, as CP rank lanes maintain replicated local parameter shards.

4. **Constraints & Guardrails**:
   - Ensured TP feature partials are consolidated within the SP ReduceScatter, avoiding redundant TP all_reduce operations.
   - Continued enforcement of the deterministic GEMM contract to prevent floating-point drift.

## Verification & Test Results
1. **Local Validation (Gloo)**
   - tests/test_tensor_parallel_ffn.py: All 11 cases passed (Verified batch/padding invariance across the full TP+CP+SP 3D topology).
   - mypy: Passed
   - ruff linting: Passed

2. **GPU Hardware Validation (Pending)**
   > [!NOTE]
   > *Reserved section for multi-GPU hardware test metrics:*
   > ```text
   > [To be filled after running on target GPU cluster]
   > - Test Command: 
   > - Output / Logs: 
   > ```