### PR TITLE
feat(ascend): add prefix-shared attention Ascend C kernel

### DIFF
--- a/csrc/ascend/attention/prefix_shared_attention_ascend.asc
+++ b/csrc/ascend/attention/prefix_shared_attention_ascend.asc
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+//
+// Prefix-shared fused attention, Ascend C (CANN) forward kernel.
+//
+//   out = softmax(Q K^T * scale) @ V
+//
+// Mirrors the CUDA kernel in csrc/cuda/attention/prefix_shared_attention.cu
+// (the GRPO decode workload): every one of the G query groups attends over
+// the same shared prompt-prefix key/value sequence, so K and V are stored
+// once per batch instead of once per group.
+//   - layout  : q [bs, G, len_q, D], k/v [bs, len_kv, D] contiguous, D = 128
+//   - numerics: bf16 in/out; fp32 online-softmax accumulation (per-row max /
+//               sum-exp rescale per key tile), the same flash-style single
+//               pass as the CUDA kernel; no causal mask, no key-padding mask
+//               (same surface as the CUDA op).
+//   - blocking: each (bs, g, 64-row query block) is processed end-to-end by
+//               one AI-core block over fixed 64-key tiles. The per-row
+//               reduction order depends only on len_kv, so row outputs are
+//               batch-invariant: they never depend on batch size, batch
+//               position, or how many blocks were launched (items are strided
+//               across blocks).
+//
+// Build: see setup.py (AscendBuildExtension, bisheng -x asc), gated by
+// KERNEL_ALIGN_FORCE_ASCEND=1. Requires CANN toolkit + torch_npu.
+// Python bindings live in csrc/ascend/ops_npu.asc (single PYBIND11_MODULE).
+
+#include <algorithm>
+#include <type_traits>
+
+#include "kernel_operator.h"
+
+#include <torch/extension.h>
+
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+
+namespace {
+
+// Fixed head dimension (matches the CUDA op gate).
+constexpr uint32_t HEAD_DIM = 128;
+// Query rows per block (CUDA BLOCK_Q).
+constexpr uint32_t BLOCK_Q = 64;
+// Keys per tile (CUDA BLOCK_KV). Fixed for all runs; this is what makes the
+// per-row reduction order batch-invariant.
+constexpr uint32_t TILE_N = 64;
+// 1/sqrt(HEAD_DIM); matches the CUDA kernel's rsqrtf(dim) softmax scale.
+constexpr float SCALE = 0.088388348f;
+// Cap on launched blocks. Work items are strided across blocks, so launching
+// fewer blocks than items is fine and never changes per-row numerics.
+constexpr int64_t MAX_BLOCKS = 512;
+constexpr float NEG_INF = -3.402823466e+38f;  // -FLT_MAX
+
+template <typename T>
+class KernelPrefixSharedAttention {
+public:
+    __aicore__ inline KernelPrefixSharedAttention(AscendC::TPipe* pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(GM_ADDR q,
+                                GM_ADDR k,
+                                GM_ADDR v,
+                                GM_ADDR out,
+                                int64_t bs,
+                                int64_t G,
+                                int64_t lenQ,
+                                int64_t lenKv)
+    {
+        bs_ = bs;
+        G_ = G;
+        lenQ_ = lenQ;
+        lenKv_ = lenKv;
+        qGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(q));
+        kGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(k));
+        vGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(v));
+        outGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(out));
+
+        // UB budget stays well under 192 KB:
+        //   q/k/v/acc fp32 tiles 4 x 32 KB + bf16 staging 16 KB
+        //   + prod/work/scores/state/scalar ~2 KB.
+        pipe_->InitBuffer(qBufF_, BLOCK_Q * HEAD_DIM * sizeof(float));
+        pipe_->InitBuffer(kBufF_, TILE_N * HEAD_DIM * sizeof(float));
+        pipe_->InitBuffer(vBufF_, TILE_N * HEAD_DIM * sizeof(float));
+        pipe_->InitBuffer(accBufF_, BLOCK_Q * HEAD_DIM * sizeof(float));
+        pipe_->InitBuffer(bufT_, BLOCK_Q * HEAD_DIM * sizeof(T));
+        pipe_->InitBuffer(prodBufF_, HEAD_DIM * sizeof(float));
+        pipe_->InitBuffer(workBufF_, HEAD_DIM * sizeof(float));
+        pipe_->InitBuffer(scoresBuf_, TILE_N * sizeof(float));
+        pipe_->InitBuffer(rowMaxBuf_, BLOCK_Q * sizeof(float));
+        pipe_->InitBuffer(rowSumExpBuf_, BLOCK_Q * sizeof(float));
+        // 64 B: floats [0,8) hold the per-row online-softmax rescale exp.
+        pipe_->InitBuffer(scalarBuf_, 64);
+
+        // Intra-core pipeline events. NOTE: AscendC::SyncAll() is a cross-core
+        // barrier and deadlocks when more blocks are launched than there are
+        // physical cores (resident blocks wait for unscheduled ones), so all
+        // synchronization here uses per-pipe SetFlag/WaitFlag instead.
+        eventVS_ = pipe_->FetchEventID(AscendC::HardEvent::V_S);
+        eventSV_ = pipe_->FetchEventID(AscendC::HardEvent::S_V);
+        eventMTE2S_ = pipe_->FetchEventID(AscendC::HardEvent::MTE2_S);
+        eventVMTE2_ = pipe_->FetchEventID(AscendC::HardEvent::V_MTE2);
+        eventVMTE3_ = pipe_->FetchEventID(AscendC::HardEvent::V_MTE3);
+        eventMTE3S_ = pipe_->FetchEventID(AscendC::HardEvent::MTE3_S);
+    }
+
+    __aicore__ inline void Process()
+    {
+        const int64_t qBlocks = (lenQ_ + BLOCK_Q - 1) / BLOCK_Q;
+        const int64_t items = bs_ * G_ * qBlocks;
+        for (int64_t item = AscendC::GetBlockIdx(); item < items;
+             item += AscendC::GetBlockNum()) {
+            const int64_t qb = item % qBlocks;
+            const int64_t g = (item / qBlocks) % G_;
+            const int64_t b = item / (qBlocks * G_);
+            ProcessBlock(b, g, qb);
+        }
+    }
+
+private:
+    __aicore__ inline void LoadQTile(int64_t b, int64_t g, int64_t rowStart, uint32_t numRows)
+    {
+        const int64_t offset = ((b * G_ + g) * lenQ_ + rowStart) * HEAD_DIM;
+        AscendC::LocalTensor<T> qT = bufT_.Get<T>();
+        AscendC::DataCopyExtParams cp{
+            1, static_cast<uint32_t>(numRows * HEAD_DIM * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<T> pp{false, 0, 0, 0};
+        AscendC::DataCopyPad(qT, qGm_[offset], cp, pp);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        AscendC::Cast(qBufF_.Get<float>(), qT, AscendC::RoundMode::CAST_NONE,
+                      numRows * HEAD_DIM);
+    }
+
+    __aicore__ inline void LoadKTile(int64_t b, int64_t start, uint32_t count)
+    {
+        // bufT_ staging may hold data the vector pipe is still reading (the
+        // Q cast or the previous tile's V cast).
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventVMTE2_);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventVMTE2_);
+        const int64_t offset = (b * lenKv_ + start) * HEAD_DIM;
+        AscendC::LocalTensor<T> kT = bufT_.Get<T>();
+        AscendC::DataCopyExtParams cp{
+            1, static_cast<uint32_t>(count * HEAD_DIM * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<T> pp{false, 0, 0, 0};
+        AscendC::DataCopyPad(kT, kGm_[offset], cp, pp);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        AscendC::Cast(kBufF_.Get<float>(), kT, AscendC::RoundMode::CAST_NONE,
+                      count * HEAD_DIM);
+    }
+
+    __aicore__ inline void LoadVTile(int64_t b, int64_t start, uint32_t count)
+    {
+        // bufT_ staging may hold data the vector pipe is still reading (the
+        // K cast of this tile).
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE2>(eventVMTE2_);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE2>(eventVMTE2_);
+        const int64_t offset = (b * lenKv_ + start) * HEAD_DIM;
+        AscendC::LocalTensor<T> vT = bufT_.Get<T>();
+        AscendC::DataCopyExtParams cp{
+            1, static_cast<uint32_t>(count * HEAD_DIM * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<T> pp{false, 0, 0, 0};
+        AscendC::DataCopyPad(vT, vGm_[offset], cp, pp);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        AscendC::Cast(vBufF_.Get<float>(), vT, AscendC::RoundMode::CAST_NONE,
+                      count * HEAD_DIM);
+    }
+
+    // Online-softmax step for query row r over one 64-key tile: recompute the
+    // row max, rescale the running (sum-exp, accumulator), then fold the tile
+    // into both with P = exp(scores - mNew) and P . V.
+    __aicore__ inline void ProcessRowTile(uint32_t r, uint32_t count)
+    {
+        AscendC::LocalTensor<float> qRow = qBufF_.Get<float>()[r * HEAD_DIM];
+        AscendC::LocalTensor<float> accRow = accBufF_.Get<float>()[r * HEAD_DIM];
+        AscendC::LocalTensor<float> kTile = kBufF_.Get<float>();
+        AscendC::LocalTensor<float> vTile = vBufF_.Get<float>();
+        AscendC::LocalTensor<float> scores = scoresBuf_.Get<float>();
+        AscendC::LocalTensor<float> prod = prodBufF_.Get<float>();
+        AscendC::LocalTensor<float> work = workBufF_.Get<float>();
+        AscendC::LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        AscendC::LocalTensor<float> rowMax = rowMaxBuf_.Get<float>();
+        AscendC::LocalTensor<float> rowSumExp = rowSumExpBuf_.Get<float>();
+
+        // scores[j] = SCALE * (q_r . k_j) for j in [0, count); past-the-end
+        // lanes become NEG_INF so they drop out of max/exp exactly.
+        for (uint32_t j = 0; j < count; ++j) {
+            AscendC::Mul(prod, qRow, kTile[j * HEAD_DIM], HEAD_DIM);
+            AscendC::ReduceSum<float, true>(scalar, prod, work, HEAD_DIM);
+            WaitVector();
+            scores.SetValue(j, scalar.GetValue(0) * SCALE);
+        }
+        for (uint32_t j = count; j < TILE_N; ++j) {
+            scores.SetValue(j, NEG_INF);
+        }
+
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(eventSV_);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(eventSV_);
+        AscendC::ReduceMax<float>(scalar, scores, work, TILE_N, false);
+        WaitVector();
+        const float mOld = rowMax.GetValue(r);
+        const float tileMax = scalar.GetValue(0);
+        const float mNew = mOld > tileMax ? mOld : tileMax;
+
+        // rescale = exp(mOld - mNew), computed through the vector Exp (aicore
+        // scalar code has no expf); 0 on the first tile, where mOld == NEG_INF.
+        scalar.SetValue(0, mOld - mNew);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(eventSV_);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(eventSV_);
+        AscendC::Exp(scalar, scalar, 8);
+        WaitVector();
+        const float rescale = scalar.GetValue(0);
+
+        // p[j] = exp(scores[j] - mNew); past-the-end lanes stay exp(-inf) = 0.
+        AscendC::Adds(scores, scores, -mNew, TILE_N);
+        AscendC::Exp(scores, scores, TILE_N);
+        AscendC::ReduceSum<float, true>(scalar, scores, work, TILE_N);
+        WaitVector();
+        const float tileSumExp = scalar.GetValue(0);
+
+        rowMax.SetValue(r, mNew);
+        rowSumExp.SetValue(r, rowSumExp.GetValue(r) * rescale + tileSumExp);
+
+        // acc_r *= rescale, then acc_r += sum_j p[j] * v_j. p[j] == 0 exactly
+        // on past-the-end lanes, and adding a zero term is a no-op, so the
+        // skip below is exact.
+        AscendC::Muls(accRow, accRow, rescale, HEAD_DIM);
+        for (uint32_t j = 0; j < count; ++j) {
+            const float pj = scores.GetValue(j);
+            if (pj == 0.0f) {
+                continue;
+            }
+            AscendC::Muls(prod, vTile[j * HEAD_DIM], pj, HEAD_DIM);
+            AscendC::Add(accRow, accRow, prod, HEAD_DIM);
+        }
+    }
+
+    __aicore__ inline void ProcessBlock(int64_t b, int64_t g, int64_t qb)
+    {
+        const int64_t rowStart = qb * BLOCK_Q;
+        const int64_t remaining = lenQ_ - rowStart;
+        const uint32_t numRows = static_cast<uint32_t>(remaining < BLOCK_Q ? remaining : BLOCK_Q);
+
+        LoadQTile(b, g, rowStart, numRows);
+
+        // Real zeroing: the buffers start as uninitialized UB and
+        // 0 * inf == NaN in the online-softmax rescale.
+        AscendC::Duplicate(accBufF_.Get<float>(), 0.0f, numRows * HEAD_DIM);
+        AscendC::Duplicate(rowMaxBuf_.Get<float>(), NEG_INF, numRows);
+        AscendC::Duplicate(rowSumExpBuf_.Get<float>(), 0.0f, numRows);
+
+        const int64_t numTiles = (lenKv_ + TILE_N - 1) / TILE_N;
+        for (int64_t tile = 0; tile < numTiles; ++tile) {
+            const int64_t start = tile * TILE_N;
+            const uint32_t count = TileCount(start);
+            LoadKTile(b, start, count);
+            LoadVTile(b, start, count);
+            for (uint32_t r = 0; r < numRows; ++r) {
+                ProcessRowTile(r, count);
+            }
+        }
+        WriteOutputs(b, g, rowStart, numRows);
+    }
+
+    __aicore__ inline void WriteOutputs(int64_t b, int64_t g, int64_t rowStart, uint32_t numRows)
+    {
+        AscendC::LocalTensor<float> acc = accBufF_.Get<float>();
+        AscendC::LocalTensor<float> rowSumExp = rowSumExpBuf_.Get<float>();
+        AscendC::LocalTensor<T> outT = bufT_.Get<T>();
+
+        // out_r = acc_r / sumExp_r, then one bf16 cast and one copy-out for
+        // the whole contiguous row block. sumExp > 0 always (every block
+        // attends over at least one real key; len_kv >= 1 is host-checked),
+        // the guard just mirrors the CUDA op's defensive division.
+        for (uint32_t r = 0; r < numRows; ++r) {
+            const float sumExp = rowSumExp.GetValue(r);
+            const float invDenom = (sumExp > 0.0f) ? (1.0f / sumExp) : 0.0f;
+            AscendC::Muls(acc[r * HEAD_DIM], acc[r * HEAD_DIM], invDenom, HEAD_DIM);
+        }
+
+        AscendC::Cast(outT, acc, AscendC::RoundMode::CAST_ROUND, numRows * HEAD_DIM);
+        AscendC::SetFlag<AscendC::HardEvent::V_MTE3>(eventVMTE3_);
+        AscendC::WaitFlag<AscendC::HardEvent::V_MTE3>(eventVMTE3_);
+        const int64_t offset = ((b * G_ + g) * lenQ_ + rowStart) * HEAD_DIM;
+        AscendC::DataCopyExtParams outCp{
+            1, static_cast<uint32_t>(numRows * HEAD_DIM * sizeof(T)), 0, 0, 0};
+        // UB -> GM has no pad-params overload (CANN 8.5.1): the row block is
+        // always contiguous, so no padding is needed anyway.
+        AscendC::DataCopyPad(outGm_[offset], outT, outCp);
+        // Drain MTE3 before the next block stages new values into the shared
+        // buffers; the scalar pipe issues all later MTE2 copies in order, so
+        // this wait alone orders them after the copy-out.
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_S>(eventMTE3S_);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_S>(eventMTE3S_);
+    }
+
+    // Wait until all outstanding vector-pipe results are readable as scalars.
+    __aicore__ inline void WaitVector()
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(eventVS_);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(eventVS_);
+    }
+
+    __aicore__ inline uint32_t TileCount(int64_t start) const
+    {
+        const int64_t remaining = lenKv_ - start;
+        return static_cast<uint32_t>(remaining < TILE_N ? remaining : TILE_N);
+    }
+
+    AscendC::TPipe* pipe_;
+    AscendC::GlobalTensor<T> qGm_;
+    AscendC::GlobalTensor<T> kGm_;
+    AscendC::GlobalTensor<T> vGm_;
+    AscendC::GlobalTensor<T> outGm_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> qBufF_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> kBufF_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> vBufF_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> accBufF_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> bufT_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> prodBufF_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> workBufF_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> scoresBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> rowMaxBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> rowSumExpBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> scalarBuf_;
+    AscendC::TEventID eventVS_;
+    AscendC::TEventID eventSV_;
+    AscendC::TEventID eventMTE2S_;
+    AscendC::TEventID eventVMTE2_;
+    AscendC::TEventID eventVMTE3_;
+    AscendC::TEventID eventMTE3S_;
+    int64_t bs_;
+    int64_t G_;
+    int64_t lenQ_;
+    int64_t lenKv_;
+};
+
+}  // namespace
+
+extern "C" __global__ __vector__ void prefix_shared_attention_ascend_kernel_bf16(
+    GM_ADDR q, GM_ADDR k, GM_ADDR v, GM_ADDR out,
+    int64_t bs, int64_t G, int64_t lenQ, int64_t lenKv)
+{
+    AscendC::TPipe pipe;
+    KernelPrefixSharedAttention<bfloat16_t> op(&pipe);
+    op.Init(q, k, v, out, bs, G, lenQ, lenKv);
+    op.Process();
+}
+
+torch::Tensor prefix_shared_attention_ascend_forward(
+    torch::Tensor q,
+    torch::Tensor k,
+    torch::Tensor v)
+{
+    TORCH_CHECK(q.is_privateuseone() && k.is_privateuseone() && v.is_privateuseone(),
+                "q, k, v must be on an NPU device");
+    TORCH_CHECK(q.dim() == 4 && k.dim() == 3 && v.dim() == 3,
+                "q must be 4-D [bs, G, len_q, D]; k and v must be 3-D [bs, len_kv, D]");
+    TORCH_CHECK(q.is_contiguous() && k.is_contiguous() && v.is_contiguous(),
+                "q, k, v must be contiguous");
+    TORCH_CHECK(q.scalar_type() == at::kBFloat16 &&
+                k.scalar_type() == at::kBFloat16 && v.scalar_type() == at::kBFloat16,
+                "prefix-shared attention requires bf16 (matches the CUDA op)");
+    TORCH_CHECK(q.size(3) == HEAD_DIM && k.size(2) == HEAD_DIM && v.size(2) == HEAD_DIM,
+                "head dim D must be 128");
+    TORCH_CHECK(q.size(0) == k.size(0) && q.size(0) == v.size(0),
+                "batch size mismatch between q/k/v");
+    TORCH_CHECK(k.size(1) == v.size(1), "k/v must share the same key length");
+    TORCH_CHECK(q.size(2) >= 1 && k.size(1) >= 1, "len_q and len_kv must be positive");
+
+    const int64_t bs = q.size(0);
+    const int64_t G = q.size(1);
+    const int64_t lenQ = q.size(2);
+    const int64_t lenKv = k.size(1);
+
+    torch::Tensor out = at::empty({bs, G, lenQ, HEAD_DIM}, q.options());
+
+    // stream(true): flush the task queue before launch so the kernel cannot
+    // overtake earlier NPU work; the output was allocated with at::empty (no
+    // queued initializer) for the same reason.
+    auto aclStream = c10_npu::getCurrentNPUStream().stream(true);
+    const int64_t qBlocks = (lenQ + BLOCK_Q - 1) / BLOCK_Q;
+    const int64_t items = bs * G * qBlocks;
+    const uint32_t blockNum = static_cast<uint32_t>(std::min(items, MAX_BLOCKS));
+    prefix_shared_attention_ascend_kernel_bf16<<<blockNum, nullptr, aclStream>>>(
+        reinterpret_cast<uint8_t*>(q.mutable_data_ptr()),
+        reinterpret_cast<uint8_t*>(k.mutable_data_ptr()),
+        reinterpret_cast<uint8_t*>(v.mutable_data_ptr()),
+        reinterpret_cast<uint8_t*>(out.mutable_data_ptr()),
+        bs, G, lenQ, lenKv);
+    return out;
+}

--- a/csrc/ascend/npu_module.cpp
+++ b/csrc/ascend/npu_module.cpp
@@ -22,6 +22,9 @@ std::vector<torch::Tensor> deterministic_attention_ascend_forward(
     double scale,
     c10::optional<torch::Tensor> key_padding_mask);
 
+torch::Tensor prefix_shared_attention_ascend_forward(
+    torch::Tensor q, torch::Tensor k, torch::Tensor v);
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
 {
     m.def("batch_invariant_logp_ascend",
@@ -33,4 +36,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("deterministic_attention_ascend",
           &deterministic_attention_ascend_forward,
           "Deterministic batch-invariant standard-softmax attention (Ascend C forward)");
+    m.def("prefix_shared_attention_ascend",
+          &prefix_shared_attention_ascend_forward,
+          "Prefix-shared fused attention (Ascend C forward)");
 }

--- a/rl_engine/_C_npu.pyi
+++ b/rl_engine/_C_npu.pyi
@@ -25,3 +25,9 @@ def deterministic_attention_ascend(
     scale: float,
     key_padding_mask: torch.Tensor | None,
 ) -> list[torch.Tensor]: ...
+
+def prefix_shared_attention_ascend(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> torch.Tensor: ...

--- a/rl_engine/kernels/gtest/operator_inputs.py
+++ b/rl_engine/kernels/gtest/operator_inputs.py
@@ -31,6 +31,7 @@ def make_operator_inputs(
         "matmul": _make_matmul_inputs,
         "det_gemm": _make_det_gemm_inputs,
         "attention": _make_attention_inputs,
+        "prefix_shared_attention": _make_prefix_shared_attention_inputs,
         "cp_attention": _make_cp_attention_inputs,
         "logp": _make_logp_inputs,
         "linear_logp": _make_linear_logp_inputs,
@@ -59,6 +60,8 @@ def operator_shape_name(op_name: str, args: argparse.Namespace) -> str:
         "matmul": f"{batch}x{seq}x{_matmul_k(args)}x{_matmul_n(args)}",
         "det_gemm": f"{batch}x{seq}x{_matmul_k(args)}x{_matmul_n(args)}",
         "attention": f"{batch}x{DEFAULT_N_HEADS}x{seq}x{DEFAULT_HEAD_DIM}",
+        "prefix_shared_attention": f"{batch}x{_arg_int(args, 'n_heads', DEFAULT_N_HEADS)}"
+        f"x{seq}x{DEFAULT_HEAD_DIM}",
         "cp_attention": f"{batch}x{DEFAULT_N_HEADS}x{seq}x{DEFAULT_HEAD_DIM}xcp2",
         "logp": f"{batch}x{seq}x{vocab}",
         "linear_logp": f"{batch}x{seq}x{_normalized_dim(args)}x{vocab}",
@@ -175,6 +178,20 @@ def _make_attention_inputs(
         inputs["key_padding_mask"] = key_padding_mask
 
     return inputs
+
+
+def _make_prefix_shared_attention_inputs(
+    args: argparse.Namespace, dtype: torch.dtype, device: torch.device
+) -> dict[str, Any]:
+    """Prefix-shared layout: k/v are 3-D [B, Skv, D] shared by all G groups."""
+    batch, seq = _batch_seq(args)
+    skv = _arg_int(args, "skv", seq)
+    n_groups = _arg_int(args, "n_heads", DEFAULT_N_HEADS)
+    return {
+        "q": _floating_tensor((batch, n_groups, seq, DEFAULT_HEAD_DIM), args, dtype, device, 0),
+        "k": _floating_tensor((batch, skv, DEFAULT_HEAD_DIM), args, dtype, device, 1),
+        "v": _floating_tensor((batch, skv, DEFAULT_HEAD_DIM), args, dtype, device, 2),
+    }
 
 
 def _make_cp_attention_inputs(

--- a/rl_engine/kernels/gtest/operator_specs.py
+++ b/rl_engine/kernels/gtest/operator_specs.py
@@ -80,6 +80,26 @@ OP_SPECS = {
         },
         grad_input_names=("q", "k", "v"),
     ),
+    # GRPO decode: every G group attends over one shared K/V sequence
+    # ([B, Skv, D] instead of [B, Hkv, Skv, D]). Forward-only (no backward),
+    # same surface as the CUDA PrefixSharedAttentionOp.
+    "prefix_shared_attention": OperatorSpec(
+        name="prefix_shared_attention",
+        op_class="attention",
+        gold_path="rl_engine.kernels.gtest.operator_specs.GtestPrefixSharedAttentionOp",
+        gold_method="forward_fp32",
+        candidate_paths={
+            "pytorch": "rl_engine.kernels.gtest.operator_specs.GtestPrefixSharedAttentionOp",
+            "cuda": (
+                "rl_engine.kernels.ops.cuda.attention.prefix_shared_attn."
+                "PrefixSharedAttentionOp"
+            ),
+            "ascend": (
+                "rl_engine.kernels.ops.ascend.attention.prefix_shared_attn."
+                "PrefixSharedAttentionAscendOp"
+            ),
+        },
+    ),
     "cp_attention": OperatorSpec(
         name="cp_attention",
         op_class="attention",
@@ -246,6 +266,26 @@ class GtestPackOp:
     def forward_fp32(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
         packed, _cu_seqlens = self._op(x.float(), mask)
         return packed
+
+
+class GtestPrefixSharedAttentionOp:
+    """gtest view of the prefix-shared layout: expand the shared K/V over the
+    G groups and reuse the standard fp32 attention reference (non-causal,
+    default scale), which is the gold for the CUDA/Ascend prefix-shared ops.
+    """
+
+    op_class = "attention"
+
+    def __init__(self) -> None:
+        from rl_engine.kernels.ops.pytorch.attention.standard_attn import NativeAttentionOp
+
+        self._op = NativeAttentionOp()
+
+    def __call__(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        return self._op(q, k.unsqueeze(1), v.unsqueeze(1), causal=False)
+
+    def forward_fp32(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> torch.Tensor:
+        return self._op.forward_fp32(q, k.unsqueeze(1), v.unsqueeze(1), causal=False)
 
 
 class _LogpSM90CandidateAdapter:

--- a/rl_engine/kernels/ops/ascend/attention/__init__.py
+++ b/rl_engine/kernels/ops/ascend/attention/__init__.py
@@ -2,5 +2,8 @@
 # Copyright (c) 2026 RL-Kernel Contributors
 
 from rl_engine.kernels.ops.ascend.attention.deterministic_attn import DeterministicAttentionAscendOp
+from rl_engine.kernels.ops.ascend.attention.prefix_shared_attn import (
+    PrefixSharedAttentionAscendOp,
+)
 
-__all__ = ["DeterministicAttentionAscendOp"]
+__all__ = ["DeterministicAttentionAscendOp", "PrefixSharedAttentionAscendOp"]

--- a/rl_engine/kernels/ops/ascend/attention/prefix_shared_attn.py
+++ b/rl_engine/kernels/ops/ascend/attention/prefix_shared_attn.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Ascend NPU prefix-shared fused attention (GRPO decode workload).
+
+Port of the CUDA op in rl_engine/kernels/ops/cuda/attention/prefix_shared_attn.py:
+in GRPO, the G generated responses share the exact same prompt-prefix KV cache,
+so K/V are stored once per batch and broadcast across all G query groups.
+
+Forward: softmax(Q K^T * scale) @ V on an Ascend C kernel
+(`_C_npu.prefix_shared_attention_ascend`) with fp32 online-softmax
+accumulation. bf16 in/out, non-causal, no key-padding mask, head dim fixed at
+128 -- the same surface as the CUDA `PrefixSharedAttentionOp`, which is
+forward-only and so is this port.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from rl_engine.utils.logger import logger
+
+_C_npu: Any = None
+try:
+    from rl_engine import _C_npu
+
+    _NPU_EXT_AVAILABLE = True
+except ImportError:  # pragma: no cover - Ascend extension not built
+    _NPU_EXT_AVAILABLE = False
+
+_HEAD_DIM = 128
+
+
+class PrefixSharedAttentionAscendOp:
+    """Prefix-shared softmax attention on Ascend NPU.
+
+    q [bs, G, len_q, D] attends over a single shared k/v sequence
+    [bs, len_kv, D] that every G group reuses. Mirrors the CUDA
+    ``PrefixSharedAttentionOp`` surface (``op(q, k, v) -> out``).
+    """
+
+    def __init__(self) -> None:
+        if not _NPU_EXT_AVAILABLE or not hasattr(_C_npu, "prefix_shared_attention_ascend"):
+            raise RuntimeError(
+                "prefix_shared_attention_ascend is not compiled into the extension. "
+                "Rebuild with KERNEL_ALIGN_FORCE_ASCEND=1 on an Ascend NPU host: "
+                "'pip install -e .'"
+            )
+        logger.info(
+            "Successfully linked to precompiled _C_npu.prefix_shared_attention_ascend kernel."
+        )
+
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        """
+        Prefix-shared attention forward pass.
+
+        Args:
+            q: Query tensor of shape [bs, G, len_q, head_dim]
+            k: Shared Key tensor of shape [bs, len_kv, head_dim]
+            v: Shared Value tensor of shape [bs, len_kv, head_dim]
+
+        Returns:
+            Output tensor of shape [bs, G, len_q, head_dim]
+        """
+        return self.forward(q, k, v)
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        self._validate_inputs(q, k, v)
+        return _C_npu.prefix_shared_attention_ascend(
+            q.contiguous(), k.contiguous(), v.contiguous()
+        )
+
+    @staticmethod
+    def _validate_inputs(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor) -> None:
+        if q.dim() != 4 or k.dim() != 3 or v.dim() != 3:
+            raise ValueError(
+                f"q must be 4-D [B, G, Sq, D] and k/v 3-D [B, Skv, D], got "
+                f"q={tuple(q.shape)}, k={tuple(k.shape)}, v={tuple(v.shape)}"
+            )
+        b, g, sq, d = q.shape
+        skv = k.shape[1]
+        if k.shape[0] != b or v.shape[0] != b:
+            raise ValueError("batch size mismatch between q/k/v")
+        if k.shape[2] != d or v.shape[2] != d:
+            raise ValueError(
+                f"k/v head dim mismatch: k={tuple(k.shape)}, v={tuple(v.shape)}, "
+                f"expected D={d}"
+            )
+        if v.shape[1] != skv:
+            raise ValueError(
+                f"k/v key length mismatch: k={tuple(k.shape)}, v={tuple(v.shape)}"
+            )
+        if d != _HEAD_DIM:
+            raise ValueError(f"head dim D must be {_HEAD_DIM}, got {d}")
+        if q.dtype != torch.bfloat16 or k.dtype != torch.bfloat16 or v.dtype != torch.bfloat16:
+            raise ValueError(
+                f"only BF16 is supported (matches the CUDA op), got "
+                f"q={q.dtype}, k={k.dtype}, v={v.dtype}"
+            )
+        if not (
+            q.device.type == "npu" and k.device.type == "npu" and v.device.type == "npu"
+        ):
+            raise ValueError("q, k, v must be NPU tensors")
+        if sq < 1 or skv < 1:
+            raise ValueError(f"Sq and Skv must be positive, got Sq={sq}, Skv={skv}")
+        if g < 1:
+            raise ValueError(f"G must be positive, got G={g}")

--- a/scripts/check_operator.py
+++ b/scripts/check_operator.py
@@ -56,6 +56,17 @@ def _select_device(value: str) -> torch.device:
     device = torch.device(value)
     if device.type == "cuda" and not torch.cuda.is_available():
         raise RuntimeError("--device cuda was requested, but CUDA is not available")
+    if device.type == "npu":
+        # torch.npu only exists after torch_npu is imported (mirrors the
+        # defensive probe in rl_engine.platforms.device).
+        try:
+            import torch_npu  # noqa: F401
+        except ImportError as exc:
+            raise RuntimeError(
+                "--device npu was requested, but torch_npu is not installed"
+            ) from exc
+        if not torch.npu.is_available():
+            raise RuntimeError("--device npu was requested, but no NPU is available")
     return device
 
 

--- a/tests/test_prefix_shared_attention_ascend.py
+++ b/tests/test_prefix_shared_attention_ascend.py
@@ -1,0 +1,250 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Tests for the Ascend NPU prefix-shared fused attention.
+
+Validates the same properties as the CUDA prefix-shared op:
+1. **Correctness** - output matches the ``NativeAttentionOp.forward_fp32``
+   ground truth (full softmax over the shared K/V, no causal mask) within the
+   reduction tolerances.
+2. **Batch-invariance** - a query row's output is bitwise identical regardless
+   of batch size, batch position, or how many AI-core blocks were launched
+   (each (bs, g, 64-row block) item is processed end-to-end by one block).
+"""
+
+import math
+
+import pytest
+import torch
+
+from rl_engine.kernels.ops.pytorch.attention.standard_attn import NativeAttentionOp
+
+_D = 128
+
+# Accuracy tolerance from the gtest contract, "attention" op class.
+_ATOL = {torch.bfloat16: 5.0e-2}
+_RTOL = {torch.bfloat16: 2.0e-2}
+
+
+def _npu_available() -> bool:
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(torch, "npu") and torch.npu.is_available()
+
+
+def _ascend_kernel_available() -> bool:
+    if not _npu_available():
+        return False
+    try:
+        from rl_engine.kernels.ops.ascend.attention.prefix_shared_attn import (
+            _C_npu,
+            _NPU_EXT_AVAILABLE,
+        )
+    except Exception:
+        return False
+    return _NPU_EXT_AVAILABLE and hasattr(_C_npu, "prefix_shared_attention_ascend")
+
+
+requires_ascend = pytest.mark.skipif(
+    not _ascend_kernel_available(),
+    reason="prefix_shared_attention_ascend kernel not compiled "
+    "(needs KERNEL_ALIGN_FORCE_ASCEND=1 on an Ascend NPU host).",
+)
+
+
+def _get_op():
+    from rl_engine.kernels.ops.ascend.attention.prefix_shared_attn import (
+        PrefixSharedAttentionAscendOp,
+    )
+
+    return PrefixSharedAttentionAscendOp()
+
+
+def _gold(q, k, v):
+    """fp32 ground truth: softmax(Q K^T / sqrt(D)) V over the shared K/V."""
+    return NativeAttentionOp().forward_fp32(
+        q,
+        k.unsqueeze(1),  # [bs, 1, Skv, D]: every G group shares the same KV head
+        v.unsqueeze(1),
+        causal=False,
+        scale=1.0 / math.sqrt(_D),
+    )
+
+
+def _make_qkv(batch, groups, sq, skv, dtype, seed=0):
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    q = torch.randn(batch, groups, sq, _D, dtype=dtype, generator=generator).to("npu")
+    k = torch.randn(batch, skv, _D, dtype=dtype, generator=generator).to("npu")
+    v = torch.randn(batch, skv, _D, dtype=dtype, generator=generator).to("npu")
+    return q, k, v
+
+
+# ---------------------------------------------------------------------------
+# Correctness
+# ---------------------------------------------------------------------------
+
+
+@requires_ascend
+class TestAscendPrefixSharedAttentionCorrectness:
+    def test_basic(self):
+        op = _get_op()
+        q, k, v = _make_qkv(2, 4, 65, 130, torch.bfloat16)  # ragged Sq/Skv
+        out = op(q, k, v)
+        gold = _gold(q, k, v)
+        assert out.dtype == torch.bfloat16
+        assert out.shape == (2, 4, 65, _D)
+        assert torch.allclose(
+            out.float(), gold, atol=_ATOL[torch.bfloat16], rtol=_RTOL[torch.bfloat16]
+        )
+
+    def test_exact_tiles(self):
+        op = _get_op()
+        q, k, v = _make_qkv(2, 8, 64, 64, torch.bfloat16)  # one Q block, one KV tile
+        out = op(q, k, v)
+        gold = _gold(q, k, v)
+        assert torch.allclose(
+            out.float(), gold, atol=_ATOL[torch.bfloat16], rtol=_RTOL[torch.bfloat16]
+        )
+
+    def test_decode_window(self):
+        op = _get_op()
+        q, k, v = _make_qkv(1, 16, 1, 512, torch.bfloat16)  # Sq << Skv, 8 KV tiles
+        out = op(q, k, v)
+        gold = _gold(q, k, v)
+        assert torch.allclose(
+            out.float(), gold, atol=_ATOL[torch.bfloat16], rtol=_RTOL[torch.bfloat16]
+        )
+
+    def test_long_prefix_multi_tile(self):
+        op = _get_op()
+        q, k, v = _make_qkv(1, 2, 32, 1024, torch.bfloat16)  # 16 KV tiles
+        out = op(q, k, v)
+        gold = _gold(q, k, v)
+        assert torch.allclose(
+            out.float(), gold, atol=_ATOL[torch.bfloat16], rtol=_RTOL[torch.bfloat16]
+        )
+
+    def test_shared_kv_across_groups(self):
+        # Every G group attends over the exact same K/V; a G-sweep must match
+        # the per-group reference (and be bitwise equal across G for equal q).
+        op = _get_op()
+        q, k, v = _make_qkv(1, 4, 32, 96, torch.bfloat16)
+        q[0, 1, :, :] = q[0, 0, :, :]  # force identical query rows in 2 groups
+        out = op(q, k, v)
+        assert torch.equal(out[0, 0], out[0, 1])
+        gold = _gold(q, k, v)
+        assert torch.allclose(
+            out.float(), gold, atol=_ATOL[torch.bfloat16], rtol=_RTOL[torch.bfloat16]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Batch invariance
+# ---------------------------------------------------------------------------
+
+
+@requires_ascend
+class TestAscendPrefixSharedAttentionBatchInvariance:
+    def test_batch_size_1_vs_n(self):
+        # The same (b=0, g=0, row 0) content computed alone vs embedded in a
+        # larger batch must be bitwise identical. (Content is copied in
+        # explicitly: CPU bf16 randn consumes two fp32 draws per element, so
+        # same-seed tensors of different batch sizes would not line up.)
+        dtype = torch.bfloat16
+        op = _get_op()
+        q1, k1, v1 = _make_qkv(1, 4, 64, 64, dtype, seed=7)
+        alone = op(q1, k1, v1)[0, 0, 0, :].clone()
+        for batch in (2, 4, 8):
+            q, k, v = _make_qkv(batch, 4, 64, 64, dtype, seed=7)
+            q[0, 0, 0, :] = q1[0, 0, 0, :]
+            k[0, :, :] = k1[0, :, :]
+            v[0, :, :] = v1[0, :, :]
+            in_batch = op(q, k, v)[0, 0, 0, :].clone()
+            assert torch.equal(alone, in_batch), f"drift at batch_size={batch}"
+
+    def test_different_positions_in_batch(self):
+        # One fixed query row embedded at several positions (spanning both
+        # 64-row query blocks) must give the bitwise-identical output at each.
+        dtype = torch.bfloat16
+        op = _get_op()
+        q1, k1, v1 = _make_qkv(1, 1, 1, 64, dtype, seed=11)
+        baseline = op(q1, k1, v1)[0, 0, 0, :].clone()
+        q, k, v = _make_qkv(2, 4, 128, 64, dtype, seed=11)
+        k[0, :, :] = k1[0, :, :]
+        v[0, :, :] = v1[0, :, :]
+        for pos in (0, 63, 64, 127):
+            q[0, 0, pos, :] = q1[0, 0, 0, :]
+        out = op(q, k, v)
+        for pos in (0, 63, 64, 127):
+            assert torch.equal(baseline, out[0, 0, pos, :]), f"drift at position={pos}"
+
+    def test_block_striding(self):
+        # The strided run below has 8 * 16 * (320/64) = 640 work items >
+        # MAX_BLOCKS (512), so items are strided across blocks; numerics must
+        # not depend on block assignment. The 1-item run and the strided run
+        # must give the bitwise-identical rows for the same content.
+        dtype = torch.bfloat16
+        op = _get_op()
+        small_q, small_k, small_v = _make_qkv(1, 1, 64, 64, dtype, seed=3)
+        small = op(small_q, small_k, small_v)
+        big_q, big_k, big_v = _make_qkv(8, 16, 320, 64, dtype, seed=3)
+        big_q[0, 0, :64, :] = small_q[0, 0, :, :]
+        big_k[0, :, :] = small_k[0, :, :]
+        big_v[0, :, :] = small_v[0, :, :]
+        big = op(big_q, big_k, big_v)
+        assert torch.equal(big[0, 0, :64, :], small[0, 0, :, :])
+
+    def test_repeated_runs_deterministic(self):
+        dtype = torch.bfloat16
+        q, k, v = _make_qkv(2, 4, 128, 128, dtype, seed=5)
+        op = _get_op()
+        first = op(q, k, v)
+        for _ in range(3):
+            again = op(q, k, v)
+            assert torch.equal(first, again)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+@requires_ascend
+class TestAscendPrefixSharedAttentionValidation:
+    def test_rejects_fp32(self):
+        op = _get_op()
+        q, k, v = _make_qkv(1, 4, 32, 32, torch.float32)
+        with pytest.raises(ValueError, match="only BF16"):
+            op(q, k, v)
+
+    def test_rejects_fp16(self):
+        op = _get_op()
+        q, k, v = _make_qkv(1, 4, 32, 32, torch.float16)
+        with pytest.raises(ValueError, match="only BF16"):
+            op(q, k, v)
+
+    def test_rejects_bad_head_dim(self):
+        op = _get_op()
+        q = torch.randn(1, 4, 32, 64, device="npu", dtype=torch.bfloat16)
+        k = torch.randn(1, 32, 64, device="npu", dtype=torch.bfloat16)
+        v = torch.randn(1, 32, 64, device="npu", dtype=torch.bfloat16)
+        with pytest.raises(ValueError, match="head dim D must be 128"):
+            op(q, k, v)
+
+    def test_rejects_4d_kv(self):
+        op = _get_op()
+        q = torch.randn(1, 4, 32, 128, device="npu", dtype=torch.bfloat16)
+        k = torch.randn(1, 1, 32, 128, device="npu", dtype=torch.bfloat16)
+        v = torch.randn(1, 1, 32, 128, device="npu", dtype=torch.bfloat16)
+        with pytest.raises(ValueError, match="k/v 3-D"):
+            op(q, k, v)
+
+    def test_rejects_kv_length_mismatch(self):
+        op = _get_op()
+        q = torch.randn(1, 4, 32, 128, device="npu", dtype=torch.bfloat16)
+        k = torch.randn(1, 32, 128, device="npu", dtype=torch.bfloat16)
+        v = torch.randn(1, 64, 128, device="npu", dtype=torch.bfloat16)
+        with pytest.raises(ValueError, match="key length mismatch"):
+            op(q, k, v)

--- a/tests/test_ws1_gtest_gpu.py
+++ b/tests/test_ws1_gtest_gpu.py
@@ -48,6 +48,7 @@ def test_all_ws1_single_ops_are_registered():
         "swiglu",
         "pack",
         "linear_logp",
+        "prefix_shared_attention",
     } <= names
 
 


### PR DESCRIPTION
## Latest Status [25 Aug 2026]

Will fix CI error then mark as ready for review

## Summary

Port of the CUDA prefix-shared fused attention (`csrc/cuda/attention/prefix_shared_attention.cu`, the GRPO decode workload) to an Ascend NPU version:

- **Forward** is implemented as an Ascend C (CANN) kernel, `_C_npu.prefix_shared_attention_ascend`:
  - Layout `q [bs, G, len_q, 128]`, `k/v [bs, len_kv, 128]` — the G generated responses share one prompt-prefix KV sequence, stored once per batch instead of once per group (same surface as the CUDA `PrefixSharedAttentionOp`: bf16 only, D=128, non-causal, no key-padding mask, forward-only).
  - Each `(bs, g, 64-row query block)` is processed end-to-end by one AI-core block, streaming the keys in a **fixed 64-key tile order** with **fp32 online-softmax** accumulation (per-row max / sum-exp rescaling per tile — the same flash-style single pass as the CUDA kernel).
  - **No split-K and no cross-block summary merge**, so the per-row reduction order depends only on `len_kv` — outputs are batch-invariant: bitwise identical regardless of batch size, batch position, or how many blocks were launched (items are strided across blocks).
  - UB budget ~146 KB < 192 KB. Correctness-first pure vector-unit implementation (one dot product per key); the CUBE Q·Kᵀ path is left for future work, same as the deterministic attention kernel in PR #320.

- **Integration**:
  - gtest spec `prefix_shared_attention` (op class `attention`, reusing its tolerance contract) with `pytorch` / `cuda` / `ascend` candidates and a `GtestPrefixSharedAttentionOp` gold that expands the shared K/V over G and reuses `NativeAttentionOp.forward_fp32` (non-causal, default scale).
  - `scripts/check_operator.py` learns `--device npu` (defensive `torch_npu` probe) so the ascend candidates run in the gtest harness on NPU hosts.
  - `setup.py` `.asc` glob changed to recursive `**/*.asc`, allowing kernels to follow the CUDA-style directory structure under `csrc/ascend/attention/`.

### Build notes (same pattern as PR #320)

Each `.asc` source file can define only one `PYBIND11_MODULE`, because linking multiple sources with Bisheng causes a duplicate `PyInit__C_npu` error. Therefore pybind registrations are consolidated in `csrc/ascend/ops_npu.asc` (logp + prefix-shared attention), while individual kernel files contain only the kernel and host forward functions.

## Files

| Path | Status |
| --- | --- |
| `csrc/ascend/attention/prefix_shared_attention_ascend.asc` | Ascend C forward kernel (bf16, fp32 online softmax, fixed 64-key tile order, one block per (bs, g, query block)). New. |
| `csrc/ascend/ops_npu.asc` | Aggregated `_C_npu` pybind registration file (logp + prefix-shared attention). New. |
| `csrc/ascend/batch_invariant_logp_ascend.asc` | Only removes `PYBIND11_MODULE`, which is moved to the aggregated registration file. Kernel logic is unchanged. |
| `rl_engine/kernels/ops/ascend/attention/prefix_shared_attn.py` | `PrefixSharedAttentionAscendOp` wrapper, same surface as the CUDA `PrefixSharedAttentionOp` (`op(q, k, v) -> out`) with bf16/D=128 validation. New. |
| `rl_engine/kernels/ops/ascend/attention/__init__.py` | Package exports. New. |
| `rl_engine/kernels/gtest/operator_specs.py` | Adds the `prefix_shared_attention` spec (pytorch/cuda/ascend candidates) and the `GtestPrefixSharedAttentionOp` gold. |
| `rl_engine/kernels/gtest/operator_inputs.py` | Adds the prefix-shared input maker and shape name. |
| `scripts/check_operator.py` | `--device npu` support (defensive `torch_npu` probe). |
| `tests/test_prefix_shared_attention_ascend.py` | Ascend unit tests for correctness / batch invariance / validation. New. |
| `tests/test_ws1_gtest_gpu.py` | Adds `prefix_shared_attention` to the registered-ops coverage set. |
| `setup.py` | Changes the `.asc` glob to `**/*.asc`. |

## Test

Build first (same as PR #320):

```bash
source /usr/local/Ascend/ascend-toolkit/set_env.sh
export KERNEL_ALIGN_FORCE_ASCEND=1
pip install -e . --no-build-isolation --no-deps
```

### gtest

```bash
python scripts/check_operator.py --op prefix_shared_attention --candidate ascend --device npu --dtype bf16 --batch 2 --seq 64
python scripts/check_operator.py --op prefix_shared_attention --candidate pytorch --device npu --dtype bf16 --batch 2 --seq 64
python scripts/check_operator.py --op batch_invariant_logp --candidate ascend --device npu --dtype bf16
```

### pytest

```bash
python -m pytest tests/test_prefix_shared_attention_ascend.py -v
python -m pytest tests/test_batch_invariant_logp.py -v
```

## Test results

Environment: 8× Ascend 910, CANN 8.5.1 (Bisheng), torch 2.7.1 + torch_npu 2.7.1.

| Test | Result |
| --- | --- |
| gtest prefix_shared_attention ascend bf16 (forward) | ✅ `suite=prefix_shared_attention passed=True pass_rate=1.0000` |
| gtest prefix_shared_attention pytorch bf16 (gold wiring) | ✅ `suite=prefix_shared_attention passed=True pass_rate=1.0000` |
| gtest batch_invariant_logp ascend bf16 (regression) | ✅ `suite=batch_invariant_logp passed=True pass_rate=1.0000` |
| pytest `tests/test_prefix_shared_attention_ascend.py` | ✅ 14 passed |
| pytest `tests/test_batch_invariant_logp.py` (regression) | ✅ 44 passed, 42 skipped (non-NPU backends) |

<details>

<summary>gtest: prefix_shared_attention ascend bf16 (raw)</summary>

```
INFO 08-25 14:19:47 [RL-Kernel]: Successfully linked to precompiled _C_npu.prefix_shared_attention_ascend kernel.
suite=prefix_shared_attention passed=True pass_rate=1.0000
candidate=ascend-prefix_shared_attention backend=ascend passed=True pass_rate=1.0000
  case=prefix_shared_attention-torch.bfloat16-2x32x64x128 output=0 shape=(2, 32, 64, 128) dtype=torch.bfloat16 max_abs=3.89850140e-03 mean_abs=2.17124965e-04 max_rel=9.33131874e-02 tol=(atol=5.000e-02, rtol=2.000e-02) passed=True
```

</details>

<details>

<summary>gtest: prefix_shared_attention pytorch bf16 (raw)</summary>

```
suite=prefix_shared_attention passed=True pass_rate=1.0000
candidate=pytorch-prefix_shared_attention backend=pytorch passed=True pass_rate=1.0000
  case=prefix_shared_attention-torch.bfloat16-2x32x64x128 output=0 shape=(2, 32, 64, 128) dtype=torch.bfloat16 max_abs=1.66380405e-02 mean_abs=6.89244305e-04 max_rel=2.99679004e+03 tol=(atol=5.000e-02, rtol=2.000e-02) passed=True
```

</details>

<details>

<summary>gtest: batch_invariant_logp ascend bf16 regression (raw)</summary>

```
INFO 08-25 14:20:07 [RL-Kernel]: Successfully linked to precompiled _C_npu.batch_invariant_logp_ascend kernel.
/home/ma-user/work/z84450661/rl-kernel/rl_engine/kernels/ops/pytorch/loss/batch_invariant_logp.py:105: UserWarning: Cannot create tensor with interal format while allow_internel_format=False, tensor will be created with base format. (Triggered internally at build/CMakeFiles/torch_npu.dir/compiler_depend.ts:335.)
  selected_logp = selected_logp.where(valid_mask, torch.zeros_like(selected_logp))
suite=batch_invariant_logp passed=True pass_rate=1.0000
candidate=ascend-batch_invariant_logp backend=ascend passed=True pass_rate=1.0000
  case=batch_invariant_logp-torch.bfloat16-2x16x257 output=0 shape=(2, 16) dtype=torch.float32 max_abs=4.76837158e-07 mean_abs=1.49011612e-08 max_rel=7.54759455e-08 tol=(atol=6.000e-02, rtol=0.000e+00) passed=True
```

</details>

<details>

<summary>pytest: tests/test_prefix_shared_attention_ascend.py (raw)</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.10.20, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/ma-user/work/z84450661/rl-kernel
configfile: pyproject.toml
collecting ... collected 14 items

tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionCorrectness::test_basic PASSED [  7%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionCorrectness::test_exact_tiles PASSED [ 14%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionCorrectness::test_decode_window PASSED [ 21%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionCorrectness::test_long_prefix_multi_tile PASSED [ 28%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionCorrectness::test_shared_kv_across_groups PASSED [ 35%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionBatchInvariance::test_batch_size_1_vs_n PASSED [ 42%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionBatchInvariance::test_different_positions_in_batch PASSED [ 50%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionBatchInvariance::test_block_striding PASSED [ 57%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionBatchInvariance::test_repeated_runs_deterministic PASSED [ 64%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionValidation::test_rejects_fp32 PASSED [ 71%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionValidation::test_rejects_fp16 PASSED [ 78%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionValidation::test_rejects_bad_head_dim PASSED [ 85%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionValidation::test_rejects_4d_kv PASSED [ 92%]
tests/test_prefix_shared_attention_ascend.py::TestAscendPrefixSharedAttentionValidation::test_rejects_kv_length_mismatch PASSED [100%]

============================== 14 passed in 5.81s ==============================
```

</details>

<details>

<summary>pytest: tests/test_batch_invariant_logp.py regression (summary)</summary>

```
================== 44 passed, 42 skipped, 1 warning in 6.37s ===================
```

(all `TestAscend*` classes passed; skips are CUDA/Triton-only tests on this NPU host)

</details>

## Notes

- Single-device operator; no CP/SP or other communication. Scope is consistent with the CUDA `PrefixSharedAttentionOp`.
- The op is not added to the kernel registry dispatch: the CUDA `PrefixSharedAttentionOp` is consumed directly (e.g. `benchmarks/benchmark_attention.py`) and is not registered either; the Ascend op follows the same surface.
- `ruff check` passes for all modified Python files.
