### PR TITLE
docs: replace expired Discord links with Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
   <a href="https://rl-align.github.io/RL-Kernel/"><img src="https://img.shields.io/badge/Documentation-Docs-2ea44f" alt="Documentation"></a>
-  <a href="https://discord.gg/RGUQrr74z"><img src="https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://rl-align.slack.com/join/shared_invite/zt-46bxj7uyt-gEK3xzwSJr_lppJsZolR~g#/shared-invite/email"><img src="https://img.shields.io/badge/Slack-Join%20Us-4A154B" alt="Slack"></a>
   <a href="./docs/community/wechat.md"><img src="https://img.shields.io/badge/WeChat-Join%20Group-07C160?logo=wechat&logoColor=white" alt="WeChat"></a>
   <a href="./docs/assets/whatsapp-group.png"><img src="https://img.shields.io/badge/WhatsApp-Join%20Group-25D366?logo=whatsapp&logoColor=white" alt="WhatsApp"></a>
   <a href="https://deepwiki.com/RL-Align/RL-Kernel"><img src="https://img.shields.io/badge/Ask-DeepWiki-7B3FE4" alt="Ask DeepWiki"></a>
@@ -133,7 +133,7 @@ Target: Building the most efficient RLHF toolchain for the open-source community
 # Support
 Don’t hesitate to ask!
 
-Contact the developers and community on the [Discord](https://discord.gg/RGUQrr74z) if you need any help.
+Contact the developers and community on the [Slack](https://rl-align.slack.com/join/shared_invite/zt-46bxj7uyt-gEK3xzwSJr_lppJsZolR~g#/shared-invite/email) if you need any help.
 
 [Open an issue](https://github.com/RL-Align/RL-Kernel/issues) if you find a bug in **RL-Kernel**.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Target: Building the most efficient RLHF toolchain for the open-source community
 # Support
 Don’t hesitate to ask!
 
-Contact the developers and community on the [Slack](https://rl-align.slack.com/join/shared_invite/zt-46bxj7uyt-gEK3xzwSJr_lppJsZolR~g#/shared-invite/email) if you need any help.
+Contact the developers and community in [Slack](https://rl-align.slack.com/join/shared_invite/zt-46bxj7uyt-gEK3xzwSJr_lppJsZolR~g#/shared-invite/email) if you need any help.
 
 [Open an issue](https://github.com/RL-Align/RL-Kernel/issues) if you find a bug in **RL-Kernel**.
 


### PR DESCRIPTION
## Summary

- Replace the expired Discord badge in `README.md` with the official Slack invite.
- Update the Support section to direct contributors and community members to Slack.
- Remove the obsolete Discord references.

## Context

The Discord channel has been paused, and the project community has moved to
Slack to make communication easier across different time zones. The canonical
Slack invite used in this change was confirmed by a project maintainer.

Follow-up to #286.

## Validation

- [x] Ran `git diff --check`.
- [x] Confirmed that the Slack badge renders correctly in the Markdown preview.
- [x] Confirmed that the badge and Support link open the Slack invitation page.

## Tests

Not applicable — this PR only updates README links and badge text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the community badge to link to Slack instead of Discord.
  * Updated the support contact information to direct users to Slack.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->