### PR TITLE
[CI] Run CI-Pipeline and GPU CI on PRs targeting test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ name: CI-Pipeline
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, test ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, test ]
 
 permissions:
   contents: read

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -2,7 +2,7 @@ name: GPU CI
 
 on:
   pull_request_target:
-    branches: [ main ]
+    branches: [ main, test ]
     paths:
       - 'csrc/**'
       - 'rl_engine/**'


### PR DESCRIPTION
## Summary

PRs are now required to target `test`, but the gate workflows still only listed `main` as the base branch. As a result, `CI-Pipeline` and `GPU CI` never started on those PRs (see #305).

This change only updates the trigger filters:

- `.github/workflows/ci.yml`: `push` / `pull_request` now include `test`
- `.github/workflows/gpu-ci.yml`: `pull_request_target` now includes `test`

`docs.yml` and `build-ci-image.yml` stay on `main` (Pages deploy and CI image publish).

## Why this needs to land on `test` first

`gpu-ci.yml` uses `pull_request_target`, which reads the workflow file from the **base branch**, not the PR head. Until this commit is on `test`, GPU CI cannot run for any PR targeting `test`.

## After merge

- Existing PRs targeting `test` should pick up `CI-Pipeline` on the next push, or after close/reopen.
- GPU CI still requires the `needs-gpu-ci` label.
- Fork PRs still cannot use same-repo-only workflows such as `WS1-gtest-GPU`.

## Test plan

- [ ] Confirm this PR itself starts `CI-Pipeline` after the workflow is on `test` (first-run may need a follow-up push or close/reopen).
- [ ] After merge, confirm a `test`-based PR without `needs-gpu-ci` still runs `CI-Pipeline`.
- [ ] After merge, add `needs-gpu-ci` to a `test`-based PR and confirm `GPU CI` starts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded automated validation to run for changes targeting both the main and test branches.
  * Included GPU-specific validation for pull requests targeting the test branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->