### PR TITLE
feat(ascend): add SwiGLU operator

### DIFF
--- a/csrc/ascend/batch_invariant_logp_ascend.asc
+++ b/csrc/ascend/batch_invariant_logp_ascend.asc
@@ -308,9 +308,19 @@ std::vector<torch::Tensor> batch_invariant_logp_ascend_forward(torch::Tensor log
     return {logp, lse};
 }
 
+torch::Tensor swiglu_ascend_forward(torch::Tensor gate, torch::Tensor up);
+std::vector<torch::Tensor> swiglu_ascend_backward(
+    torch::Tensor dy, torch::Tensor gate, torch::Tensor up);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
     m.def("batch_invariant_logp_ascend",
           &batch_invariant_logp_ascend_forward,
           "Batch-invariant selected-token log-probability (Ascend C forward)");
+    m.def("swiglu_ascend_forward",
+          &swiglu_ascend_forward,
+          "SwiGLU (Ascend C forward)");
+    m.def("swiglu_ascend_backward",
+          &swiglu_ascend_backward,
+          "SwiGLU (Ascend C backward)");
 }

--- a/csrc/ascend/swiglu_ascend.asc
+++ b/csrc/ascend/swiglu_ascend.asc
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+//
+// SwiGLU for Ascend C (dav-2201/A2/A3 path).
+//
+//   y      = silu(gate) * up
+//   d_up   = dy * silu(gate)
+//   d_gate = dy * up * sigmoid(gate) * (1 + gate * (1 - sigmoid(gate)))
+//
+// Inputs may be FP32/FP16/BF16; all arithmetic is performed in FP32.
+
+#include <algorithm>
+#include <type_traits>
+#include <vector>
+
+#include "kernel_operator.h"
+
+#include <c10/core/DeviceGuard.h>
+#include <torch/extension.h>
+
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+
+namespace {
+
+constexpr uint32_t TILE_ELEMENTS = 5120;
+constexpr uint32_t CORE_ALIGN_ELEMENTS = 512;
+constexpr int64_t MAX_BLOCKS = 128;
+
+template <typename T>
+class KernelSwiGLUForward {
+public:
+    __aicore__ inline explicit KernelSwiGLUForward(AscendC::TPipe* pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(GM_ADDR gate, GM_ADDR up, GM_ADDR output, int64_t numElements)
+    {
+        numElements_ = numElements;
+        gateGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(gate));
+        upGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(up));
+        outputGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(output));
+
+        const uint32_t tensorBytes = TILE_ELEMENTS * sizeof(T);
+        pipe_->InitBuffer(gateQueue_, 2, tensorBytes);
+        pipe_->InitBuffer(upQueue_, 2, tensorBytes);
+        pipe_->InitBuffer(outputQueue_, 2, tensorBytes);
+        if constexpr (!std::is_same_v<T, float>) {
+            pipe_->InitBuffer(gateFp32Buf_, TILE_ELEMENTS * sizeof(float));
+            pipe_->InitBuffer(upFp32Buf_, TILE_ELEMENTS * sizeof(float));
+        }
+        pipe_->InitBuffer(denomBuf_, TILE_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(sigmoidBuf_, TILE_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(tmpBuf_, TILE_ELEMENTS * sizeof(float));
+    }
+
+    __aicore__ inline void Process()
+    {
+        const int64_t blockCount = AscendC::GetBlockNum();
+        const int64_t unalignedSpan = (numElements_ + blockCount - 1) / blockCount;
+        const int64_t coreSpan =
+            (unalignedSpan + CORE_ALIGN_ELEMENTS - 1) / CORE_ALIGN_ELEMENTS * CORE_ALIGN_ELEMENTS;
+        const int64_t coreStart = static_cast<int64_t>(AscendC::GetBlockIdx()) * coreSpan;
+        if (coreStart >= numElements_) {
+            return;
+        }
+        const int64_t coreEnd = (coreStart + coreSpan < numElements_)
+            ? coreStart + coreSpan
+            : numElements_;
+        for (int64_t offset = coreStart; offset < coreEnd; offset += TILE_ELEMENTS) {
+            const uint32_t count = static_cast<uint32_t>(
+                (offset + TILE_ELEMENTS < coreEnd) ? TILE_ELEMENTS : coreEnd - offset);
+            CopyIn(offset, count);
+            Compute(count);
+            CopyOut(offset, count);
+        }
+    }
+
+private:
+    template <typename LocalT, typename GlobalT>
+    __aicore__ inline void CopyTensor(LocalT dst, GlobalT src, uint32_t count)
+    {
+        const uint32_t blockBytes = count * sizeof(T);
+        const uint32_t paddedBytes = (blockBytes + 31U) / 32U * 32U;
+        const uint8_t rightPad = static_cast<uint8_t>((paddedBytes - blockBytes) / sizeof(T));
+        AscendC::DataCopyExtParams copyParams{1, blockBytes, 0, 0, 0};
+        AscendC::DataCopyPadExtParams<T> padParams{true, 0, rightPad, static_cast<T>(0)};
+        AscendC::DataCopyPad(dst, src, copyParams, padParams);
+    }
+
+    __aicore__ inline void CopyIn(int64_t offset, uint32_t count)
+    {
+        AscendC::LocalTensor<T> gate = gateQueue_.AllocTensor<T>();
+        AscendC::LocalTensor<T> up = upQueue_.AllocTensor<T>();
+        CopyTensor(gate, gateGm_[offset], count);
+        CopyTensor(up, upGm_[offset], count);
+        gateQueue_.EnQue(gate);
+        upQueue_.EnQue(up);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float> ToFp32(
+        const AscendC::LocalTensor<T>& input,
+        AscendC::TBuf<AscendC::TPosition::VECCALC>& fp32Buf,
+        uint32_t count)
+    {
+        if constexpr (std::is_same_v<T, float>) {
+            return input;
+        } else {
+            AscendC::LocalTensor<float> output = fp32Buf.Get<float>();
+            AscendC::Cast(output, input, AscendC::RoundMode::CAST_NONE, count);
+            return output;
+        }
+    }
+
+    __aicore__ inline void FromFp32(
+        AscendC::LocalTensor<T> output,
+        const AscendC::LocalTensor<float>& input,
+        uint32_t count)
+    {
+        if constexpr (std::is_same_v<T, float>) {
+            AscendC::Muls(output, input, 1.0f, count);
+        } else if constexpr (std::is_same_v<T, bfloat16_t>) {
+            AscendC::Cast(output, input, AscendC::RoundMode::CAST_RINT, count);
+        } else {
+            AscendC::Cast(output, input, AscendC::RoundMode::CAST_ROUND, count);
+        }
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float> Sigmoid(
+        const AscendC::LocalTensor<float>& gate, uint32_t count)
+    {
+        AscendC::LocalTensor<float> denom = denomBuf_.Get<float>();
+        AscendC::LocalTensor<float> sigmoid = sigmoidBuf_.Get<float>();
+        AscendC::LocalTensor<float> tmp = tmpBuf_.Get<float>();
+        AscendC::Muls(denom, gate, -1.0f, count);
+        // Avoid inf * 0 in the Newton refinement for large negative gates.
+        AscendC::Mins(denom, denom, 80.0f, count);
+        AscendC::Exp(denom, denom, count);
+        AscendC::Adds(denom, denom, 1.0f, count);
+        AscendC::Reciprocal(sigmoid, denom, count);
+        // Refine the hardware reciprocal: r <- r * (2 - denom * r).
+        AscendC::Mul(tmp, denom, sigmoid, count);
+        AscendC::Muls(tmp, tmp, -1.0f, count);
+        AscendC::Adds(tmp, tmp, 2.0f, count);
+        AscendC::Mul(sigmoid, sigmoid, tmp, count);
+        return sigmoid;
+    }
+
+    __aicore__ inline void Compute(uint32_t count)
+    {
+        AscendC::LocalTensor<T> gate = gateQueue_.DeQue<T>();
+        AscendC::LocalTensor<T> up = upQueue_.DeQue<T>();
+        AscendC::LocalTensor<T> output = outputQueue_.AllocTensor<T>();
+        AscendC::LocalTensor<float> gateFp32 = ToFp32(gate, gateFp32Buf_, count);
+        AscendC::LocalTensor<float> upFp32 = ToFp32(up, upFp32Buf_, count);
+        AscendC::LocalTensor<float> sigmoid = Sigmoid(gateFp32, count);
+        AscendC::Mul(gateFp32, gateFp32, sigmoid, count);
+        AscendC::Mul(gateFp32, gateFp32, upFp32, count);
+        FromFp32(output, gateFp32, count);
+        outputQueue_.EnQue(output);
+        gateQueue_.FreeTensor(gate);
+        upQueue_.FreeTensor(up);
+    }
+
+    __aicore__ inline void CopyOut(int64_t offset, uint32_t count)
+    {
+        AscendC::LocalTensor<T> output = outputQueue_.DeQue<T>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(count * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPad(outputGm_[offset], output, copyParams);
+        outputQueue_.FreeTensor(output);
+    }
+
+    AscendC::TPipe* pipe_;
+    AscendC::GlobalTensor<T> gateGm_;
+    AscendC::GlobalTensor<T> upGm_;
+    AscendC::GlobalTensor<T> outputGm_;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> gateQueue_;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> upQueue_;
+    AscendC::TQue<AscendC::TPosition::VECOUT, 1> outputQueue_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> gateFp32Buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> upFp32Buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> denomBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> sigmoidBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> tmpBuf_;
+    int64_t numElements_;
+};
+
+template <typename T>
+class KernelSwiGLUBackward {
+public:
+    __aicore__ inline explicit KernelSwiGLUBackward(AscendC::TPipe* pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(GM_ADDR dy,
+                                GM_ADDR gate,
+                                GM_ADDR up,
+                                GM_ADDR dGate,
+                                GM_ADDR dUp,
+                                int64_t numElements)
+    {
+        numElements_ = numElements;
+        dyGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(dy));
+        gateGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(gate));
+        upGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(up));
+        dGateGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(dGate));
+        dUpGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(dUp));
+
+        const uint32_t tensorBytes = TILE_ELEMENTS * sizeof(T);
+        pipe_->InitBuffer(dyQueue_, 1, tensorBytes);
+        pipe_->InitBuffer(gateQueue_, 1, tensorBytes);
+        pipe_->InitBuffer(upQueue_, 1, tensorBytes);
+        pipe_->InitBuffer(dGateQueue_, 1, tensorBytes);
+        pipe_->InitBuffer(dUpQueue_, 1, tensorBytes);
+        if constexpr (!std::is_same_v<T, float>) {
+            pipe_->InitBuffer(dyFp32Buf_, TILE_ELEMENTS * sizeof(float));
+            pipe_->InitBuffer(gateFp32Buf_, TILE_ELEMENTS * sizeof(float));
+            pipe_->InitBuffer(upFp32Buf_, TILE_ELEMENTS * sizeof(float));
+        }
+        pipe_->InitBuffer(denomBuf_, TILE_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(sigmoidBuf_, TILE_ELEMENTS * sizeof(float));
+        pipe_->InitBuffer(tmpBuf_, TILE_ELEMENTS * sizeof(float));
+    }
+
+    __aicore__ inline void Process()
+    {
+        const int64_t blockCount = AscendC::GetBlockNum();
+        const int64_t unalignedSpan = (numElements_ + blockCount - 1) / blockCount;
+        const int64_t coreSpan =
+            (unalignedSpan + CORE_ALIGN_ELEMENTS - 1) / CORE_ALIGN_ELEMENTS * CORE_ALIGN_ELEMENTS;
+        const int64_t coreStart = static_cast<int64_t>(AscendC::GetBlockIdx()) * coreSpan;
+        if (coreStart >= numElements_) {
+            return;
+        }
+        const int64_t coreEnd = (coreStart + coreSpan < numElements_)
+            ? coreStart + coreSpan
+            : numElements_;
+        for (int64_t offset = coreStart; offset < coreEnd; offset += TILE_ELEMENTS) {
+            const uint32_t count = static_cast<uint32_t>(
+                (offset + TILE_ELEMENTS < coreEnd) ? TILE_ELEMENTS : coreEnd - offset);
+            CopyIn(offset, count);
+            Compute(count);
+            CopyOut(offset, count);
+        }
+    }
+
+private:
+    template <typename LocalT, typename GlobalT>
+    __aicore__ inline void CopyTensor(LocalT dst, GlobalT src, uint32_t count)
+    {
+        const uint32_t blockBytes = count * sizeof(T);
+        const uint32_t paddedBytes = (blockBytes + 31U) / 32U * 32U;
+        const uint8_t rightPad = static_cast<uint8_t>((paddedBytes - blockBytes) / sizeof(T));
+        AscendC::DataCopyExtParams copyParams{1, blockBytes, 0, 0, 0};
+        AscendC::DataCopyPadExtParams<T> padParams{true, 0, rightPad, static_cast<T>(0)};
+        AscendC::DataCopyPad(dst, src, copyParams, padParams);
+    }
+
+    __aicore__ inline void CopyIn(int64_t offset, uint32_t count)
+    {
+        AscendC::LocalTensor<T> dy = dyQueue_.AllocTensor<T>();
+        AscendC::LocalTensor<T> gate = gateQueue_.AllocTensor<T>();
+        AscendC::LocalTensor<T> up = upQueue_.AllocTensor<T>();
+        CopyTensor(dy, dyGm_[offset], count);
+        CopyTensor(gate, gateGm_[offset], count);
+        CopyTensor(up, upGm_[offset], count);
+        dyQueue_.EnQue(dy);
+        gateQueue_.EnQue(gate);
+        upQueue_.EnQue(up);
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float> ToFp32(
+        const AscendC::LocalTensor<T>& input,
+        AscendC::TBuf<AscendC::TPosition::VECCALC>& fp32Buf,
+        uint32_t count)
+    {
+        if constexpr (std::is_same_v<T, float>) {
+            return input;
+        } else {
+            AscendC::LocalTensor<float> output = fp32Buf.Get<float>();
+            AscendC::Cast(output, input, AscendC::RoundMode::CAST_NONE, count);
+            return output;
+        }
+    }
+
+    __aicore__ inline void FromFp32(
+        AscendC::LocalTensor<T> output,
+        const AscendC::LocalTensor<float>& input,
+        uint32_t count)
+    {
+        if constexpr (std::is_same_v<T, float>) {
+            AscendC::Muls(output, input, 1.0f, count);
+        } else if constexpr (std::is_same_v<T, bfloat16_t>) {
+            AscendC::Cast(output, input, AscendC::RoundMode::CAST_RINT, count);
+        } else {
+            AscendC::Cast(output, input, AscendC::RoundMode::CAST_ROUND, count);
+        }
+    }
+
+    __aicore__ inline AscendC::LocalTensor<float> Sigmoid(
+        const AscendC::LocalTensor<float>& gate, uint32_t count)
+    {
+        AscendC::LocalTensor<float> denom = denomBuf_.Get<float>();
+        AscendC::LocalTensor<float> sigmoid = sigmoidBuf_.Get<float>();
+        AscendC::LocalTensor<float> tmp = tmpBuf_.Get<float>();
+        AscendC::Muls(denom, gate, -1.0f, count);
+        AscendC::Mins(denom, denom, 80.0f, count);
+        AscendC::Exp(denom, denom, count);
+        AscendC::Adds(denom, denom, 1.0f, count);
+        AscendC::Reciprocal(sigmoid, denom, count);
+        AscendC::Mul(tmp, denom, sigmoid, count);
+        AscendC::Muls(tmp, tmp, -1.0f, count);
+        AscendC::Adds(tmp, tmp, 2.0f, count);
+        AscendC::Mul(sigmoid, sigmoid, tmp, count);
+        return sigmoid;
+    }
+
+    __aicore__ inline void Compute(uint32_t count)
+    {
+        AscendC::LocalTensor<T> dy = dyQueue_.DeQue<T>();
+        AscendC::LocalTensor<T> gate = gateQueue_.DeQue<T>();
+        AscendC::LocalTensor<T> up = upQueue_.DeQue<T>();
+        AscendC::LocalTensor<T> dGate = dGateQueue_.AllocTensor<T>();
+        AscendC::LocalTensor<T> dUp = dUpQueue_.AllocTensor<T>();
+        AscendC::LocalTensor<float> dyFp32 = ToFp32(dy, dyFp32Buf_, count);
+        AscendC::LocalTensor<float> gateFp32 = ToFp32(gate, gateFp32Buf_, count);
+        AscendC::LocalTensor<float> upFp32 = ToFp32(up, upFp32Buf_, count);
+        AscendC::LocalTensor<float> sigmoid = Sigmoid(gateFp32, count);
+        AscendC::LocalTensor<float> derivative = denomBuf_.Get<float>();
+        AscendC::LocalTensor<float> dUpFp32 = tmpBuf_.Get<float>();
+
+        // silu'(g) = sigmoid(g) * (1 + g * (1 - sigmoid(g))).
+        AscendC::Muls(derivative, sigmoid, -1.0f, count);
+        AscendC::Adds(derivative, derivative, 1.0f, count);
+        AscendC::Mul(derivative, derivative, gateFp32, count);
+        AscendC::Adds(derivative, derivative, 1.0f, count);
+        AscendC::Mul(derivative, derivative, sigmoid, count);
+
+        AscendC::Mul(dUpFp32, gateFp32, sigmoid, count);
+        AscendC::Mul(dUpFp32, dUpFp32, dyFp32, count);
+        AscendC::Mul(gateFp32, dyFp32, upFp32, count);
+        AscendC::Mul(gateFp32, gateFp32, derivative, count);
+        FromFp32(dGate, gateFp32, count);
+        FromFp32(dUp, dUpFp32, count);
+
+        dGateQueue_.EnQue(dGate);
+        dUpQueue_.EnQue(dUp);
+        dyQueue_.FreeTensor(dy);
+        gateQueue_.FreeTensor(gate);
+        upQueue_.FreeTensor(up);
+    }
+
+    __aicore__ inline void CopyOut(int64_t offset, uint32_t count)
+    {
+        AscendC::LocalTensor<T> dGate = dGateQueue_.DeQue<T>();
+        AscendC::LocalTensor<T> dUp = dUpQueue_.DeQue<T>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(count * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPad(dGateGm_[offset], dGate, copyParams);
+        AscendC::DataCopyPad(dUpGm_[offset], dUp, copyParams);
+        dGateQueue_.FreeTensor(dGate);
+        dUpQueue_.FreeTensor(dUp);
+    }
+
+    AscendC::TPipe* pipe_;
+    AscendC::GlobalTensor<T> dyGm_;
+    AscendC::GlobalTensor<T> gateGm_;
+    AscendC::GlobalTensor<T> upGm_;
+    AscendC::GlobalTensor<T> dGateGm_;
+    AscendC::GlobalTensor<T> dUpGm_;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> dyQueue_;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> gateQueue_;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> upQueue_;
+    AscendC::TQue<AscendC::TPosition::VECOUT, 1> dGateQueue_;
+    AscendC::TQue<AscendC::TPosition::VECOUT, 1> dUpQueue_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> dyFp32Buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> gateFp32Buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> upFp32Buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> denomBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> sigmoidBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> tmpBuf_;
+    int64_t numElements_;
+};
+
+}  // namespace
+
+#define DEFINE_SWIGLU_FORWARD_KERNEL(NAME, TYPE)                                               \
+    extern "C" __global__ __vector__ void NAME(                                              \
+        GM_ADDR gate, GM_ADDR up, GM_ADDR output, int64_t numElements)                         \
+    {                                                                                           \
+        AscendC::TPipe pipe;                                                                    \
+        KernelSwiGLUForward<TYPE> op(&pipe);                                                    \
+        op.Init(gate, up, output, numElements);                                                 \
+        op.Process();                                                                           \
+    }
+
+#define DEFINE_SWIGLU_BACKWARD_KERNEL(NAME, TYPE)                                              \
+    extern "C" __global__ __vector__ void NAME(GM_ADDR dy,                                   \
+                                                  GM_ADDR gate,                                 \
+                                                  GM_ADDR up,                                   \
+                                                  GM_ADDR dGate,                                \
+                                                  GM_ADDR dUp,                                  \
+                                                  int64_t numElements)                          \
+    {                                                                                           \
+        AscendC::TPipe pipe;                                                                    \
+        KernelSwiGLUBackward<TYPE> op(&pipe);                                                   \
+        op.Init(dy, gate, up, dGate, dUp, numElements);                                        \
+        op.Process();                                                                           \
+    }
+
+DEFINE_SWIGLU_FORWARD_KERNEL(swiglu_ascend_forward_kernel_fp32, float)
+DEFINE_SWIGLU_FORWARD_KERNEL(swiglu_ascend_forward_kernel_fp16, half)
+DEFINE_SWIGLU_FORWARD_KERNEL(swiglu_ascend_forward_kernel_bf16, bfloat16_t)
+DEFINE_SWIGLU_BACKWARD_KERNEL(swiglu_ascend_backward_kernel_fp32, float)
+DEFINE_SWIGLU_BACKWARD_KERNEL(swiglu_ascend_backward_kernel_fp16, half)
+DEFINE_SWIGLU_BACKWARD_KERNEL(swiglu_ascend_backward_kernel_bf16, bfloat16_t)
+
+namespace {
+
+void CheckActivationTensor(const torch::Tensor& tensor, const char* name)
+{
+    TORCH_CHECK(tensor.is_privateuseone(), name, " must be on an NPU device");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+    TORCH_CHECK(tensor.scalar_type() == at::kFloat || tensor.scalar_type() == at::kHalf ||
+                    tensor.scalar_type() == at::kBFloat16,
+                name, " must be fp32, fp16, or bf16");
+}
+
+uint32_t ActivationBlockCount(int64_t numElements)
+{
+    const int64_t targetSpan = (numElements + MAX_BLOCKS - 1) / MAX_BLOCKS;
+    const int64_t alignedSpan =
+        (targetSpan + CORE_ALIGN_ELEMENTS - 1) / CORE_ALIGN_ELEMENTS * CORE_ALIGN_ELEMENTS;
+    const int64_t usefulBlocks = (numElements + alignedSpan - 1) / alignedSpan;
+    return static_cast<uint32_t>(usefulBlocks);
+}
+
+}  // namespace
+
+torch::Tensor swiglu_ascend_forward(torch::Tensor gate, torch::Tensor up)
+{
+    CheckActivationTensor(gate, "gate");
+    CheckActivationTensor(up, "up");
+    TORCH_CHECK(gate.device() == up.device(), "gate and up must be on the same NPU device");
+    TORCH_CHECK(gate.sizes() == up.sizes(), "gate and up must share shape");
+    TORCH_CHECK(gate.scalar_type() == up.scalar_type(), "gate and up must share dtype");
+    torch::Tensor output = at::empty_like(gate);
+    const int64_t numElements = gate.numel();
+    if (numElements == 0) {
+        return output;
+    }
+
+    const c10::DeviceGuard deviceGuard(gate.device());
+    auto aclStream = c10_npu::getCurrentNPUStream().stream(true);
+    const uint32_t blockNum = ActivationBlockCount(numElements);
+    auto* gatePtr = reinterpret_cast<uint8_t*>(gate.mutable_data_ptr());
+    auto* upPtr = reinterpret_cast<uint8_t*>(up.mutable_data_ptr());
+    auto* outputPtr = reinterpret_cast<uint8_t*>(output.mutable_data_ptr());
+    if (gate.scalar_type() == at::kFloat) {
+        swiglu_ascend_forward_kernel_fp32<<<blockNum, nullptr, aclStream>>>(
+            gatePtr, upPtr, outputPtr, numElements);
+    } else if (gate.scalar_type() == at::kHalf) {
+        swiglu_ascend_forward_kernel_fp16<<<blockNum, nullptr, aclStream>>>(
+            gatePtr, upPtr, outputPtr, numElements);
+    } else {
+        swiglu_ascend_forward_kernel_bf16<<<blockNum, nullptr, aclStream>>>(
+            gatePtr, upPtr, outputPtr, numElements);
+    }
+    return output;
+}
+
+std::vector<torch::Tensor> swiglu_ascend_backward(
+    torch::Tensor dy, torch::Tensor gate, torch::Tensor up)
+{
+    CheckActivationTensor(dy, "dy");
+    CheckActivationTensor(gate, "gate");
+    CheckActivationTensor(up, "up");
+    TORCH_CHECK(dy.device() == gate.device() && up.device() == gate.device(),
+                "dy, gate, and up must be on the same NPU device");
+    TORCH_CHECK(dy.sizes() == gate.sizes() && up.sizes() == gate.sizes(),
+                "dy, gate, and up must share shape");
+    TORCH_CHECK(dy.scalar_type() == gate.scalar_type() &&
+                    up.scalar_type() == gate.scalar_type(),
+                "dy, gate, and up must share dtype");
+    torch::Tensor dGate = at::empty_like(gate);
+    torch::Tensor dUp = at::empty_like(up);
+    const int64_t numElements = gate.numel();
+    if (numElements == 0) {
+        return {dGate, dUp};
+    }
+
+    const c10::DeviceGuard deviceGuard(gate.device());
+    auto aclStream = c10_npu::getCurrentNPUStream().stream(true);
+    const uint32_t blockNum = ActivationBlockCount(numElements);
+    auto* dyPtr = reinterpret_cast<uint8_t*>(dy.mutable_data_ptr());
+    auto* gatePtr = reinterpret_cast<uint8_t*>(gate.mutable_data_ptr());
+    auto* upPtr = reinterpret_cast<uint8_t*>(up.mutable_data_ptr());
+    auto* dGatePtr = reinterpret_cast<uint8_t*>(dGate.mutable_data_ptr());
+    auto* dUpPtr = reinterpret_cast<uint8_t*>(dUp.mutable_data_ptr());
+    if (gate.scalar_type() == at::kFloat) {
+        swiglu_ascend_backward_kernel_fp32<<<blockNum, nullptr, aclStream>>>(
+            dyPtr, gatePtr, upPtr, dGatePtr, dUpPtr, numElements);
+    } else if (gate.scalar_type() == at::kHalf) {
+        swiglu_ascend_backward_kernel_fp16<<<blockNum, nullptr, aclStream>>>(
+            dyPtr, gatePtr, upPtr, dGatePtr, dUpPtr, numElements);
+    } else {
+        swiglu_ascend_backward_kernel_bf16<<<blockNum, nullptr, aclStream>>>(
+            dyPtr, gatePtr, upPtr, dGatePtr, dUpPtr, numElements);
+    }
+    return {dGate, dUp};
+}

--- a/docs/operators/activation.md
+++ b/docs/operators/activation.md
@@ -2,11 +2,12 @@
 
 The activation operators are the element-wise core of the Qwen3/Llama gated MLP. They
 implement the WS1 dual-path contract (issue #108): pure-PyTorch fp32 ground truth, plus
-CUDA and Triton candidates that validate against it.
+CUDA, Triton, and Ascend C candidates that validate against it.
 
 - **SiLU** (`NativeSiLUOp` / `SiLUCudaOp` / `TritonSiLUOp`): `silu(x) = x * sigmoid(x)` —
   the `hidden_act="silu"` gate.
-- **SwiGLU** (`NativeSwiGLUOp` / `SwiGLUCudaOp` / `TritonSwiGLUOp`):
+- **SwiGLU** (`NativeSwiGLUOp` / `SwiGLUCudaOp` / `TritonSwiGLUOp` /
+  `SwiGLUAscendOp`):
   `swiglu(gate, up) = silu(gate) * up` — the gated MLP middle stage. `gate` / `up` are the
   `gate_proj` / `up_proj` outputs (already at the intermediate width); the following
   `down_proj` is a plain Matmul and is **not** part of this operator.
@@ -44,6 +45,7 @@ All backends expose the WS1 dual-path contract:
 | PyTorch fallback | `NativeSiLUOp` / `NativeSwiGLUOp` | None | fp32 ground-truth reference; CPU and any GPU. |
 | CUDA | `SiLUCudaOp` / `SwiGLUCudaOp` | `_C.silu_*` / `_C.swiglu_*` | General CUDA (fp16/bf16/fp32); math in fp32. |
 | Triton | `TritonSiLUOp` / `TritonSwiGLUOp` | Triton JIT | Portable GPU baseline; same fp32 math contract. |
+| Ascend C | `SwiGLUAscendOp` | `_C_npu.swiglu_ascend_*` | NPU SwiGLU forward/backward (fp16/bf16/fp32); math in fp32. |
 
 ## Tensor Contract
 
@@ -67,9 +69,10 @@ mutation, device/dtype follow the inputs.
 | `cuda` | CUDA → Triton → PyTorch native |
 | `rocm` | Triton → PyTorch native |
 | `cpu` | PyTorch native |
+| `npu` | Ascend C SwiGLU → PyTorch native (SwiGLU); PyTorch native (SiLU) |
 
-If the CUDA extension is not built (or symbols are missing), the registry falls back to
-Triton, then to the native gold.
+If an accelerated extension is not built (or its symbols are missing), the registry moves
+to the next available candidate and ultimately falls back to the native gold.
 
 ## Accuracy
 
@@ -106,29 +109,34 @@ Gold path: `NativeSiLUOp.forward_fp32` / `NativeSwiGLUOp.forward_fp32`.
 
 ## Performance Notes
 
-Element-wise kernels with a fixed 1-D grid (CUDA) / `BLOCK=1024` (Triton). Suitable as the
-standalone WS1 activation path; fused bias+SiLU MLP kernels remain a separate future work
-item and should continue to validate against this reference.
+Element-wise kernels with a fixed 1-D grid (CUDA), `BLOCK=1024` (Triton), or aligned
+multi-core 1-D tiles of at most 5120 elements (Ascend C). Suitable as the standalone WS1
+activation path; fused bias+SiLU MLP kernels remain a separate future work item and should
+continue to validate against this reference.
 
 ## Tests
 
 ```bash
-python -m pytest tests/test_swiglu.py -v
+python -m pytest tests/test_swiglu.py tests/test_swiglu_ascend.py -v
 ```
 
 Covers: correctness vs an independent fp32 formula, dtype paths, Axis-A batch invariance
 (slice + padding), input purity, gradient flow, the SwiGLU shape guard, CUDA/Triton vs
-native forward+backward, registry dispatch, and the issue-#108 `OP_SPECS` harness.
+native forward+backward, Ascend C forward/backward and tail tiles when NPU hardware is
+available, registry dispatch, and the issue-#108 `OP_SPECS` harness.
 
 ## Implementation Files
 
 - `rl_engine/kernels/ops/pytorch/activation/swiglu.py` — gold
 - `rl_engine/kernels/ops/cuda/activation/swiglu.py` — CUDA wrappers
 - `rl_engine/kernels/ops/triton/activation/swiglu.py` — Triton kernels
+- `rl_engine/kernels/ops/ascend/activation/swiglu.py` — Ascend wrapper/autograd
 - `csrc/cuda/activation.cu` — CUDA kernels
+- `csrc/ascend/swiglu_ascend.asc` — Ascend C forward/backward kernels
 - `rl_engine/kernels/registry.py`
 - `rl_engine/kernels/gtest/operator_specs.py`
 - `tests/test_swiglu.py`
+- `tests/test_swiglu_ascend.py`
 
 ## Known Limitations
 

--- a/rl_engine/_C_npu.pyi
+++ b/rl_engine/_C_npu.pyi
@@ -8,3 +8,14 @@ def batch_invariant_logp_ascend(
     target: torch.Tensor,
     ignore_index: int,
 ) -> list[torch.Tensor]: ...
+
+def swiglu_ascend_forward(
+    gate: torch.Tensor,
+    up: torch.Tensor,
+) -> torch.Tensor: ...
+
+def swiglu_ascend_backward(
+    dy: torch.Tensor,
+    gate: torch.Tensor,
+    up: torch.Tensor,
+) -> list[torch.Tensor]: ...

--- a/rl_engine/kernels/gtest/operator_specs.py
+++ b/rl_engine/kernels/gtest/operator_specs.py
@@ -171,6 +171,7 @@ OP_SPECS = {
             "pytorch": "rl_engine.kernels.ops.pytorch.activation.swiglu.NativeSwiGLUOp",
             "triton": "rl_engine.kernels.ops.triton.activation.swiglu.TritonSwiGLUOp",
             "cuda": "rl_engine.kernels.ops.cuda.activation.swiglu.SwiGLUCudaOp",
+            "ascend": "rl_engine.kernels.ops.ascend.activation.swiglu.SwiGLUAscendOp",
         },
         grad_input_names=("gate", "up"),
     ),

--- a/rl_engine/kernels/ops/ascend/activation/__init__.py
+++ b/rl_engine/kernels/ops/ascend/activation/__init__.py
@@ -1,4 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
 
-from . import activation, loss  # noqa: F401
+from .swiglu import SwiGLUAscendOp
+
+__all__ = ["SwiGLUAscendOp"]

--- a/rl_engine/kernels/ops/ascend/activation/swiglu.py
+++ b/rl_engine/kernels/ops/ascend/activation/swiglu.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+"""Ascend C SwiGLU matching the WS1 FP32-compute activation contract."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from rl_engine.utils.logger import logger
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+_C_npu: Any = None
+try:
+    from rl_engine import _C_npu
+
+    _NPU_EXT_AVAILABLE = True
+except ImportError:  # pragma: no cover - Ascend extension not built
+    _NPU_EXT_AVAILABLE = False
+
+
+def _fallback_op():
+    from rl_engine.kernels.ops.pytorch.activation.swiglu import NativeSwiGLUOp
+
+    return NativeSwiGLUOp()
+
+
+def _validate_inputs(gate: Tensor, up: Tensor) -> None:
+    if gate.shape != up.shape:
+        raise ValueError(
+            f"gate and up must share shape, got tuple(gate.shape)={tuple(gate.shape)} "
+            f"vs tuple(up.shape)={tuple(up.shape)}"
+        )
+    if gate.device != up.device:
+        raise RuntimeError(
+            f"gate and up must be on the same device, got '{gate.device}' and '{up.device}'."
+        )
+    if gate.dtype not in _SUPPORTED_DTYPES or up.dtype not in _SUPPORTED_DTYPES:
+        raise TypeError(
+            f"gate and up must have dtype fp16, bf16, or fp32, got {gate.dtype} and {up.dtype}."
+        )
+    if gate.dtype != up.dtype:
+        raise TypeError(f"gate and up must share dtype, got {gate.dtype} and {up.dtype}.")
+
+
+class _SwiGLUAscendFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, gate: Tensor, up: Tensor) -> Tensor:
+        gate_c = gate.contiguous()
+        up_c = up.contiguous()
+        output = _C_npu.swiglu_ascend_forward(gate_c, up_c)
+        ctx.save_for_backward(gate_c, up_c)
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output: Tensor):
+        gate, up = ctx.saved_tensors
+        d_gate = d_up = None
+        if ctx.needs_input_grad[0] or ctx.needs_input_grad[1]:
+            grads = _C_npu.swiglu_ascend_backward(grad_output.contiguous(), gate, up)
+            if ctx.needs_input_grad[0]:
+                d_gate = grads[0]
+            if ctx.needs_input_grad[1]:
+                d_up = grads[1]
+        return d_gate, d_up
+
+
+class SwiGLUAscendOp:
+    """Ascend C SwiGLU: ``silu(gate) * up``, with FP32 arithmetic."""
+
+    op_class = "elementwise"
+
+    def __init__(self) -> None:
+        required = ("swiglu_ascend_forward", "swiglu_ascend_backward")
+        if not _NPU_EXT_AVAILABLE or any(not hasattr(_C_npu, name) for name in required):
+            raise RuntimeError(
+                "Ascend SwiGLU kernels are not compiled into the extension. Rebuild with "
+                "KERNEL_ALIGN_FORCE_ASCEND=1 on an Ascend NPU host: 'pip install -e .'"
+            )
+        logger.info("Successfully linked to precompiled _C_npu SwiGLU kernels.")
+
+    def __call__(self, gate: Tensor, up: Tensor) -> Tensor:
+        return self.forward(gate, up)
+
+    def forward(self, gate: Tensor, up: Tensor) -> Tensor:
+        _validate_inputs(gate, up)
+        if gate.device.type != "npu":
+            return _fallback_op().forward(gate, up)
+        return _SwiGLUAscendFunction.apply(gate, up)
+
+    def forward_fp32(self, gate: Tensor, up: Tensor) -> Tensor:
+        _validate_inputs(gate, up)
+        if gate.device.type != "npu":
+            return _fallback_op().forward_fp32(gate, up)
+        return _SwiGLUAscendFunction.apply(gate.float(), up.float())

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -77,6 +77,7 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     ASCEND_BATCH_INVARIANT_LOGP = (
         "rl_engine.kernels.ops.ascend.loss.batch_invariant_logp.BatchInvariantLogpAscendOp"
     )
+    ASCEND_SWIGLU = "rl_engine.kernels.ops.ascend.activation.swiglu.SwiGLUAscendOp"
 
     # RMSNorm(pre-norm / QK-Norm) - pure Pytorch reference(ws1 ground-truth)
     PYTORCH_NATIVE_RMS_NORM = "rl_engine.kernels.ops.pytorch.norm.rms_norm.NativeRMSNormOp"
@@ -299,6 +300,10 @@ class KernelRegistry:
         self._priority_map["npu"]["batch_invariant_logp"] = [
             OpBackend.ASCEND_BATCH_INVARIANT_LOGP,
             OpBackend.PYTORCH_BATCH_INVARIANT_LOGP,
+        ]
+        self._priority_map["npu"]["swiglu"] = [
+            OpBackend.ASCEND_SWIGLU,
+            OpBackend.PYTORCH_NATIVE_SWIGLU,
         ]
         logger.info(f"KernelRegistry initialized for {device_ctx.device_type}")
         self._adjust_priority_for_hardware()

--- a/rl_engine/tests/test_dispatch.py
+++ b/rl_engine/tests/test_dispatch.py
@@ -90,6 +90,10 @@ def test_npu_registry_preserves_per_operator_cpu_fallbacks(monkeypatch):
         OpBackend.ASCEND_BATCH_INVARIANT_LOGP,
         OpBackend.PYTORCH_BATCH_INVARIANT_LOGP,
     ]
+    assert registry._priority_map["npu"]["swiglu"] == [
+        OpBackend.ASCEND_SWIGLU,
+        OpBackend.PYTORCH_NATIVE_SWIGLU,
+    ]
 
 
 def test_npu_available_handles_runtime_failure(monkeypatch):

--- a/tests/test_swiglu_ascend.py
+++ b/tests/test_swiglu_ascend.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Ascend C SwiGLU coverage: contracts on CPU and kernels on available NPUs."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from rl_engine.kernels.gtest.operator_specs import OP_SPECS
+from rl_engine.kernels.ops.pytorch.activation.swiglu import NativeSwiGLUOp
+from rl_engine.platforms.device import _npu_available
+
+
+def _ascend_kernel_available() -> bool:
+    if not _npu_available():
+        return False
+    try:
+        from rl_engine.kernels.ops.ascend.activation.swiglu import (
+            _C_npu,
+            _NPU_EXT_AVAILABLE,
+        )
+    except Exception:
+        return False
+    return _NPU_EXT_AVAILABLE and all(
+        hasattr(_C_npu, name) for name in ("swiglu_ascend_forward", "swiglu_ascend_backward")
+    )
+
+
+requires_ascend = pytest.mark.skipif(
+    not _ascend_kernel_available(),
+    reason="Ascend C SwiGLU kernels are not compiled "
+    "(needs KERNEL_ALIGN_FORCE_ASCEND=1 on an Ascend NPU host).",
+)
+
+
+def _op():
+    from rl_engine.kernels.ops.ascend.activation.swiglu import SwiGLUAscendOp
+
+    return SwiGLUAscendOp()
+
+
+def _rand(shape, *, seed: int, dtype: torch.dtype, device: str = "npu") -> torch.Tensor:
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    return torch.randn(shape, generator=generator).to(device=device, dtype=dtype)
+
+
+def _tolerance(dtype: torch.dtype) -> tuple[float, float]:
+    if dtype is torch.float32:
+        return 1e-5, 1e-5
+    if dtype is torch.float16:
+        return 1e-3, 1e-3
+    if dtype is torch.bfloat16:
+        return 2e-2, 1.6e-2
+    raise ValueError(f"unsupported dtype: {dtype}")
+
+
+def test_swiglu_ascend_candidate_is_registered():
+    path = OP_SPECS["swiglu"].candidate_paths["ascend"]
+    assert path.endswith(".SwiGLUAscendOp")
+
+
+def test_swiglu_ascend_validation_is_available_without_an_npu():
+    from rl_engine.kernels.ops.ascend.activation.swiglu import _validate_inputs
+
+    with pytest.raises(ValueError, match="share shape"):
+        _validate_inputs(torch.ones(2, 3), torch.ones(2, 4))
+    with pytest.raises(TypeError, match="share dtype"):
+        _validate_inputs(torch.ones(8, dtype=torch.float16), torch.ones(8, dtype=torch.bfloat16))
+    with pytest.raises(TypeError, match="fp16, bf16, or fp32"):
+        _validate_inputs(torch.ones(8, dtype=torch.int32), torch.ones(8, dtype=torch.int32))
+
+
+@requires_ascend
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("shape", [(63,), (2, 3, 257), (2, 12288)])
+def test_swiglu_ascend_forward_matches_native(dtype: torch.dtype, shape: tuple[int, ...]):
+    gate = _rand(shape, seed=1, dtype=dtype)
+    up = _rand(shape, seed=2, dtype=dtype)
+
+    actual = _op().forward(gate, up)
+    expected = NativeSwiGLUOp().forward_fp32(gate.cpu(), up.cpu())
+
+    atol, rtol = _tolerance(dtype)
+    assert actual.dtype is dtype
+    torch.testing.assert_close(actual.cpu().float(), expected, atol=atol, rtol=rtol)
+
+
+@requires_ascend
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_swiglu_ascend_backward_matches_native(dtype: torch.dtype):
+    shape = (2, 3, 257)
+    gate_cpu = _rand(shape, seed=3, dtype=dtype, device="cpu")
+    up_cpu = _rand(shape, seed=4, dtype=dtype, device="cpu")
+    dy_cpu = _rand(shape, seed=5, dtype=dtype, device="cpu")
+
+    gate_ref = gate_cpu.float().requires_grad_(True)
+    up_ref = up_cpu.float().requires_grad_(True)
+    NativeSwiGLUOp().forward_fp32(gate_ref, up_ref).backward(dy_cpu.float())
+
+    gate = gate_cpu.to(device="npu").requires_grad_(True)
+    up = up_cpu.to(device="npu").requires_grad_(True)
+    _op().forward(gate, up).backward(dy_cpu.to(device="npu"))
+
+    atol, rtol = _tolerance(dtype)
+    torch.testing.assert_close(gate.grad.cpu().float(), gate_ref.grad, atol=atol, rtol=rtol)
+    torch.testing.assert_close(up.grad.cpu().float(), up_ref.grad, atol=atol, rtol=rtol)
+
+
+@requires_ascend
+def test_swiglu_ascend_extreme_finite_gates_do_not_produce_nan():
+    gate = torch.tensor([-100.0, -90.0, 0.0, 90.0, 100.0], device="npu")
+    up = torch.ones_like(gate)
+
+    actual = _op().forward(gate, up)
+    expected = NativeSwiGLUOp().forward_fp32(gate.cpu(), up.cpu())
+
+    assert torch.isfinite(actual).all()
+    torch.testing.assert_close(actual.cpu(), expected, atol=1e-5, rtol=1e-5)
+
+
+@requires_ascend
+def test_swiglu_ascend_batch_and_padding_invariance_forward_backward():
+    dtype = torch.bfloat16
+    gate = _rand((7, 4, 64), seed=6, dtype=dtype)
+    up = _rand((7, 4, 64), seed=7, dtype=dtype)
+    dy = _rand(gate.shape, seed=8, dtype=dtype)
+
+    gate_full = gate.detach().clone().requires_grad_(True)
+    up_full = up.detach().clone().requires_grad_(True)
+    output_full = _op().forward(gate_full, up_full)
+    output_full.backward(dy)
+
+    gate_real = gate[:4].detach().clone().requires_grad_(True)
+    up_real = up[:4].detach().clone().requires_grad_(True)
+    output_real = _op().forward(gate_real, up_real)
+    output_real.backward(dy[:4])
+
+    assert torch.equal(output_full[:4], output_real)
+    assert torch.equal(gate_full.grad[:4], gate_real.grad)
+    assert torch.equal(up_full.grad[:4], up_real.grad)
+
+
+@requires_ascend
+def test_swiglu_ascend_handles_noncontiguous_and_empty_inputs():
+    gate = torch.randn(5, 3, device="npu", dtype=torch.bfloat16).T.requires_grad_(True)
+    up = torch.randn(5, 3, device="npu", dtype=torch.bfloat16).T.requires_grad_(True)
+    assert not gate.is_contiguous() and not up.is_contiguous()
+    _op().forward(gate, up).sum().backward()
+    assert gate.grad is not None and up.grad is not None
+
+    empty_gate = torch.empty((0, 64), device="npu", dtype=torch.bfloat16, requires_grad=True)
+    empty_up = torch.empty_like(empty_gate, requires_grad=True)
+    output = _op().forward(empty_gate, empty_up)
+    output.sum().backward()
+    assert output.shape == empty_gate.shape
+    assert empty_gate.grad.shape == empty_gate.shape
+    assert empty_up.grad.shape == empty_up.shape


### PR DESCRIPTION
Title:

feat(ascend): add SwiGLU operator

## Summary

- Add Ascend C forward and backward kernels for SwiGLU.
- Support FP32, FP16, and BF16 inputs with FP32 intermediate computation.
- Implement aligned multi-core 1D tiling, non-aligned tail handling, and empty tensor support.
- Improve numerical stability with bounded sigmoid evaluation and reciprocal refinement.
- Integrate the kernels with `_C_npu`, PyTorch Autograd, NPU dispatch, and `OP_SPECS`.
- Add Ascend-specific tests and update the operator documentation.

## Operator Definition

```text
y      = silu(gate) * up
d_up   = dy * silu(gate)
d_gate = dy * up * sigmoid(gate)
         * (1 + gate * (1 - sigmoid(gate)))
```

`gate` and `up` must have the same shape, dtype, and device.

## Supported Data Types

- FP32
- FP16
- BF16

Activation and gradient calculations are performed in FP32, with results cast back to the input dtype.

## Dispatch

SwiGLU dispatch priority on NPU:

```text
Ascend C SwiGLU → PyTorch Native SwiGLU
```

## Testing

```text
73 passed, 95 skipped
```

The tests cover:

- Forward and backward accuracy
- FP32, FP16, and BF16 inputs
- Non-aligned tail tiles
- Batch and padding invariance
- Non-contiguous tensors
- Empty tensors
- Shape and dtype validation
- Registry and operator specification integration
