### PR TITLE
[WS2][GEMM] implement PR 5 TP with gemm backward

### DIFF
--- a/rl_engine/kernels/ops/pytorch/ffn/__init__.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from .ffn import qwen3_ffn_backward
+
+__all__ = ["qwen3_ffn_backward"]

--- a/rl_engine/kernels/ops/pytorch/ffn/ffn.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/ffn.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 from torch import Tensor
 
@@ -27,6 +29,21 @@ def _require_ffn_backward_kernels() -> None:
             "qwen3_ffn_backward requires the compiled deterministic GEMM and "
             f"SwiGLU CUDA kernels.{suffix}"
         )
+
+
+def _require_tensor_parallel_group(tp_group: Any):
+    if tp_group is None:
+        return None
+
+    import torch.distributed as dist
+
+    if not dist.is_available():
+        raise RuntimeError("tensor-parallel FFN backward requires torch.distributed.")
+    if not dist.is_initialized():
+        raise RuntimeError("tensor-parallel FFN backward requires an initialized process group.")
+    if dist.get_world_size(group=tp_group) <= 1:
+        raise ValueError("tp_group must contain at least two ranks.")
+    return dist
 
 
 def _validate_ffn_backward_inputs(
@@ -102,6 +119,8 @@ def qwen3_ffn_backward(
     gate_weight: Tensor,
     up_weight: Tensor,
     down_weight: Tensor,
+    *,
+    tp_group: Any = None,
 ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
     """Compute all gradients of a bias-free SiLU-gated FFN.
 
@@ -127,6 +146,21 @@ def qwen3_ffn_backward(
             ``[I, H]``.
         down_weight: Down projection weight in ``[out, in]`` layout, shape
             ``[H, I]``.
+        tp_group: Optional tensor-parallel process group. ``None`` selects the
+            single-rank path.
+
+    TP gradient layout (``I_local = I / TP``):
+        - Gate/Up are column-parallel. Their input gradients have the same
+          ``[T,H]`` coordinates and are reduced across TP. Their weight
+          gradients are shards that concatenate on dimension 0 to ``[I,H]``.
+        - Down is row-parallel. Its input-gradient shards concatenate on the
+          last dimension to ``[T,I]``. Its weight-gradient shards concatenate
+          on dimension 1 to ``[H,I]``.
+
+        This function performs the Gate and Up input-gradient reductions
+        separately, then adds the two complete ``[T,H]`` gradients locally.
+        Concatenation describes shard ownership and does not require a
+        collective inside this function.
 
     Returns:
         ``(grad_rmsnorm_output, grad_gate_weight, grad_up_weight,
@@ -145,6 +179,7 @@ def qwen3_ffn_backward(
         down_weight,
     )
     _require_ffn_backward_kernels()
+    dist = _require_tensor_parallel_group(tp_group)
 
     # GEMM kernels accept 2-D matrices. Flatten all leading token dimensions
     # into T while preserving H or I as the reduction/projection dimension.
@@ -154,29 +189,36 @@ def qwen3_ffn_backward(
     up_2d = up.reshape(-1, up.size(-1)).contiguous()
     activated_2d = activated.reshape(-1, activated.size(-1)).contiguous()
 
-    # Down projection: output[T,H] = activated[T,I] @ down_weight.T[I,H].
-    # det_gemm_db returns activated.T @ grad_output in [I,H], then transpose it
-    # back to the stored down_weight layout [H,I].
+    # Down is row-parallel. Each rank returns grad_down_weight[H,I_local]; the
+    # full weight gradient is concat(local_grad, dim=1).
     grad_down_weight = _C.det_gemm_db(activated_2d, grad_output_2d).t().contiguous()
 
-    # d_activated[T,I] = grad_output[T,H] @ down_weight[H,I]. The stored
-    # [out,in] weight already has the exact right-hand GEMM layout, so this is a
-    # direct matrix multiply rather than det_gemm_da, which would transpose B.
+    # Each rank returns grad_activated[T,I_local]; the full input gradient of
+    # Down is concat(local_grad, dim=-1), so no TP reduction is needed here.
     grad_activated = _C.det_gemm_fwd(grad_output_2d, down_weight)
 
     # Differentiate activated = silu(gate) * up elementwise.
     grad_gate, grad_up = _C.swiglu_backward(grad_activated, gate_2d, up_2d)
 
-    # Input projection weight gradients are accumulated over the T token rows.
-    # det_gemm_db returns [H,I]; transpose to the stored [I,H] weight layout.
+    # Gate/Up are column-parallel. Each local weight gradient is [I_local,H];
+    # the full weight gradient is concat(local_grad, dim=0).
     grad_gate_weight = _C.det_gemm_db(rmsnorm_output_2d, grad_gate).t().contiguous()
     grad_up_weight = _C.det_gemm_db(rmsnorm_output_2d, grad_up).t().contiguous()
 
-    # Both input projections consume the same RMSNorm output, so its gradient
-    # is the sum of the gate and up branches. As above, [out,in] weights already
-    # have the right GEMM layout: [T,I] @ [I,H] -> [T,H].
-    grad_rmsnorm_output = _C.det_gemm_fwd(grad_gate, gate_weight)
-    grad_rmsnorm_output.add_(_C.det_gemm_fwd(grad_up, up_weight))
+    # Gate/Up local input gradients address the same [T,H] coordinates. Keep
+    # their ColumnParallel backward boundaries separate: reduce each complete
+    # branch across TP, then add the two results locally.
+    grad_rmsnorm_from_gate = _C.det_gemm_fwd(grad_gate, gate_weight)
+    if dist is not None:
+        # TODO: CUDA currently uses NCCL. Replace it with the custom
+        # deterministic AllReduce and compare both communication paths.
+        dist.all_reduce(grad_rmsnorm_from_gate, op=dist.ReduceOp.SUM, group=tp_group)
+
+    grad_rmsnorm_from_up = _C.det_gemm_fwd(grad_up, up_weight)
+    if dist is not None:
+        dist.all_reduce(grad_rmsnorm_from_up, op=dist.ReduceOp.SUM, group=tp_group)
+
+    grad_rmsnorm_output = grad_rmsnorm_from_gate.add_(grad_rmsnorm_from_up)
 
     return (
         grad_rmsnorm_output.reshape_as(rmsnorm_output),

--- a/rl_engine/kernels/ops/pytorch/ffn/ffn.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/ffn.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+"""Bias-free gated FFN backward assembled from deterministic CUDA kernels."""
+
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
+
+QWEN3_8B_HIDDEN_SIZE = 4096
+QWEN3_8B_INTERMEDIATE_SIZE = 12288
+
+_REQUIRED_SYMBOLS = (
+    "det_gemm_fwd",
+    "det_gemm_db",
+    "swiglu_backward",
+)
+
+
+def _require_ffn_backward_kernels() -> None:
+    missing = [name for name in _REQUIRED_SYMBOLS if not hasattr(_C, name)]
+    if not _EXT_AVAILABLE or _C is None or missing:
+        suffix = f" Missing symbols: {', '.join(missing)}." if missing else ""
+        raise RuntimeError(
+            "qwen3_ffn_backward requires the compiled deterministic GEMM and "
+            f"SwiGLU CUDA kernels.{suffix}"
+        )
+
+
+def _validate_ffn_backward_inputs(
+    grad_output: Tensor,
+    rmsnorm_output: Tensor,
+    gate: Tensor,
+    up: Tensor,
+    activated: Tensor,
+    gate_weight: Tensor,
+    up_weight: Tensor,
+    down_weight: Tensor,
+) -> None:
+    tensors = {
+        "grad_output": grad_output,
+        "rmsnorm_output": rmsnorm_output,
+        "gate": gate,
+        "up": up,
+        "activated": activated,
+        "gate_weight": gate_weight,
+        "up_weight": up_weight,
+        "down_weight": down_weight,
+    }
+    for name, tensor in tensors.items():
+        if not isinstance(tensor, Tensor):
+            raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor)!r}.")
+
+    if rmsnorm_output.dim() < 1:
+        raise ValueError("rmsnorm_output must have at least one dimension.")
+    if rmsnorm_output.numel() == 0:
+        raise ValueError("rmsnorm_output must contain at least one token.")
+    for name, weight in (
+        ("gate_weight", gate_weight),
+        ("up_weight", up_weight),
+        ("down_weight", down_weight),
+    ):
+        if weight.dim() != 2:
+            raise ValueError(f"{name} must be 2-D, got shape {tuple(weight.shape)}.")
+
+    hidden_size = rmsnorm_output.size(-1)
+    intermediate_size = gate.size(-1)
+    expected_shapes = {
+        "grad_output": (*rmsnorm_output.shape[:-1], hidden_size),
+        "gate": (*rmsnorm_output.shape[:-1], intermediate_size),
+        "up": (*rmsnorm_output.shape[:-1], intermediate_size),
+        "activated": (*rmsnorm_output.shape[:-1], intermediate_size),
+        "gate_weight": (intermediate_size, hidden_size),
+        "up_weight": (intermediate_size, hidden_size),
+        "down_weight": (hidden_size, intermediate_size),
+    }
+    for name, expected in expected_shapes.items():
+        actual = tuple(tensors[name].shape)
+        if actual != expected:
+            raise ValueError(f"{name} must have shape {expected}, got {actual}.")
+
+    for name, tensor in tensors.items():
+        if tensor.dtype != torch.bfloat16:
+            raise TypeError(f"{name} must have dtype bfloat16, got {tensor.dtype}.")
+        if not tensor.is_cuda:
+            raise RuntimeError(f"{name} must be on a CUDA device, got '{tensor.device}'.")
+        if tensor.device != rmsnorm_output.device:
+            raise RuntimeError(
+                f"all FFN inputs must be on {rmsnorm_output.device}, "
+                f"got {name} on {tensor.device}."
+            )
+
+
+def qwen3_ffn_backward(
+    grad_output: Tensor,
+    rmsnorm_output: Tensor,
+    gate: Tensor,
+    up: Tensor,
+    activated: Tensor,
+    gate_weight: Tensor,
+    up_weight: Tensor,
+    down_weight: Tensor,
+) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    """Compute all gradients of a bias-free SiLU-gated FFN.
+
+    ``T`` denotes the product of all leading token dimensions, ``H`` the hidden
+    width, and ``I`` the intermediate width. The corresponding forward is::
+
+        gate = rmsnorm_output @ gate_weight.T
+        up = rmsnorm_output @ up_weight.T
+        activated = silu(gate) * up
+        output = activated @ down_weight.T
+
+    Args:
+        grad_output: Gradient from the FFN output, shape ``[..., H]``.
+        rmsnorm_output: Saved RMSNorm output consumed by both input projections,
+            shape ``[..., H]``. It is the tensor whose gradient must be returned
+            to the RMSNorm backward.
+        gate: Saved gate projection output before SiLU, shape ``[..., I]``.
+        up: Saved up projection output, shape ``[..., I]``.
+        activated: Saved SwiGLU result ``silu(gate) * up``, shape ``[..., I]``.
+        gate_weight: Gate projection weight in ``[out, in]`` layout, shape
+            ``[I, H]``.
+        up_weight: Up projection weight in ``[out, in]`` layout, shape
+            ``[I, H]``.
+        down_weight: Down projection weight in ``[out, in]`` layout, shape
+            ``[H, I]``.
+
+    Returns:
+        ``(grad_rmsnorm_output, grad_gate_weight, grad_up_weight,
+        grad_down_weight)``. Each gradient has the same shape and layout as its
+        corresponding forward input.
+    """
+
+    _validate_ffn_backward_inputs(
+        grad_output,
+        rmsnorm_output,
+        gate,
+        up,
+        activated,
+        gate_weight,
+        up_weight,
+        down_weight,
+    )
+    _require_ffn_backward_kernels()
+
+    # GEMM kernels accept 2-D matrices. Flatten all leading token dimensions
+    # into T while preserving H or I as the reduction/projection dimension.
+    rmsnorm_output_2d = rmsnorm_output.reshape(-1, rmsnorm_output.size(-1)).contiguous()
+    grad_output_2d = grad_output.reshape(-1, grad_output.size(-1)).contiguous()
+    gate_2d = gate.reshape(-1, gate.size(-1)).contiguous()
+    up_2d = up.reshape(-1, up.size(-1)).contiguous()
+    activated_2d = activated.reshape(-1, activated.size(-1)).contiguous()
+
+    # Down projection: output[T,H] = activated[T,I] @ down_weight.T[I,H].
+    # det_gemm_db returns activated.T @ grad_output in [I,H], then transpose it
+    # back to the stored down_weight layout [H,I].
+    grad_down_weight = _C.det_gemm_db(activated_2d, grad_output_2d).t().contiguous()
+
+    # d_activated[T,I] = grad_output[T,H] @ down_weight[H,I]. The stored
+    # [out,in] weight already has the exact right-hand GEMM layout, so this is a
+    # direct matrix multiply rather than det_gemm_da, which would transpose B.
+    grad_activated = _C.det_gemm_fwd(grad_output_2d, down_weight)
+
+    # Differentiate activated = silu(gate) * up elementwise.
+    grad_gate, grad_up = _C.swiglu_backward(grad_activated, gate_2d, up_2d)
+
+    # Input projection weight gradients are accumulated over the T token rows.
+    # det_gemm_db returns [H,I]; transpose to the stored [I,H] weight layout.
+    grad_gate_weight = _C.det_gemm_db(rmsnorm_output_2d, grad_gate).t().contiguous()
+    grad_up_weight = _C.det_gemm_db(rmsnorm_output_2d, grad_up).t().contiguous()
+
+    # Both input projections consume the same RMSNorm output, so its gradient
+    # is the sum of the gate and up branches. As above, [out,in] weights already
+    # have the right GEMM layout: [T,I] @ [I,H] -> [T,H].
+    grad_rmsnorm_output = _C.det_gemm_fwd(grad_gate, gate_weight)
+    grad_rmsnorm_output.add_(_C.det_gemm_fwd(grad_up, up_weight))
+
+    return (
+        grad_rmsnorm_output.reshape_as(rmsnorm_output),
+        grad_gate_weight,
+        grad_up_weight,
+        grad_down_weight,
+    )

--- a/tests/test_qwen3_ffn_backward.py
+++ b/tests/test_qwen3_ffn_backward.py
@@ -1,0 +1,343 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+"""Tests for the deterministic Qwen3 dense FFN backward assembly."""
+
+from __future__ import annotations
+
+import queue
+import tempfile
+import traceback
+from pathlib import Path
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+import torch.nn.functional as F
+
+import rl_engine.kernels.ops.pytorch.ffn.ffn as ffn_module
+from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
+from rl_engine.kernels.ops.pytorch.ffn.ffn import (
+    QWEN3_8B_HIDDEN_SIZE,
+    QWEN3_8B_INTERMEDIATE_SIZE,
+    qwen3_ffn_backward,
+)
+
+_REQUIRED_SYMBOLS = (
+    "det_gemm_fwd",
+    "det_gemm_db",
+    "swiglu_forward",
+    "swiglu_backward",
+)
+_HAS_SM90_FFN = (
+    torch.cuda.is_available()
+    and torch.cuda.get_device_capability()[0] == 9
+    and _EXT_AVAILABLE
+    and all(hasattr(_C, name) for name in _REQUIRED_SYMBOLS)
+)
+
+requires_cuda_ffn = pytest.mark.skipif(
+    not _HAS_SM90_FFN,
+    reason="FFN optimized-path validation requires SM90 and the GEMM/SwiGLU extension symbols",
+)
+
+
+def _gloo_available():
+    return torch.distributed.is_available() and torch.distributed.is_gloo_available()
+
+
+requires_gloo = pytest.mark.skipif(
+    not _gloo_available(),
+    reason="tensor-parallel FFN backward CPU test requires torch.distributed Gloo",
+)
+
+
+class _TorchKernelStub:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def det_gemm_fwd(self, a, b):
+        self.calls.append("det_gemm_fwd")
+        return a @ b
+
+    def det_gemm_db(self, a, grad_output):
+        self.calls.append("det_gemm_db")
+        return a.t().contiguous() @ grad_output
+
+    def swiglu_forward(self, gate, up):
+        self.calls.append("swiglu_forward")
+        return gate * torch.sigmoid(gate) * up
+
+    def swiglu_backward(self, grad_output, gate, up):
+        self.calls.append("swiglu_backward")
+        sigmoid = torch.sigmoid(gate)
+        grad_gate = grad_output * up * sigmoid * (1.0 + gate * (1.0 - sigmoid))
+        grad_up = grad_output * gate * sigmoid
+        return grad_gate, grad_up
+
+
+def _reference(hidden_states, gate_weight, up_weight, down_weight):
+    gate = hidden_states @ gate_weight.t()
+    up = hidden_states @ up_weight.t()
+    activated = F.silu(gate) * up
+    return (activated @ down_weight.t()), gate, up, activated
+
+
+def _randn(shape, *, seed, device="cpu", dtype=torch.float32):
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    value = torch.randn(*shape, generator=generator, dtype=torch.float32) * 0.02
+    return value.to(device=device, dtype=dtype)
+
+
+def _tp_ffn_backward_gloo_worker(rank, world_size, init_method, result_queue):
+    try:
+        import torch.distributed as dist
+
+        torch.set_num_threads(1)
+        dist.init_process_group(
+            backend="gloo",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+
+        stub = _TorchKernelStub()
+        ffn_module._C = stub
+        ffn_module._EXT_AVAILABLE = True
+        ffn_module._validate_ffn_backward_inputs = lambda *args: None
+
+        token_count, hidden_size, intermediate_size = 6, 5, 12
+        local_intermediate = intermediate_size // world_size
+        shard_start = rank * local_intermediate
+        shard_end = shard_start + local_intermediate
+
+        rmsnorm_output = _randn((token_count, hidden_size), seed=30)
+        gate_weight = _randn((intermediate_size, hidden_size), seed=31)
+        up_weight = _randn((intermediate_size, hidden_size), seed=32)
+        down_weight = _randn((hidden_size, intermediate_size), seed=33)
+        grad_output = _randn((token_count, hidden_size), seed=34)
+
+        reference_inputs = [
+            value.detach().clone().requires_grad_(True)
+            for value in (rmsnorm_output, gate_weight, up_weight, down_weight)
+        ]
+        reference_output, _, _, _ = _reference(*reference_inputs)
+        reference_output.backward(grad_output)
+
+        local_gate_weight = gate_weight[shard_start:shard_end].contiguous()
+        local_up_weight = up_weight[shard_start:shard_end].contiguous()
+        local_down_weight = down_weight[:, shard_start:shard_end].contiguous()
+        local_gate = rmsnorm_output @ local_gate_weight.t()
+        local_up = rmsnorm_output @ local_up_weight.t()
+        local_activated = F.silu(local_gate) * local_up
+
+        actual_grads = qwen3_ffn_backward(
+            grad_output,
+            rmsnorm_output,
+            local_gate,
+            local_up,
+            local_activated,
+            local_gate_weight,
+            local_up_weight,
+            local_down_weight,
+            tp_group=dist.group.WORLD,
+        )
+
+        expected_grads = (
+            reference_inputs[0].grad,
+            reference_inputs[1].grad[shard_start:shard_end],
+            reference_inputs[2].grad[shard_start:shard_end],
+            reference_inputs[3].grad[:, shard_start:shard_end],
+        )
+        result_queue.put(
+            {
+                "ok": True,
+                "rank": rank,
+                "max_errors": [
+                    float((actual - expected).abs().max().item())
+                    for actual, expected in zip(actual_grads, expected_grads, strict=True)
+                ],
+            }
+        )
+    except Exception:  # pragma: no cover - forwarded to the parent process.
+        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        raise
+    finally:
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def test_qwen3_8b_dimensions_are_pinned():
+    assert QWEN3_8B_HIDDEN_SIZE == 4096
+    assert QWEN3_8B_INTERMEDIATE_SIZE == 12288
+
+
+def test_backward_matches_autograd_reference(monkeypatch):
+    stub = _TorchKernelStub()
+    monkeypatch.setattr(ffn_module, "_C", stub)
+    monkeypatch.setattr(ffn_module, "_EXT_AVAILABLE", True)
+    monkeypatch.setattr(ffn_module, "_validate_ffn_backward_inputs", lambda *args: None)
+
+    hidden = _randn((2, 3, 8), seed=0)
+    gate_weight = _randn((12, 8), seed=1)
+    up_weight = _randn((12, 8), seed=2)
+    down_weight = _randn((8, 12), seed=3)
+    grad_output = _randn(hidden.shape, seed=4)
+
+    ref_inputs = [
+        value.detach().clone().requires_grad_(True)
+        for value in (hidden, gate_weight, up_weight, down_weight)
+    ]
+    expected, gate, up, activated = _reference(*ref_inputs)
+    expected.backward(grad_output)
+
+    actual_grads = qwen3_ffn_backward(
+        grad_output,
+        hidden,
+        gate.detach(),
+        up.detach(),
+        activated.detach(),
+        gate_weight,
+        up_weight,
+        down_weight,
+    )
+
+    for actual, reference in zip(actual_grads, ref_inputs, strict=True):
+        torch.testing.assert_close(actual, reference.grad)
+
+    assert stub.calls.count("det_gemm_fwd") == 3
+    assert stub.calls.count("det_gemm_db") == 3
+    assert stub.calls.count("swiglu_backward") == 1
+
+
+@requires_gloo
+def test_tensor_parallel_backward_matches_full_reference_cpu_gloo_2_ranks():
+    ctx = mp.get_context("spawn")
+    world_size = 2
+    with tempfile.TemporaryDirectory() as tmpdir:
+        init_method = (Path(tmpdir) / "gloo_init").as_uri()
+        result_queue = ctx.Queue()
+        processes = [
+            ctx.Process(
+                target=_tp_ffn_backward_gloo_worker,
+                args=(rank, world_size, init_method, result_queue),
+            )
+            for rank in range(world_size)
+        ]
+
+        for process in processes:
+            process.start()
+
+        results = []
+        try:
+            for _ in processes:
+                results.append(result_queue.get(timeout=45))
+        except queue.Empty:
+            for process in processes:
+                if process.is_alive():
+                    process.terminate()
+            pytest.fail("timed out waiting for tensor-parallel Gloo workers")
+        finally:
+            for process in processes:
+                process.join(timeout=10)
+                if process.is_alive():
+                    process.terminate()
+
+    for result in sorted(results, key=lambda item: item["rank"]):
+        assert result["ok"], result.get("traceback")
+        assert max(result["max_errors"]) < 1e-6
+    for process in processes:
+        assert process.exitcode == 0
+
+
+def test_rejects_non_huggingface_weight_layout():
+    hidden = torch.empty((2, 8), dtype=torch.bfloat16)
+    grad_output = torch.empty_like(hidden)
+    gate = torch.empty((2, 12), dtype=torch.bfloat16)
+    up = torch.empty_like(gate)
+    activated = torch.empty_like(gate)
+    gate_weight = torch.empty((8, 12), dtype=torch.bfloat16)
+    up_weight = torch.empty((12, 8), dtype=torch.bfloat16)
+    down_weight = torch.empty((8, 12), dtype=torch.bfloat16)
+
+    with pytest.raises(ValueError, match="gate_weight must have shape"):
+        qwen3_ffn_backward(
+            grad_output,
+            hidden,
+            gate,
+            up,
+            activated,
+            gate_weight,
+            up_weight,
+            down_weight,
+        )
+
+
+@requires_cuda_ffn
+def test_cuda_forward_backward_matches_fp32_reference():
+    hidden = _randn((2, 3, 64), seed=10, device="cuda", dtype=torch.bfloat16)
+    gate_weight = _randn((128, 64), seed=11, device="cuda", dtype=torch.bfloat16)
+    up_weight = _randn((128, 64), seed=12, device="cuda", dtype=torch.bfloat16)
+    down_weight = _randn((64, 128), seed=13, device="cuda", dtype=torch.bfloat16)
+    grad_output = _randn(hidden.shape, seed=14, device="cuda", dtype=torch.bfloat16)
+
+    ref_inputs = [
+        value.detach().cpu().float().requires_grad_(True)
+        for value in (hidden, gate_weight, up_weight, down_weight)
+    ]
+    expected, _, _, _ = _reference(*ref_inputs)
+    expected.backward(grad_output.cpu().float())
+
+    hidden_2d = hidden.reshape(-1, hidden.size(-1))
+    gate = _C.det_gemm_fwd(hidden_2d, gate_weight.t().contiguous())
+    up = _C.det_gemm_fwd(hidden_2d, up_weight.t().contiguous())
+    activated = _C.swiglu_forward(gate, up)
+    actual_grads = qwen3_ffn_backward(
+        grad_output,
+        hidden,
+        gate.reshape(*hidden.shape[:-1], gate.size(-1)),
+        up.reshape(*hidden.shape[:-1], up.size(-1)),
+        activated.reshape(*hidden.shape[:-1], activated.size(-1)),
+        gate_weight,
+        up_weight,
+        down_weight,
+    )
+
+    for actual, reference in zip(actual_grads, ref_inputs, strict=True):
+        torch.testing.assert_close(actual.cpu().float(), reference.grad, atol=5e-2, rtol=2e-2)
+
+
+@requires_cuda_ffn
+def test_cuda_forward_and_input_gradient_are_batch_invariant():
+    gate_weight = _randn((128, 64), seed=20, device="cuda", dtype=torch.bfloat16)
+    up_weight = _randn((128, 64), seed=21, device="cuda", dtype=torch.bfloat16)
+    down_weight = _randn((64, 128), seed=22, device="cuda", dtype=torch.bfloat16)
+    hidden = _randn((6, 64), seed=23, device="cuda", dtype=torch.bfloat16)
+    grad_output = _randn(hidden.shape, seed=24, device="cuda", dtype=torch.bfloat16)
+
+    def _saved_forward(value):
+        gate = _C.det_gemm_fwd(value, gate_weight.t().contiguous())
+        up = _C.det_gemm_fwd(value, up_weight.t().contiguous())
+        return gate, up, _C.swiglu_forward(gate, up)
+
+    full_saved = _saved_forward(hidden)
+    full_grad_hidden = qwen3_ffn_backward(
+        grad_output,
+        hidden,
+        *full_saved,
+        gate_weight,
+        up_weight,
+        down_weight,
+    )[0]
+
+    hidden_slice = hidden[2:4]
+    slice_saved = _saved_forward(hidden_slice)
+    slice_grad_hidden = qwen3_ffn_backward(
+        grad_output[2:4],
+        hidden_slice,
+        *slice_saved,
+        gate_weight,
+        up_weight,
+        down_weight,
+    )[0]
+
+    assert torch.equal(slice_grad_hidden, full_grad_hidden[2:4])


### PR DESCRIPTION
part of #239 

  ## Summary

  Add a deterministic backward assembly for FFN using the existing deterministic GEMM and SwiGLU kernels.

  ## Changes

  - Compute input and weight gradients for Gate, Up, and Downprojections.
  - Support Hugging Face `[out, in]` weight layout.
  - Support tensor-parallel FFN backward:
    - Gate/Up input gradients use separate TP AllReduce operations.
    - Gate/Up weight gradients remain column-parallel shards.
    - Down input and weight gradients remain row-parallel shards.

  ## Validation

  - Pre-commit hooks passed.
  - FFN tests: `4 passed, 2 skipped`.
  - GEMM/SiLU regression: `22 passed, 103 skipped`.

  The CUDA SM90 tests were skipped locally because no compatible GPU or compiled extension was available.