### PR TITLE
[Runtime][TP2 CP2] Publish strict bitwise runtime and user modes

### DIFF
--- a/csrc/cuda/activation.cu
+++ b/csrc/cuda/activation.cu
@@ -93,6 +93,47 @@ __global__ void swiglu_backward_kernel(
   d_gate[idx] = static_cast<scalar_t>(dyv * uv * silu_grad_f32(gv));
 }
 
+template <typename scalar_t>
+__global__ void swiglu_packed_forward_kernel(
+    const scalar_t* __restrict__ gate_up,
+    scalar_t* __restrict__ y,
+    const int64_t n,
+    const int64_t width) {
+  const int64_t idx = blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x;
+  if (idx >= n) {
+    return;
+  }
+  const int64_t row = idx / width;
+  const int64_t column = idx - row * width;
+  const int64_t gate_index = row * (2 * width) + column;
+  const float gv = static_cast<float>(gate_up[gate_index]);
+  const float uv = static_cast<float>(gate_up[gate_index + width]);
+  y[idx] = static_cast<scalar_t>(silu_f32(gv) * uv);
+}
+
+template <typename scalar_t>
+__global__ void swiglu_packed_backward_kernel(
+    const scalar_t* __restrict__ dy,
+    const scalar_t* __restrict__ gate_up,
+    scalar_t* __restrict__ d_gate,
+    scalar_t* __restrict__ d_up,
+    const int64_t n,
+    const int64_t width) {
+  const int64_t idx = blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x;
+  if (idx >= n) {
+    return;
+  }
+  const int64_t row = idx / width;
+  const int64_t column = idx - row * width;
+  const int64_t gate_index = row * (2 * width) + column;
+  const float dyv = static_cast<float>(dy[idx]);
+  const float gv = static_cast<float>(gate_up[gate_index]);
+  const float uv = static_cast<float>(gate_up[gate_index + width]);
+  const float s = silu_f32(gv);
+  d_up[idx] = static_cast<scalar_t>(dyv * s);
+  d_gate[idx] = static_cast<scalar_t>(dyv * uv * silu_grad_f32(gv));
+}
+
 static void launch_1d(int64_t n, int& threads, int64_t& blocks) {
   threads = 256;
   blocks = (n + threads - 1) / threads;
@@ -247,6 +288,78 @@ std::vector<torch::Tensor> swiglu_backward_cuda(
             d_gate.data_ptr<scalar_t>(),
             d_up.data_ptr<scalar_t>(),
             n);
+      });
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return {d_gate, d_up};
+}
+
+torch::Tensor swiglu_packed_forward_cuda(torch::Tensor gate_up) {
+  check_cuda_contig(gate_up, "gate_up");
+  TORCH_CHECK(gate_up.dim() == 2, "gate_up must be [rows, 2 * intermediate]");
+  TORCH_CHECK(gate_up.size(1) % 2 == 0, "gate_up width must be even");
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(gate_up));
+  const int64_t width = gate_up.size(1) / 2;
+  auto y = torch::empty({gate_up.size(0), width}, gate_up.options());
+  const int64_t n = y.numel();
+  if (n == 0) {
+    return y;
+  }
+  int threads = 0;
+  int64_t blocks = 0;
+  launch_1d(n, threads, blocks);
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      gate_up.scalar_type(),
+      "swiglu_packed_forward_cuda",
+      [&] {
+        swiglu_packed_forward_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+            gate_up.data_ptr<scalar_t>(), y.data_ptr<scalar_t>(), n, width);
+      });
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return y;
+}
+
+std::vector<torch::Tensor> swiglu_packed_backward_cuda(
+    torch::Tensor dy,
+    torch::Tensor gate_up) {
+  check_cuda_contig(dy, "dy");
+  check_cuda_contig(gate_up, "gate_up");
+  check_same_device(dy, gate_up, "dy", "gate_up");
+  TORCH_CHECK(gate_up.dim() == 2, "gate_up must be [rows, 2 * intermediate]");
+  TORCH_CHECK(gate_up.size(1) % 2 == 0, "gate_up width must be even");
+  TORCH_CHECK(dy.dim() == 2, "dy must be [rows, intermediate]");
+  TORCH_CHECK(
+      dy.size(0) == gate_up.size(0) && dy.size(1) * 2 == gate_up.size(1),
+      "dy shape must match the packed gate/up halves");
+  TORCH_CHECK(dy.scalar_type() == gate_up.scalar_type(), "dy and gate_up must share dtype");
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(gate_up));
+  auto d_gate = torch::empty_like(dy);
+  auto d_up = torch::empty_like(dy);
+  const int64_t n = dy.numel();
+  if (n == 0) {
+    return {d_gate, d_up};
+  }
+  int threads = 0;
+  int64_t blocks = 0;
+  launch_1d(n, threads, blocks);
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      gate_up.scalar_type(),
+      "swiglu_packed_backward_cuda",
+      [&] {
+        swiglu_packed_backward_kernel<scalar_t><<<blocks, threads, 0, stream>>>(
+            dy.data_ptr<scalar_t>(),
+            gate_up.data_ptr<scalar_t>(),
+            d_gate.data_ptr<scalar_t>(),
+            d_up.data_ptr<scalar_t>(),
+            n,
+            dy.size(1));
       });
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return {d_gate, d_up};

--- a/csrc/cuda/distributed/deterministic_collective.cu
+++ b/csrc/cuda/distributed/deterministic_collective.cu
@@ -13,10 +13,13 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 namespace {
@@ -24,13 +27,76 @@ namespace {
 constexpr int kMaxDeterministicWorldSize = 8;
 constexpr int kThreads = 256;
 constexpr int kMaxBlocks = 4096;
+constexpr int64_t kSequenceHeaderBytes = 2 * sizeof(uint64_t);
 
 struct PeerPointers {
   const void* values[kMaxDeterministicWorldSize];
+  const uint64_t* stage_sequences[kMaxDeterministicWorldSize];
+  const uint64_t* done_sequences[kMaxDeterministicWorldSize];
 };
 
 bool is_supported_world_size(int64_t world_size) {
   return world_size == 1 || world_size == 2 || world_size == 4 || world_size == 8;
+}
+
+__device__ __forceinline__ uint64_t load_acquire_system(
+    const uint64_t* address) {
+  uint64_t value;
+  asm volatile(
+      "ld.acquire.sys.global.u64 %0, [%1];"
+      : "=l"(value)
+      : "l"(address)
+      : "memory");
+  return value;
+}
+
+__device__ __forceinline__ void store_release_system(
+    uint64_t* address,
+    uint64_t value) {
+  asm volatile(
+      "st.release.sys.global.u64 [%0], %1;"
+      :
+      : "l"(address), "l"(value)
+      : "memory");
+}
+
+__global__ void wait_for_previous_done_kernel(
+    PeerPointers peers,
+    int world_size,
+    const uint64_t* local_stage_sequence) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) return;
+  const uint64_t sequence = load_acquire_system(local_stage_sequence);
+  for (int peer = 0; peer < world_size; ++peer) {
+    while (load_acquire_system(peers.done_sequences[peer]) < sequence) {
+      __nanosleep(64);
+    }
+  }
+}
+
+__global__ void publish_next_stage_sequence_kernel(uint64_t* stage_sequence) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) return;
+  const uint64_t current = load_acquire_system(stage_sequence);
+  store_release_system(stage_sequence, current + 1);
+}
+
+__global__ void wait_for_staged_peers_kernel(
+    PeerPointers peers,
+    int world_size,
+    const uint64_t* local_stage_sequence) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) return;
+  const uint64_t sequence = load_acquire_system(local_stage_sequence);
+  for (int peer = 0; peer < world_size; ++peer) {
+    while (load_acquire_system(peers.stage_sequences[peer]) < sequence) {
+      __nanosleep(64);
+    }
+  }
+}
+
+__global__ void publish_done_sequence_kernel(
+    uint64_t* done_sequence,
+    const uint64_t* stage_sequence) {
+  if (blockIdx.x != 0 || threadIdx.x != 0) return;
+  store_release_system(done_sequence, load_acquire_system(stage_sequence));
 }
 
 template <typename T>
@@ -208,13 +274,16 @@ class DeterministicCollectiveState {
       : rank_(rank),
         world_size_(handles.size()),
         device_index_(staging.get_device()),
-        capacity_bytes_(staging.numel() * staging.element_size()) {
+        capacity_bytes_(
+            staging.numel() * staging.element_size() - kSequenceHeaderBytes) {
     TORCH_CHECK(staging.is_cuda(), "collective staging buffer must be CUDA");
     TORCH_CHECK(staging.is_contiguous(), "collective staging buffer must be contiguous");
     TORCH_CHECK(
         staging.scalar_type() == torch::kUInt8,
         "collective staging buffer must have dtype torch.uint8");
-    TORCH_CHECK(capacity_bytes_ > 0, "collective staging capacity must be positive");
+    TORCH_CHECK(
+        capacity_bytes_ > 0,
+        "collective staging must reserve sequence metadata and positive payload capacity");
     TORCH_CHECK(
         is_supported_world_size(world_size_),
         "deterministic collectives require world size 1, 2, 4, or 8; got ",
@@ -228,8 +297,10 @@ class DeterministicCollectiveState {
         world_size_,
         ")");
 
-    for (auto& peer : peers_.values) {
-      peer = nullptr;
+    for (int peer = 0; peer < kMaxDeterministicWorldSize; ++peer) {
+      peers_.values[peer] = nullptr;
+      peers_.stage_sequences[peer] = nullptr;
+      peers_.done_sequences[peer] = nullptr;
     }
     imported_bases_.fill(nullptr);
     try {
@@ -240,29 +311,39 @@ class DeterministicCollectiveState {
             peer);
         TORCH_CHECK(offsets[peer] >= 0, "negative CUDA IPC offset for rank ", peer);
 
+        void* allocation = nullptr;
         if (peer == rank_) {
-          peers_.values[peer] = staging.data_ptr();
-          continue;
-        }
+          allocation = staging.data_ptr();
+        } else {
+          cudaIpcMemHandle_t handle{};
+          auto* raw_handle = reinterpret_cast<uint8_t*>(&handle);
+          for (size_t byte = 0; byte < sizeof(handle); ++byte) {
+            TORCH_CHECK(
+                handles[peer][byte] >= 0 && handles[peer][byte] <= 255,
+                "invalid CUDA IPC handle byte for rank ",
+                peer);
+            raw_handle[byte] = static_cast<uint8_t>(handles[peer][byte]);
+          }
 
-        cudaIpcMemHandle_t handle{};
-        auto* raw_handle = reinterpret_cast<uint8_t*>(&handle);
-        for (size_t byte = 0; byte < sizeof(handle); ++byte) {
-          TORCH_CHECK(
-              handles[peer][byte] >= 0 && handles[peer][byte] <= 255,
-              "invalid CUDA IPC handle byte for rank ",
-              peer);
-          raw_handle[byte] = static_cast<uint8_t>(handles[peer][byte]);
+          void* base = nullptr;
+          AT_CUDA_CHECK(cudaIpcOpenMemHandle(
+              &base,
+              handle,
+              cudaIpcMemLazyEnablePeerAccess));
+          imported_bases_[peer] = base;
+          allocation = static_cast<char*>(base) + offsets[peer];
         }
-
-        void* base = nullptr;
-        AT_CUDA_CHECK(cudaIpcOpenMemHandle(
-            &base,
-            handle,
-            cudaIpcMemLazyEnablePeerAccess));
-        imported_bases_[peer] = base;
-        peers_.values[peer] = static_cast<const char*>(base) + offsets[peer];
+        auto* bytes = static_cast<uint8_t*>(allocation);
+        peers_.stage_sequences[peer] =
+            reinterpret_cast<const uint64_t*>(bytes);
+        peers_.done_sequences[peer] =
+            reinterpret_cast<const uint64_t*>(bytes + sizeof(uint64_t));
+        peers_.values[peer] = bytes + kSequenceHeaderBytes;
       }
+      auto* local_bytes = static_cast<uint8_t*>(staging.data_ptr());
+      local_stage_sequence_ = reinterpret_cast<uint64_t*>(local_bytes);
+      local_done_sequence_ =
+          reinterpret_cast<uint64_t*>(local_bytes + sizeof(uint64_t));
     } catch (...) {
       close_imports();
       throw;
@@ -291,6 +372,9 @@ class DeterministicCollectiveState {
         input_bytes,
         " bytes but staging capacity is ",
         capacity_bytes_);
+    wait_for_previous_done_kernel<<<1, 1, 0, stream>>>(
+        peers_, world_size_, local_stage_sequence_);
+    AT_CUDA_CHECK(cudaGetLastError());
     if (input_bytes > 0) {
       AT_CUDA_CHECK(cudaMemcpyAsync(
           const_cast<void*>(peers_.values[rank_]),
@@ -299,12 +383,15 @@ class DeterministicCollectiveState {
           cudaMemcpyDeviceToDevice,
           stream));
     }
+    publish_next_stage_sequence_kernel<<<1, 1, 0, stream>>>(
+        local_stage_sequence_);
+    AT_CUDA_CHECK(cudaGetLastError());
     staged_bytes_ = input_bytes;
     staged_scalar_type_ = input.scalar_type();
     has_staged_input_ = true;
   }
 
-  void all_reduce(torch::Tensor& output, cudaStream_t stream) const {
+  void all_reduce(torch::Tensor& output, cudaStream_t stream) {
     check_tensor(output, "output");
     TORCH_CHECK(has_staged_input_, "stage() must be called before all_reduce()");
     TORCH_CHECK(
@@ -314,8 +401,10 @@ class DeterministicCollectiveState {
         output.numel() * output.element_size() == staged_bytes_,
         "all-reduce output size must match the staged input size");
 
+    wait_for_staged_peers(stream);
     const int64_t element_count = output.numel();
     if (element_count == 0) {
+      publish_done(stream);
       return;
     }
     const int blocks = static_cast<int>(std::min<int64_t>(
@@ -359,9 +448,10 @@ class DeterministicCollectiveState {
             output.scalar_type());
     }
     AT_CUDA_CHECK(cudaGetLastError());
+    publish_done(stream);
   }
 
-  void reduce_scatter(torch::Tensor& output, cudaStream_t stream) const {
+  void reduce_scatter(torch::Tensor& output, cudaStream_t stream) {
     check_tensor(output, "output");
     TORCH_CHECK(has_staged_input_, "stage() must be called before reduce_scatter()");
     TORCH_CHECK(
@@ -371,8 +461,10 @@ class DeterministicCollectiveState {
         output.numel() * output.element_size() * world_size_ == staged_bytes_,
         "reduce-scatter output must contain one world-size fraction of the staged input");
 
+    wait_for_staged_peers(stream);
     const int64_t output_element_count = output.numel();
     if (output_element_count == 0) {
+      publish_done(stream);
       return;
     }
     const int blocks = static_cast<int>(std::min<int64_t>(
@@ -419,9 +511,10 @@ class DeterministicCollectiveState {
             output.scalar_type());
     }
     AT_CUDA_CHECK(cudaGetLastError());
+    publish_done(stream);
   }
 
-  void all_gather(torch::Tensor& output, cudaStream_t stream) const {
+  void all_gather(torch::Tensor& output, cudaStream_t stream) {
     check_tensor(output, "output");
     TORCH_CHECK(has_staged_input_, "stage() must be called before all_gather()");
     TORCH_CHECK(
@@ -432,8 +525,10 @@ class DeterministicCollectiveState {
             staged_bytes_ * world_size_,
         "all-gather output must contain one staged input per rank");
 
+    wait_for_staged_peers(stream);
     const int64_t output_bytes = output.numel() * output.element_size();
     if (output_bytes == 0) {
+      publish_done(stream);
       return;
     }
     const int blocks = static_cast<int>(std::min<int64_t>(
@@ -445,9 +540,23 @@ class DeterministicCollectiveState {
         staged_bytes_,
         world_size_);
     AT_CUDA_CHECK(cudaGetLastError());
+    publish_done(stream);
   }
 
  private:
+  void wait_for_staged_peers(cudaStream_t stream) const {
+    wait_for_staged_peers_kernel<<<1, 1, 0, stream>>>(
+        peers_, world_size_, local_stage_sequence_);
+    AT_CUDA_CHECK(cudaGetLastError());
+  }
+
+  void publish_done(cudaStream_t stream) {
+    publish_done_sequence_kernel<<<1, 1, 0, stream>>>(
+        local_done_sequence_, local_stage_sequence_);
+    AT_CUDA_CHECK(cudaGetLastError());
+    has_staged_input_ = false;
+  }
+
   void check_tensor(const torch::Tensor& tensor, const char* name) const {
     TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
     TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
@@ -476,13 +585,27 @@ class DeterministicCollectiveState {
   int64_t staged_bytes_{0};
   at::ScalarType staged_scalar_type_{at::ScalarType::Undefined};
   bool has_staged_input_{false};
+  uint64_t* local_stage_sequence_{nullptr};
+  uint64_t* local_done_sequence_{nullptr};
   PeerPointers peers_{};
   std::array<void*, kMaxDeterministicWorldSize> imported_bases_{};
 };
 
-DeterministicCollectiveState* state_from_handle(int64_t handle) {
+std::atomic<int64_t> next_collective_handle{1};
+std::mutex collective_states_mutex;
+std::unordered_map<int64_t, std::shared_ptr<DeterministicCollectiveState>>
+    collective_states;
+
+std::shared_ptr<DeterministicCollectiveState> state_from_handle(int64_t handle) {
   TORCH_CHECK(handle != 0, "deterministic collective handle is closed");
-  return reinterpret_cast<DeterministicCollectiveState*>(handle);
+  std::lock_guard<std::mutex> lock(collective_states_mutex);
+  const auto it = collective_states.find(handle);
+  TORCH_CHECK(
+      it != collective_states.end(),
+      "deterministic collective handle ",
+      handle,
+      " is unknown or already closed");
+  return it->second;
 }
 
 }  // namespace
@@ -535,16 +658,35 @@ int64_t deterministic_collective_create(
     const std::vector<int64_t>& offsets,
     int64_t rank) {
   const c10::cuda::CUDAGuard device_guard(staging.device());
-  auto state = std::make_unique<DeterministicCollectiveState>(
+  auto state = std::make_shared<DeterministicCollectiveState>(
       staging,
       handles,
       offsets,
       rank);
-  return reinterpret_cast<int64_t>(state.release());
+  const int64_t handle = next_collective_handle.fetch_add(
+      1, std::memory_order_relaxed);
+  TORCH_CHECK(handle > 0, "deterministic collective handle space exhausted");
+  {
+    std::lock_guard<std::mutex> lock(collective_states_mutex);
+    const bool inserted = collective_states.emplace(handle, state).second;
+    TORCH_CHECK(inserted, "duplicate deterministic collective handle ", handle);
+  }
+  return handle;
 }
 
 void deterministic_collective_destroy(int64_t handle) {
-  delete state_from_handle(handle);
+  std::shared_ptr<DeterministicCollectiveState> state;
+  {
+    std::lock_guard<std::mutex> lock(collective_states_mutex);
+    const auto it = collective_states.find(handle);
+    TORCH_CHECK(
+        it != collective_states.end(),
+        "deterministic collective handle ",
+        handle,
+        " is unknown or already closed");
+    state = std::move(it->second);
+    collective_states.erase(it);
+  }
 }
 
 void deterministic_collective_stage(int64_t handle, torch::Tensor& input) {

--- a/csrc/cuda/gemm/det_gemm_kernel.cu
+++ b/csrc/cuda/gemm/det_gemm_kernel.cu
@@ -18,7 +18,12 @@
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
 #include <cuda_bf16.h>
+#include <array>
+#include <atomic>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
 
 #if defined(RL_KERNEL_ENABLE_SM90)
 #include "det_gemm_tma.cuh"
@@ -42,27 +47,6 @@ __device__ __forceinline__ float cast_output<float>(float value) {
 }
 
 __host__ __device__ constexpr int cdiv(int a, int b) { return (a + b - 1) / b; }
-
-enum class RhsLayout {
-  // Physical RHS is the logical [K,N] matrix.
-  kKN,
-  // Physical RHS is [N,K] and represents the transpose of the logical RHS.
-  kNK,
-};
-
-enum class OutputLayout {
-  // Store the logical [M,N] result in its usual contiguous layout.
-  kMN,
-  // Store logical (m,n) at contiguous [N,M](n,m).
-  kNM,
-};
-
-template <bool TRANSPOSE_OUTPUT>
-__device__ __forceinline__ int output_offset(int row, int col, int M, int N) {
-  if constexpr (TRANSPOSE_OUTPUT)
-    return col * M + row;
-  return row * N + col;
-}
 
 // Must match SM90 BK so an aligned-K naive tree equals the SM90 tile tree.
 constexpr int K_TREE_LEAF = 32;
@@ -104,7 +88,7 @@ __device__ nv_bf16 k_tree_naive(const nv_bf16* __restrict__ A, const nv_bf16* __
 // construction: one thread = one output element, mid-split K tree.
 constexpr int NAIVE_TILE = 16;
 
-template <typename output_t, bool TRANSPOSE_OUTPUT>
+template <typename output_t>
 __global__ void det_gemm_naive(const nv_bf16* __restrict__ A,
                                const nv_bf16* __restrict__ B,
                                output_t* __restrict__ C,
@@ -112,17 +96,16 @@ __global__ void det_gemm_naive(const nv_bf16* __restrict__ A,
   const int row = blockIdx.y * NAIVE_TILE + threadIdx.y;
   const int col = blockIdx.x * NAIVE_TILE + threadIdx.x;
   if (row >= M || col >= N) return;
-  C[output_offset<TRANSPOSE_OUTPUT>(row, col, M, N)] = cast_output<output_t>(
+  C[row * N + col] = cast_output<output_t>(
       __bfloat162float(k_tree_naive(A, B, row, col, N, K, 0, K)));
 }
 
-template <typename output_t, bool TRANSPOSE_OUTPUT>
+template <typename output_t>
 void launch_naive(const nv_bf16* A, const nv_bf16* B, output_t* C,
                   int M, int N, int K, cudaStream_t stream) {
   dim3 block(NAIVE_TILE, NAIVE_TILE);
   dim3 grid(cdiv(N, NAIVE_TILE), cdiv(M, NAIVE_TILE));
-  det_gemm_naive<output_t, TRANSPOSE_OUTPUT><<<grid, block, 0, stream>>>(
-      A, B, C, M, N, K);
+  det_gemm_naive<output_t><<<grid, block, 0, stream>>>(A, B, C, M, N, K);
 }
 
 #if defined(RL_KERNEL_ENABLE_SM90)
@@ -131,15 +114,12 @@ void launch_naive(const nv_bf16* A, const nv_bf16* B, output_t* C,
 // split-K). A tile [BM,BK] row-major; B operand col-major [n,k] supplied by
 // passing B^T ([N,K] row-major) so the B smem tile is [BN,BK] (row=n,col=k),
 // matching the validated logp ldmatrix addressing.
-constexpr int BM = 128, BN = 64, BK = 32;
+constexpr int BM = 128, DECODE_BM = 16, BN = 64, BK = 32;
 static_assert(BK == K_TREE_LEAF, "SM90 tile width must match the naive K-tree leaf");
 constexpr int WARPS = 4;
-constexpr int WG_THREADS = WARPS * 32;  // 128
 constexpr int STAGES = 2;
 
 constexpr int MMA_M = 16, MMA_N = 8, MMA_K = 16;
-constexpr int WARP_M = BM / WARPS;        // 32
-constexpr int M_TILES = WARP_M / MMA_M;   // 2
 constexpr int N_TILES = BN / MMA_N;       // 8
 constexpr int K_TILES = BK / MMA_K;       // 2
 constexpr int KK_GROUPS = BK / 32;        // 1
@@ -158,21 +138,25 @@ __device__ __forceinline__ void mma_m16n8k16(const uint32_t A[4], const uint32_t
                  "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]));
 }
 
-template <typename output_t, bool TRANSPOSE_OUTPUT>
+template <typename output_t, int TILE_M, int NUM_WARPS>
 __global__ void det_gemm_sm90_kernel(const __grid_constant__ CUtensorMap a_tmap,
                                      const __grid_constant__ CUtensorMap bt_tmap,
                                      output_t* __restrict__ C,
                                      int M, int N, int K) {
+  static_assert(TILE_M % NUM_WARPS == 0);
+  static_assert((TILE_M / NUM_WARPS) % MMA_M == 0);
+  constexpr int WARP_M = TILE_M / NUM_WARPS;
+  constexpr int M_TILES = WARP_M / MMA_M;
   const int tid = threadIdx.x;
   const int warp = tid / 32;
   const int lane = tid % 32;
-  const int row_base = blockIdx.y * BM;
+  const int row_base = blockIdx.y * TILE_M;
   const int col_base = blockIdx.x * BN;
   const int kd = K / BK;
 
   extern __shared__ __align__(1024) char smem[];
   nv_bf16* sA = reinterpret_cast<nv_bf16*>(smem);
-  nv_bf16* sB = reinterpret_cast<nv_bf16*>(sA + STAGES * BM * BK);
+  nv_bf16* sB = reinterpret_cast<nv_bf16*>(sA + STAGES * TILE_M * BK);
   int* mbar_base = reinterpret_cast<int*>(sB + STAGES * BN * BK);
 
   const uint32_t sA_base = static_cast<uint32_t>(__cvta_generic_to_shared(sA));
@@ -189,12 +173,12 @@ __global__ void det_gemm_sm90_kernel(const __grid_constant__ CUtensorMap a_tmap,
   }
   __syncthreads();
 
-  const uint32_t tile_bytes = (BM * BK + BN * BK) * sizeof(nv_bf16);
+  const uint32_t tile_bytes = (TILE_M * BK + BN * BK) * sizeof(nv_bf16);
 
   auto issue_load = [&](int k) {
     const int buf = k % STAGES;
     const int koff = k * BK;
-    det_gemm::tma_2d_g2s(sA_base + buf * BM * BK * sizeof(nv_bf16), &a_tmap, koff, row_base, mbar[buf]);
+    det_gemm::tma_2d_g2s(sA_base + buf * TILE_M * BK * sizeof(nv_bf16), &a_tmap, koff, row_base, mbar[buf]);
     det_gemm::tma_2d_g2s(sB_base + buf * BN * BK * sizeof(nv_bf16), &bt_tmap, koff, col_base, mbar[buf]);
     det_gemm::mbar_arrive_expect_tx(mbar[buf], tile_bytes);
   };
@@ -221,7 +205,7 @@ __global__ void det_gemm_sm90_kernel(const __grid_constant__ CUtensorMap a_tmap,
     phase[buf] ^= 1;
     __syncthreads();
 
-    const uint32_t sA_buf = sA_base + buf * BM * BK * sizeof(nv_bf16);
+    const uint32_t sA_buf = sA_base + buf * TILE_M * BK * sizeof(nv_bf16);
     const uint32_t sB_buf = sB_base + buf * BN * BK * sizeof(nv_bf16);
 
 #pragma unroll
@@ -300,45 +284,73 @@ __global__ void det_gemm_sm90_kernel(const __grid_constant__ CUtensorMap a_tmap,
     for (int n = 0; n < N_TILES; ++n) {
       const int col = col_base + n * MMA_N + (lane % 4) * 2;
       if (row < M && col + 1 < N) {
-        C[output_offset<TRANSPOSE_OUTPUT>(row, col + 0, M, N)] =
-            cast_output<output_t>(__bfloat162float(tree_v[mi][n][0]));
-        C[output_offset<TRANSPOSE_OUTPUT>(row, col + 1, M, N)] =
-            cast_output<output_t>(__bfloat162float(tree_v[mi][n][1]));
+        C[row * N + col + 0] = cast_output<output_t>(__bfloat162float(tree_v[mi][n][0]));
+        C[row * N + col + 1] = cast_output<output_t>(__bfloat162float(tree_v[mi][n][1]));
       }
       if (row + 8 < M && col + 1 < N) {
-        C[output_offset<TRANSPOSE_OUTPUT>(row + 8, col + 0, M, N)] =
-            cast_output<output_t>(__bfloat162float(tree_v[mi][n][2]));
-        C[output_offset<TRANSPOSE_OUTPUT>(row + 8, col + 1, M, N)] =
-            cast_output<output_t>(__bfloat162float(tree_v[mi][n][3]));
+        C[(row + 8) * N + col + 0] = cast_output<output_t>(__bfloat162float(tree_v[mi][n][2]));
+        C[(row + 8) * N + col + 1] = cast_output<output_t>(__bfloat162float(tree_v[mi][n][3]));
       }
     }
   }
 }
 
-template <typename output_t, bool TRANSPOSE_OUTPUT>
+template <typename output_t>
 bool launch_sm90(const nv_bf16* A, const nv_bf16* Bt, output_t* C,
                  int M, int N, int K, cudaStream_t stream) {
-  if (M % BM != 0 || N % BN != 0 || K % BK != 0) return false;  // fall back
+  if (N % BN != 0 || K % BK != 0) return false;  // fall back
 
+  const bool decode_tile = M <= DECODE_BM;
+  const int tile_m = decode_tile ? DECODE_BM : BM;
+  const int num_warps = decode_tile ? 1 : WARPS;
   CUtensorMap a_tmap, bt_tmap;
-  det_gemm::init_tmap_noswizzle(&a_tmap, A, M, K, BM, BK);
+  det_gemm::init_tmap_noswizzle(&a_tmap, A, M, K, tile_m, BK);
   det_gemm::init_tmap_noswizzle(&bt_tmap, Bt, N, K, BN, BK);
 
-  const int smem = STAGES * (BM * BK + BN * BK) * sizeof(nv_bf16) + STAGES * 8;
-  if (smem > 48 * 1024)
-    cudaFuncSetAttribute(det_gemm_sm90_kernel<output_t, TRANSPOSE_OUTPUT>,
-                         cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+  const int smem = STAGES * (tile_m * BK + BN * BK) * sizeof(nv_bf16) + STAGES * 8;
+  if (smem > 48 * 1024) {
+    static std::once_flag configure_large_smem;
+    std::call_once(configure_large_smem, [smem]() {
+      const cudaError_t status = cudaFuncSetAttribute(
+          det_gemm_sm90_kernel<output_t, BM, WARPS>,
+          cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+      TORCH_CHECK(status == cudaSuccess,
+                  "det_gemm: cudaFuncSetAttribute failed: ",
+                  cudaGetErrorString(status));
+    });
+  }
 
-  dim3 grid(cdiv(N, BN), cdiv(M, BM));
-  det_gemm_sm90_kernel<output_t, TRANSPOSE_OUTPUT>
-      <<<grid, WG_THREADS, smem, stream>>>(a_tmap, bt_tmap, C, M, N, K);
+  dim3 grid(cdiv(N, BN), cdiv(M, tile_m));
+  if (decode_tile) {
+    det_gemm_sm90_kernel<output_t, DECODE_BM, 1>
+        <<<grid, 32, smem, stream>>>(a_tmap, bt_tmap, C, M, N, K);
+  } else {
+    det_gemm_sm90_kernel<output_t, BM, WARPS>
+        <<<grid, num_warps * 32, smem, stream>>>(a_tmap, bt_tmap, C, M, N, K);
+  }
   return true;
 }
 #endif  // RL_KERNEL_ENABLE_SM90
 
 int sm_major() {
-  int dev = 0; cudaGetDevice(&dev);
-  cudaDeviceProp p{}; cudaGetDeviceProperties(&p, dev);
+  constexpr int kMaxCachedDevices = 64;
+  static std::array<std::atomic<int>, kMaxCachedDevices> cached{};
+  int dev = 0;
+  const cudaError_t device_status = cudaGetDevice(&dev);
+  TORCH_CHECK(device_status == cudaSuccess,
+              "det_gemm: cudaGetDevice failed: ",
+              cudaGetErrorString(device_status));
+  if (dev >= 0 && dev < kMaxCachedDevices) {
+    const int value = cached[dev].load(std::memory_order_acquire);
+    if (value != 0) return value;
+  }
+  cudaDeviceProp p{};
+  const cudaError_t properties_status = cudaGetDeviceProperties(&p, dev);
+  TORCH_CHECK(properties_status == cudaSuccess,
+              "det_gemm: cudaGetDeviceProperties failed: ",
+              cudaGetErrorString(properties_status));
+  if (dev >= 0 && dev < kMaxCachedDevices)
+    cached[dev].store(p.major, std::memory_order_release);
   return p.major;
 }
 inline const nv_bf16* bf16(const torch::Tensor& t) {
@@ -347,87 +359,71 @@ inline const nv_bf16* bf16(const torch::Tensor& t) {
 inline nv_bf16* bf16o(torch::Tensor& t) {
   return reinterpret_cast<nv_bf16*>(t.data_ptr<at::BFloat16>());
 }
+bool require_sm90() {
+  const char* value = std::getenv("RL_KERNEL_DET_GEMM_SM90_ONLY");
+  return value != nullptr &&
+      (std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 ||
+       std::strcmp(value, "yes") == 0 || std::strcmp(value, "on") == 0);
+}
 void check_in(const torch::Tensor& t, const char* n) {
   TORCH_CHECK(t.is_cuda(), n, " must be CUDA");
   TORCH_CHECK(t.scalar_type() == torch::kBFloat16, n, " must be bf16");
 }
 
-torch::Tensor gemm_dispatch(const torch::Tensor& a, const torch::Tensor& rhs,
-                            RhsLayout rhs_layout = RhsLayout::kKN,
-                            OutputLayout output_layout = OutputLayout::kMN,
-                            bool output_fp32 = false) {
-  const int M = a.size(0), K = a.size(1);
-  const int N = rhs_layout == RhsLayout::kKN ? rhs.size(1) : rhs.size(0);
-  const bool transpose_output = output_layout == OutputLayout::kNM;
+torch::Tensor gemm_dispatch_bt(const torch::Tensor& a, const torch::Tensor& bt,
+                               bool output_fp32 = false) {
+  const int M = a.size(0), K = a.size(1), N = bt.size(0);
   auto options = a.options().dtype(output_fp32 ? torch::kFloat32 : torch::kBFloat16);
-  auto c = transpose_output ? torch::empty({N, M}, options) : torch::empty({M, N}, options);
+  auto c = torch::empty({M, N}, options);
+  if (M == 0 || N == 0) return c;
   auto stream = at::cuda::getCurrentCUDAStream();
 
 #if defined(RL_KERNEL_ENABLE_SM90)
-  // Tensor-core path requires N,K tile-aligned. M is padded up to a multiple of
-  // BM so that EVERY M (including M=1 and non-aligned M) takes the SAME kernel.
-  // Selecting a different kernel based on M would itself break batch-invariance
-  // because M is the batch dimension.
+  // TMA zero-fills out-of-bounds rows in the final M tile. Valid rows therefore
+  // use the same tensor-core instructions and K tree for every batch size without
+  // materializing or computing padded rows.
   if (sm_major() >= 9 && K % BK == 0 && N % BN == 0) {
-    const int Mp = cdiv(M, BM) * BM;
     torch::Tensor a_use = a;
-    if (Mp != M) {
-      a_use = torch::zeros({Mp, K}, a.options());
-      a_use.narrow(0, 0, M).copy_(a);
-    } else if (reinterpret_cast<std::uintptr_t>(a_use.data_ptr()) % 16 != 0) {
-      // cuTensorMapEncodeTiled requires a 16-byte-aligned global base. A
-      // contiguous offset view is not guaranteed to satisfy that contract.
+    torch::Tensor bt_use = bt;
+    if (reinterpret_cast<std::uintptr_t>(a_use.data_ptr()) % 16 != 0)
       a_use = a.clone();
-    }
-    torch::Tensor c_use = c;
-    if (Mp != M)
-      c_use = transpose_output ? torch::empty({N, Mp}, options)
-                               : torch::empty({Mp, N}, options);
-
-    // TMA consumes the physical [N,K] representation.  The explicit kNK
-    // contract lets callers provide that layout directly without a round-trip
-    // transpose through logical [K,N].
-    torch::Tensor bt = rhs_layout == RhsLayout::kNK ? rhs : rhs.t().contiguous();
-    if (reinterpret_cast<std::uintptr_t>(bt.data_ptr()) % 16 != 0)
-      bt = bt.clone();
-    bool launched = false;
-    if (output_fp32) {
-      launched = transpose_output
-          ? launch_sm90<float, true>(
-                bf16(a_use), bf16(bt), c_use.data_ptr<float>(), Mp, N, K, stream)
-          : launch_sm90<float, false>(
-                bf16(a_use), bf16(bt), c_use.data_ptr<float>(), Mp, N, K, stream);
-    } else {
-      launched = transpose_output
-          ? launch_sm90<nv_bf16, true>(bf16(a_use), bf16(bt), bf16o(c_use), Mp, N, K, stream)
-          : launch_sm90<nv_bf16, false>(bf16(a_use), bf16(bt), bf16o(c_use), Mp, N, K, stream);
-    }
-    if (launched) {
-      if (Mp != M)
-        c.copy_(c_use.narrow(transpose_output ? 1 : 0, 0, M));
-      return c;
-    }
+    if (reinterpret_cast<std::uintptr_t>(bt_use.data_ptr()) % 16 != 0)
+      bt_use = bt.clone();
+    const bool launched = output_fp32
+        ? launch_sm90<float>(
+              bf16(a_use), bf16(bt_use), c.data_ptr<float>(), M, N, K, stream)
+        : launch_sm90<nv_bf16>(
+              bf16(a_use), bf16(bt_use), bf16o(c), M, N, K, stream);
+    if (launched) return c;
   }
 #endif
-
-  // The scalar fallback keeps its original logical [K,N] operand traversal.
-  // Materialize only for the new physical-[N,K] contract.
-  torch::Tensor b = rhs_layout == RhsLayout::kKN ? rhs : rhs.t().contiguous();
-  if (output_fp32) {
-    if (transpose_output)
-      launch_naive<float, true>(bf16(a), bf16(b), c.data_ptr<float>(), M, N, K, stream);
-    else
-      launch_naive<float, false>(bf16(a), bf16(b), c.data_ptr<float>(), M, N, K, stream);
-  } else {
-    if (transpose_output)
-      launch_naive<nv_bf16, true>(bf16(a), bf16(b), bf16o(c), M, N, K, stream);
-    else
-      launch_naive<nv_bf16, false>(bf16(a), bf16(b), bf16o(c), M, N, K, stream);
-  }
+  TORCH_CHECK(
+      !require_sm90(),
+      "RL_KERNEL_DET_GEMM_SM90_ONLY=1 forbids det_gemm_naive; SM90 dispatch "
+      "was unavailable for M=", M, ", N=", N, ", K=", K,
+      ". Rebuild with KERNEL_ALIGN_DET_GEMM_SM90=1 and use SM90-aligned N/K.");
+  auto b = bt.t().contiguous();
+  if (output_fp32)
+    launch_naive<float>(bf16(a), bf16(b), c.data_ptr<float>(), M, N, K, stream);
+  else
+    launch_naive<nv_bf16>(bf16(a), bf16(b), bf16o(c), M, N, K, stream);
   return c;
 }
 
+torch::Tensor gemm_dispatch(const torch::Tensor& a, const torch::Tensor& b,
+                            bool output_fp32 = false) {
+  return gemm_dispatch_bt(a, b.t().contiguous(), output_fp32);
+}
+
 }  // anonymous namespace
+
+bool det_gemm_sm90_compiled() {
+#if defined(RL_KERNEL_ENABLE_SM90)
+  return true;
+#else
+  return false;
+#endif
+}
 
 torch::Tensor det_gemm_fwd(torch::Tensor a, torch::Tensor b) {
   check_in(a, "A"); check_in(b, "B");
@@ -437,53 +433,62 @@ torch::Tensor det_gemm_fwd(torch::Tensor a, torch::Tensor b) {
   return gemm_dispatch(a, b);
 }
 
-torch::Tensor det_gemm_fwd_rhs_transposed(torch::Tensor a, torch::Tensor bt) {
-  check_in(a, "A"); check_in(bt, "Bt");
-  a = a.contiguous(); bt = bt.contiguous();
-  TORCH_CHECK(a.dim() == 2 && bt.dim() == 2,
-              "det_gemm_fwd_rhs_transposed: expect A[M,K] and Bt[N,K]");
-  TORCH_CHECK(bt.size(1) == a.size(1), "det_gemm_fwd_rhs_transposed: K mismatch");
-  return gemm_dispatch(a, bt, RhsLayout::kNK);
-}
-
 torch::Tensor det_gemm_fwd_fp32(torch::Tensor a, torch::Tensor b) {
   check_in(a, "A"); check_in(b, "B");
   a = a.contiguous(); b = b.contiguous();
   TORCH_CHECK(a.dim() == 2 && b.dim() == 2, "det_gemm_fwd_fp32: expect 2D [M,K]@[K,N]");
   TORCH_CHECK(b.size(0) == a.size(1), "det_gemm_fwd_fp32: K mismatch");
   // Keep the FP32 running sum; only the final store is BF16.
-  return gemm_dispatch(a, b);
+  return gemm_dispatch(a, b, true);
+}
+
+torch::Tensor det_gemm_fwd_weight(torch::Tensor a, torch::Tensor weight) {
+  check_in(a, "A"); check_in(weight, "weight");
+  a = a.contiguous(); weight = weight.contiguous();
+  TORCH_CHECK(a.dim() == 2 && weight.dim() == 2,
+              "det_gemm_fwd_weight: expect A[M,K], weight[N,K]");
+  TORCH_CHECK(weight.size(1) == a.size(1), "det_gemm_fwd_weight: K mismatch");
+  return gemm_dispatch_bt(a, weight);
+}
+
+torch::Tensor det_gemm_fwd_rhs_transposed(torch::Tensor a, torch::Tensor bt) {
+  return det_gemm_fwd_weight(a, bt);
+}
+
+torch::Tensor det_gemm_da_weight(torch::Tensor dc, torch::Tensor weight) {
+  check_in(dc, "dC"); check_in(weight, "weight");
+  dc = dc.contiguous(); weight = weight.contiguous();
+  TORCH_CHECK(dc.dim() == 2 && weight.dim() == 2,
+              "det_gemm_da_weight: expect dC[M,N], weight[N,K]");
+  TORCH_CHECK(dc.size(1) == weight.size(0), "det_gemm_da_weight: N mismatch");
+  return gemm_dispatch(dc, weight);
+}
+
+torch::Tensor det_gemm_dw(torch::Tensor a, torch::Tensor dc) {
+  check_in(a, "A"); check_in(dc, "dC");
+  a = a.contiguous(); dc = dc.contiguous();
+  TORCH_CHECK(a.dim() == 2 && dc.dim() == 2,
+              "det_gemm_dw: expect A[M,K], dC[M,N]");
+  TORCH_CHECK(a.size(0) == dc.size(0), "det_gemm_dw: M mismatch");
+  return gemm_dispatch(dc.t().contiguous(), a);
+}
+
+torch::Tensor det_gemm_db_transposed(torch::Tensor a, torch::Tensor dc) {
+  return det_gemm_dw(a, dc);
 }
 
 torch::Tensor det_gemm_da(torch::Tensor dc, torch::Tensor b) {
   check_in(dc, "dC"); check_in(b, "B");
-  dc = dc.contiguous(); b = b.contiguous();
-  TORCH_CHECK(dc.dim() == 2 && b.dim() == 2,
-              "det_gemm_da: expect dC[M,N] and B[K,N]");
-  TORCH_CHECK(b.size(1) == dc.size(1), "det_gemm_da: N mismatch");
-  // dA = dC @ B^T.  B already is the physical [K,N] transpose of that
-  // logical RHS, which is exactly the SM90 TMA layout.
-  return gemm_dispatch(dc, b, RhsLayout::kNK);
+  dc = dc.contiguous();
+  auto bt = b.t().contiguous();
+  TORCH_CHECK(bt.size(0) == dc.size(1), "det_gemm_da: N mismatch");
+  return gemm_dispatch(dc, bt);
 }
 
 torch::Tensor det_gemm_db(torch::Tensor a, torch::Tensor dc) {
   check_in(a, "A"); check_in(dc, "dC");
   dc = dc.contiguous();
-  TORCH_CHECK(a.dim() == 2 && dc.dim() == 2,
-              "det_gemm_db: expect A[M,K] and dC[M,N]");
   auto at = a.t().contiguous();
   TORCH_CHECK(dc.size(0) == at.size(1), "det_gemm_db: M mismatch");
   return gemm_dispatch(at, dc);
-}
-
-torch::Tensor det_gemm_db_transposed(torch::Tensor a, torch::Tensor dc) {
-  check_in(a, "A"); check_in(dc, "dC");
-  dc = dc.contiguous();
-  TORCH_CHECK(a.dim() == 2 && dc.dim() == 2,
-              "det_gemm_db_transposed: expect A[M,K] and dC[M,N]");
-  auto at = a.t().contiguous();
-  TORCH_CHECK(dc.size(0) == at.size(1), "det_gemm_db_transposed: M mismatch");
-  // Preserve the exact A^T @ dC MMA/tree evaluation and change only the final
-  // address mapping so the canonical [N,K] weight-gradient is born contiguous.
-  return gemm_dispatch(at, dc, RhsLayout::kKN, OutputLayout::kNM);
 }

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -109,9 +109,13 @@ void deterministic_collective_all_gather(int64_t handle, torch::Tensor& output);
 
 // Batch-Invariant Deterministic GEMM Declarations
 torch::Tensor det_gemm_fwd(torch::Tensor a, torch::Tensor b);
+torch::Tensor det_gemm_fwd_weight(torch::Tensor a, torch::Tensor weight);
 torch::Tensor det_gemm_fwd_rhs_transposed(torch::Tensor a, torch::Tensor bt);
+bool det_gemm_sm90_compiled();
 torch::Tensor det_gemm_da(torch::Tensor dc, torch::Tensor b);
 torch::Tensor det_gemm_db(torch::Tensor a, torch::Tensor dc);
+torch::Tensor det_gemm_da_weight(torch::Tensor dc, torch::Tensor weight);
+torch::Tensor det_gemm_dw(torch::Tensor a, torch::Tensor dc);
 torch::Tensor det_gemm_db_transposed(torch::Tensor a, torch::Tensor dc);
 // SiLU / SwiGLU Declarations (elementwise activation, general CUDA)
 torch::Tensor silu_forward_cuda(torch::Tensor x);
@@ -121,6 +125,10 @@ std::vector<torch::Tensor> swiglu_backward_cuda(
     torch::Tensor dy,
     torch::Tensor gate,
     torch::Tensor up);
+torch::Tensor swiglu_packed_forward_cuda(torch::Tensor gate_up);
+std::vector<torch::Tensor> swiglu_packed_backward_cuda(
+    torch::Tensor dy,
+    torch::Tensor gate_up);
 
 // RMSNorm Declarations & Wrappers
 
@@ -251,6 +259,16 @@ std::vector<torch::Tensor> swiglu_backward(
     torch::Tensor gate,
     torch::Tensor up) {
   return swiglu_backward_cuda(dy, gate, up);
+}
+
+torch::Tensor swiglu_packed_forward(torch::Tensor gate_up) {
+  return swiglu_packed_forward_cuda(gate_up);
+}
+
+std::vector<torch::Tensor> swiglu_packed_backward(
+    torch::Tensor dy,
+    torch::Tensor gate_up) {
+  return swiglu_packed_backward_cuda(dy, gate_up);
 }
 
 // Deterministic standard-softmax attention (issue #147)
@@ -422,16 +440,20 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
 
     // registry Batch-Invariant Deterministic GEMM
     m.def("det_gemm_fwd", &det_gemm_fwd, "Batch-invariant deterministic GEMM forward (C=A@B)");
-    m.def(
-        "det_gemm_fwd_rhs_transposed",
-        &det_gemm_fwd_rhs_transposed,
-        "Batch-invariant deterministic GEMM with physical Bt[N,K] (C=A@Bt^T)");
+    m.def("det_gemm_fwd_weight", &det_gemm_fwd_weight,
+          "Batch-invariant deterministic linear forward (C=A@weight^T)");
+    m.def("det_gemm_fwd_rhs_transposed", &det_gemm_fwd_rhs_transposed,
+          "Batch-invariant deterministic GEMM with physical Bt[N,K] (C=A@Bt^T)");
+    m.def("det_gemm_sm90_compiled", &det_gemm_sm90_compiled,
+          "Whether deterministic GEMM was built with its SM90 path");
     m.def("det_gemm_da", &det_gemm_da, "Batch-invariant deterministic GEMM backward dA (dC@B^T)");
     m.def("det_gemm_db", &det_gemm_db, "Batch-invariant deterministic GEMM backward dB (A^T@dC)");
-    m.def(
-        "det_gemm_db_transposed",
-        &det_gemm_db_transposed,
-        "Batch-invariant deterministic GEMM backward in canonical [N,K] layout");
+    m.def("det_gemm_da_weight", &det_gemm_da_weight,
+          "Batch-invariant deterministic linear backward dA (dC@weight)");
+    m.def("det_gemm_dw", &det_gemm_dw,
+          "Batch-invariant deterministic linear backward dWeight (dC^T@A)");
+    m.def("det_gemm_db_transposed", &det_gemm_db_transposed,
+          "Batch-invariant deterministic GEMM backward in canonical [N,K] layout");
     // registry RMSNorm
     m.def("rmsnorm_forward", &rmsnorm_forward, "Batch-invariant RMSNorm forward CUDA");
     m.def("rmsnorm_backward_dx", &rmsnorm_backward_dx, "Batch-invariant RMSNorm backward dx CUDA");
@@ -442,6 +464,10 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("silu_backward", &silu_backward, "Batch-invariant SiLU backward CUDA");
     m.def("swiglu_forward", &swiglu_forward, "Batch-invariant SwiGLU forward CUDA");
     m.def("swiglu_backward", &swiglu_backward, "Batch-invariant SwiGLU backward CUDA");
+    m.def("swiglu_packed_forward", &swiglu_packed_forward,
+          "Batch-invariant SwiGLU forward for [rows, 2 * intermediate]");
+    m.def("swiglu_packed_backward", &swiglu_packed_backward,
+          "Batch-invariant SwiGLU backward for [rows, 2 * intermediate]");
 
     // Deterministic standard-softmax attention (issue #147)
     m.def(

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026 RL-Kernel Contributors

--- a/examples/vime_qwen3_8b_tp2_cp2/README.md
+++ b/examples/vime_qwen3_8b_tp2_cp2/README.md
@@ -8,7 +8,9 @@ The example is deliberately strict:
 
 - Megatron training uses `TP=2`, `CP=2`, `PP=1`, and four actor ranks.
 - vLLM rollout uses processed logprobs and `top_p=1.0`.
-- Vime must load `rl_engine.integrations.vime.logp.provider` in `strict` mode.
+- Vime must load `rl_engine.integrations.vime.linear_logp.provider` in `strict`
+  mode. The former `rl_engine.integrations.vime.logp.provider` path remains a
+  compatibility alias.
 - A native fallback or a missing provider marker is not reported as a pass.
 - Attention and FFN are not declared consistent from configuration alone. They
   require executed Megatron and vLLM readbacks, so the report marks them
@@ -18,6 +20,30 @@ The example is deliberately strict:
 
 The Vime companion must be installed or checked out separately. This example
 does not modify `vllm-project/vime`.
+
+## User modes
+
+`RL_KERNEL_MODE` is the user-facing switch. The fair runner maps each mode to
+one complete train/rollout route rather than asking users to compose module
+cases manually:
+
+| Mode | Route | Fallback policy | Intended use |
+| --- | --- | --- | --- |
+| `strict` | R/R | fail closed | production bitwise consistency |
+| `audit` | R/R | record every fallback without a strict pass claim | diagnosis and route evidence |
+| `auto` | P/P through installed adapters | observable | compatibility checks |
+| `off` | native P/P, no provider or plugin injection | native by definition | clean baseline |
+
+The recommended post-training comparison is `off` versus `strict`. Both use
+the same aligned framework flags by default, so the measured delta is the
+RL-Kernel backend cost rather than an unrelated determinism configuration.
+The older `pp`, `pp-aligned`, `rr`, and `rr-aligned` names remain accepted.
+
+```bash
+examples/vime_qwen3_8b_tp2_cp2/run_fair_perf_case.sh off
+examples/vime_qwen3_8b_tp2_cp2/run_fair_perf_case.sh strict
+examples/vime_qwen3_8b_tp2_cp2/run_fair_perf_case.sh audit
+```
 
 The executable entry point is the Vime script
 `scripts/run-qwen3-8B-rlkernel-tp2-cp2.sh`. Its default topology is an

--- a/examples/vime_qwen3_8b_tp2_cp2/__init__.py
+++ b/examples/vime_qwen3_8b_tp2_cp2/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) 2026 RL-Kernel Contributors

--- a/examples/vime_qwen3_8b_tp2_cp2/aligned_python_entrypoint.sh
+++ b/examples/vime_qwen3_8b_tp2_cp2/aligned_python_entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REAL_PYTHON="${RL_KERNEL_REAL_PYTHON:?RL_KERNEL_REAL_PYTHON must name the real Python executable}"
+
+if [[ "${1:-}" == "train.py" || "${1:-}" == */train.py ]]; then
+  exec "${REAL_PYTHON}" "$@" \
+    --seed 1234 \
+    --rollout-seed 42 \
+    --vllm-enable-deterministic-inference \
+    --vllm-attention-backend flash_attn \
+    --vllm-disable-custom-all-reduce \
+    --deterministic-mode \
+    --accumulate-allreduce-grads-in-fp32
+fi
+
+exec "${REAL_PYTHON}" "$@"

--- a/examples/vime_qwen3_8b_tp2_cp2/aligned_python_entrypoint.sh
+++ b/examples/vime_qwen3_8b_tp2_cp2/aligned_python_entrypoint.sh
@@ -2,16 +2,80 @@
 set -euo pipefail
 
 REAL_PYTHON="${RL_KERNEL_REAL_PYTHON:?RL_KERNEL_REAL_PYTHON must name the real Python executable}"
+MODE="${RL_KERNEL_MODE:-strict}"
+ALIGNED="${RL_KERNEL_ALIGNED:-0}"
+
+case "${MODE}" in
+  strict|audit|auto|off) ;;
+  *)
+    echo "RL_KERNEL_MODE must be strict, audit, auto, or off; got ${MODE}" >&2
+    exit 2
+    ;;
+esac
 
 if [[ "${1:-}" == "train.py" || "${1:-}" == */train.py ]]; then
-  exec "${REAL_PYTHON}" "$@" \
-    --seed 1234 \
-    --rollout-seed 42 \
-    --vllm-enable-deterministic-inference \
-    --vllm-attention-backend flash_attn \
-    --vllm-disable-custom-all-reduce \
-    --deterministic-mode \
-    --accumulate-allreduce-grads-in-fp32
+  args=()
+  while (( $# )); do
+    case "$1" in
+      --selected-logprob-provider|--selected-logprob-provider-mode|--custom-megatron-init-path)
+        if (( $# < 2 )); then
+          echo "$1 requires a value" >&2
+          exit 2
+        fi
+        if [[ "${MODE}" != off ]]; then
+          args+=("$1")
+          if [[ "$1" == --selected-logprob-provider ]]; then
+            args+=("rl_engine.integrations.vime.linear_logp.provider")
+          else
+            args+=("$2")
+          fi
+        fi
+        shift 2
+        ;;
+      --selected-logprob-provider=*|--selected-logprob-provider-mode=*|--custom-megatron-init-path=*)
+        if [[ "${MODE}" != off ]]; then
+          case "$1" in
+            --selected-logprob-provider=*)
+              args+=("--selected-logprob-provider=rl_engine.integrations.vime.linear_logp.provider")
+              ;;
+            *) args+=("$1") ;;
+          esac
+        fi
+        shift
+        ;;
+      *) args+=("$1"); shift ;;
+    esac
+  done
+
+  if [[ "${ALIGNED}" == 1 ]]; then
+    args+=(
+      --seed 1234
+      --rollout-seed 42
+      --vllm-enable-deterministic-inference
+      --vllm-attention-backend flash_attn
+      --vllm-disable-custom-all-reduce
+      --deterministic-mode
+      --accumulate-allreduce-grads-in-fp32
+    )
+  fi
+
+  case "${MODE}" in
+    strict|audit)
+      export VIME_RL_KERNEL_STRICT=1
+      ;;
+    auto)
+      export VIME_RL_KERNEL_STRICT=0
+      ;;
+    off)
+      exec env \
+        -u RL_KERNEL_VLLM_INTEGRATION \
+        -u VIME_RL_KERNEL_STRICT \
+        -u RL_KERNEL_DET_GEMM_SM90_ONLY \
+        -u RL_KERNEL_CUDA_ONLY \
+        "${REAL_PYTHON}" "${args[@]}"
+      ;;
+  esac
+  exec "${REAL_PYTHON}" "${args[@]}"
 fi
 
 exec "${REAL_PYTHON}" "$@"

--- a/examples/vime_qwen3_8b_tp2_cp2/qwen3_8b_tp2_cp2.json
+++ b/examples/vime_qwen3_8b_tp2_cp2/qwen3_8b_tp2_cp2.json
@@ -15,9 +15,9 @@
     "logprobs_mode": "processed_logprobs"
   },
   "selected_logprob_provider": {
-    "path": "rl_engine.integrations.vime.logp.provider",
+    "path": "rl_engine.integrations.vime.linear_logp.provider",
     "mode": "strict",
-    "backend_id": "pytorch-vocab-parallel-logp-ws2",
+    "backend_id": "rlkernel.linear_logp.bitwise.v1",
     "real_vocab_size": 151936,
     "padded_vocab_size": 152064,
     "num_vocab_tiles": 64

--- a/examples/vime_qwen3_8b_tp2_cp2/run.py
+++ b/examples/vime_qwen3_8b_tp2_cp2/run.py
@@ -61,10 +61,10 @@ def validate_config(config: Mapping[str, Any]) -> None:
         raise ValueError("rollout.top_p must remain 1.0 for the strict provider contract")
     if provider.get("mode") != "strict":
         raise ValueError("selected_logprob_provider.mode must be strict")
-    if provider.get("path") != "rl_engine.integrations.vime.logp.provider":
+    if provider.get("path") != "rl_engine.integrations.vime.linear_logp.provider":
         raise ValueError("example must use the RL-Kernel Vime provider")
-    if provider.get("backend_id") != "pytorch-vocab-parallel-logp-ws2":
-        raise ValueError("example must pin the WS2 vocab-parallel backend")
+    if provider.get("backend_id") != "rlkernel.linear_logp.bitwise.v1":
+        raise ValueError("example must pin the strict bitwise linear_logp backend")
 
 
 def load_runtime_evidence(path: Path | None) -> dict[str, Any] | None:

--- a/examples/vime_qwen3_8b_tp2_cp2/run_fair_perf_case.sh
+++ b/examples/vime_qwen3_8b_tp2_cp2/run_fair_perf_case.sh
@@ -1,13 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MODE="${1:-}"
-case "${MODE}" in
-  pp|pp-aligned|rr|rr-aligned) ;;
+REQUESTED_MODE="${1:-}"
+case "${REQUESTED_MODE}" in
+  strict|audit|auto|off|pp|pp-aligned|rr|rr-aligned) ;;
   *)
-    echo "usage: $0 {pp|pp-aligned|rr|rr-aligned}" >&2
+    echo "usage: $0 {strict|audit|auto|off|pp|pp-aligned|rr|rr-aligned}" >&2
     exit 2
     ;;
+esac
+
+MODE="${REQUESTED_MODE}"
+case_id=R/R
+aligned=1
+provider_mode=strict
+case "${REQUESTED_MODE}" in
+  strict) MODE=strict ;;
+  audit) MODE=audit ;;
+  auto) MODE=auto; case_id=P/P; provider_mode=auto ;;
+  off) MODE=off; case_id=P/P; provider_mode=auto ;;
+  rr-aligned) MODE=strict ;;
+  rr) MODE=strict; aligned=0 ;;
+  pp-aligned) MODE=off; case_id=P/P; provider_mode=auto ;;
+  pp) MODE=off; case_id=P/P; provider_mode=auto; aligned=0 ;;
 esac
 
 VIME_ROOT="${VIME_ROOT:-/home/ellm/ljj/vime-debug-main}"
@@ -18,7 +33,7 @@ TE_SITE="${TE_SITE:-/home/ellm/ljj/.te-2.11.0-site-packages}"
 CUDA_PYTHON_SITE="${CUDA_PYTHON_SITE:-/home/ellm/ljj/.cuda-python-12.8-site-packages}"
 CUDA12_COMPAT_LIB="${CUDA12_COMPAT_LIB:-/home/ellm/ljj/.cuda12-compat-lib}"
 STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
-RUN_ID="${RUN_ID:-fair-${MODE}-${STAMP}}"
+RUN_ID="${RUN_ID:-fair-${REQUESTED_MODE}-${STAMP}}"
 ARTIFACT_DIR="${ARTIFACT_DIR:-${VIME_ROOT}/outputs/rlkernel/${RUN_ID}}"
 TRACE_MODE="${TRACE_MODE:-0}"
 
@@ -26,29 +41,30 @@ NVIDIA_LIBS="$(find "$(dirname "$(dirname "${PYTHON_BIN}")")/lib/python3.11/site
 export PYTHONPATH="${CUDA_PYTHON_SITE}:${TE_SITE}:${PYTHONPATH:-}"
 export LD_LIBRARY_PATH="${CUDA12_COMPAT_LIB}:${TE_SITE}/transformer_engine/wheel_lib${NVIDIA_LIBS:+:${NVIDIA_LIBS}}:${LD_LIBRARY_PATH:-}"
 
-case_id=R/R
-[[ "${MODE}" == pp* ]] && case_id=P/P
-aligned=0
-[[ "${MODE}" == *-aligned ]] && aligned=1
 cp_comm_type=all_gather
 ci_test=1
 validate_artifacts="${VALIDATE_ARTIFACTS:-1}"
-if [[ "${MODE}" == pp* ]]; then
+if [[ "${case_id}" == P/P ]]; then
   cp_comm_type=p2p
   ci_test=0
   validate_artifacts=0
 fi
+if [[ "${MODE}" == audit ]]; then
+  validate_artifacts=0
+fi
 launcher="${VIME_ROOT}/scripts/codex-debug-qwen3-8B-production-pp-tp2-cp2.sh"
-run_python="${PYTHON_BIN}"
-aligned_env=()
+run_python="${RL_KERNEL_ROOT}/examples/vime_qwen3_8b_tp2_cp2/aligned_python_entrypoint.sh"
+[[ -x "${run_python}" ]] || {
+  echo "RL-Kernel Python entrypoint is not executable: ${run_python}" >&2
+  exit 3
+}
+adapter_env=(
+  RL_KERNEL_REAL_PYTHON="${PYTHON_BIN}"
+  RL_KERNEL_MODE="${MODE}"
+  RL_KERNEL_ALIGNED="${aligned}"
+)
 if [[ "${aligned}" == 1 ]]; then
-  run_python="${RL_KERNEL_ROOT}/examples/vime_qwen3_8b_tp2_cp2/aligned_python_entrypoint.sh"
-  [[ -x "${run_python}" ]] || {
-    echo "Aligned Python entrypoint is not executable: ${run_python}" >&2
-    exit 3
-  }
-  aligned_env=(
-    RL_KERNEL_REAL_PYTHON="${PYTHON_BIN}"
+  adapter_env+=(
     VLLM_BATCH_INVARIANT=1
     NCCL_ALGO=Ring
     NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
@@ -56,19 +72,24 @@ if [[ "${aligned}" == 1 ]]; then
     CUBLASLT_WORKSPACE_SIZE=1
   )
 fi
+if [[ "${MODE}" == audit ]]; then
+  adapter_env+=(RL_KERNEL_ROUTE_REPORT_ALL_RANKS=1)
+fi
 
 mkdir -p "${ARTIFACT_DIR}"
-run_case=(env "${aligned_env[@]}" \
+run_case=(env "${adapter_env[@]}" \
+  RL_KERNEL_MODE="${MODE}" \
   RL_KERNEL_ROOT="${RL_KERNEL_ROOT}" \
   PYTHON_BIN="${run_python}" \
   RAY_BIN="${RAY_BIN}" \
   RL_KERNEL_RUN_ID="${RUN_ID}" \
   RL_KERNEL_ARTIFACT_DIR="${ARTIFACT_DIR}" \
-  RAY_TEMP_DIR="/tmp/rlk-fair-${MODE}" \
+  RAY_TEMP_DIR="/tmp/rlk-fair-${REQUESTED_MODE}" \
   VIME_CKPT="${ARTIFACT_DIR}/unused-checkpoint" \
   RL_KERNEL_ATTENTION_CASE="${case_id}" \
   RL_KERNEL_FFN_CASE="${case_id}" \
   RL_KERNEL_LOGP_CASE="${case_id}" \
+  SELECTED_LOGPROB_PROVIDER_MODE="${provider_mode}" \
   TRANSFORMER_IMPL=transformer_engine \
   ATTENTION_BACKEND="${ATTENTION_BACKEND:-auto}" \
   VLLM_ENFORCE_EAGER=0 \
@@ -100,7 +121,7 @@ elif [[ "${TRACE_MODE}" == 1 ]]; then
     exit 3
   }
   trace_base="${ARTIFACT_DIR}/trace/full-stack"
-  session="rlkfair${MODE//-/}$$"
+  session="rlkfair${REQUESTED_MODE//-/}$$"
   launch_pid=""
   cleanup_trace() {
     nsys stop --session="${session}" >/dev/null 2>&1 || true
@@ -153,5 +174,5 @@ if [[ "${validate_artifacts}" == 1 ]]; then
     >>"${ARTIFACT_DIR}/run.log"
 fi
 
-printf 'MODE=%s\nRUN_ID=%s\nARTIFACT_DIR=%s\n' \
-  "${MODE}" "${RUN_ID}" "${ARTIFACT_DIR}"
+printf 'MODE=%s\nREQUESTED_MODE=%s\nRUN_ID=%s\nARTIFACT_DIR=%s\n' \
+  "${MODE}" "${REQUESTED_MODE}" "${RUN_ID}" "${ARTIFACT_DIR}"

--- a/examples/vime_qwen3_8b_tp2_cp2/run_fair_perf_case.sh
+++ b/examples/vime_qwen3_8b_tp2_cp2/run_fair_perf_case.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-}"
+case "${MODE}" in
+  pp|pp-aligned|rr|rr-aligned) ;;
+  *)
+    echo "usage: $0 {pp|pp-aligned|rr|rr-aligned}" >&2
+    exit 2
+    ;;
+esac
+
+VIME_ROOT="${VIME_ROOT:-/home/ellm/ljj/vime-debug-main}"
+RL_KERNEL_ROOT="${RL_KERNEL_ROOT:-/home/ellm/ljj/RL-Kernel-issue335-fix}"
+PYTHON_BIN="${PYTHON_BIN:-/home/ellm/workspace/ljj/.conda/envs/rlk-attention-engines/bin/python}"
+RAY_BIN="${RAY_BIN:-$(dirname "${PYTHON_BIN}")/ray}"
+TE_SITE="${TE_SITE:-/home/ellm/ljj/.te-2.11.0-site-packages}"
+CUDA_PYTHON_SITE="${CUDA_PYTHON_SITE:-/home/ellm/ljj/.cuda-python-12.8-site-packages}"
+CUDA12_COMPAT_LIB="${CUDA12_COMPAT_LIB:-/home/ellm/ljj/.cuda12-compat-lib}"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_ID="${RUN_ID:-fair-${MODE}-${STAMP}}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-${VIME_ROOT}/outputs/rlkernel/${RUN_ID}}"
+TRACE_MODE="${TRACE_MODE:-0}"
+
+NVIDIA_LIBS="$(find "$(dirname "$(dirname "${PYTHON_BIN}")")/lib/python3.11/site-packages/nvidia" -type d -name lib -print 2>/dev/null | paste -sd: -)"
+export PYTHONPATH="${CUDA_PYTHON_SITE}:${TE_SITE}:${PYTHONPATH:-}"
+export LD_LIBRARY_PATH="${CUDA12_COMPAT_LIB}:${TE_SITE}/transformer_engine/wheel_lib${NVIDIA_LIBS:+:${NVIDIA_LIBS}}:${LD_LIBRARY_PATH:-}"
+
+case_id=R/R
+[[ "${MODE}" == pp* ]] && case_id=P/P
+aligned=0
+[[ "${MODE}" == *-aligned ]] && aligned=1
+cp_comm_type=all_gather
+ci_test=1
+validate_artifacts="${VALIDATE_ARTIFACTS:-1}"
+if [[ "${MODE}" == pp* ]]; then
+  cp_comm_type=p2p
+  ci_test=0
+  validate_artifacts=0
+fi
+launcher="${VIME_ROOT}/scripts/codex-debug-qwen3-8B-production-pp-tp2-cp2.sh"
+run_python="${PYTHON_BIN}"
+aligned_env=()
+if [[ "${aligned}" == 1 ]]; then
+  run_python="${RL_KERNEL_ROOT}/examples/vime_qwen3_8b_tp2_cp2/aligned_python_entrypoint.sh"
+  [[ -x "${run_python}" ]] || {
+    echo "Aligned Python entrypoint is not executable: ${run_python}" >&2
+    exit 3
+  }
+  aligned_env=(
+    RL_KERNEL_REAL_PYTHON="${PYTHON_BIN}"
+    VLLM_BATCH_INVARIANT=1
+    NCCL_ALGO=Ring
+    NVTE_ALLOW_NONDETERMINISTIC_ALGO=0
+    CUBLAS_WORKSPACE_CONFIG=:16:8
+    CUBLASLT_WORKSPACE_SIZE=1
+  )
+fi
+
+mkdir -p "${ARTIFACT_DIR}"
+run_case=(env "${aligned_env[@]}" \
+  RL_KERNEL_ROOT="${RL_KERNEL_ROOT}" \
+  PYTHON_BIN="${run_python}" \
+  RAY_BIN="${RAY_BIN}" \
+  RL_KERNEL_RUN_ID="${RUN_ID}" \
+  RL_KERNEL_ARTIFACT_DIR="${ARTIFACT_DIR}" \
+  RAY_TEMP_DIR="/tmp/rlk-fair-${MODE}" \
+  VIME_CKPT="${ARTIFACT_DIR}/unused-checkpoint" \
+  RL_KERNEL_ATTENTION_CASE="${case_id}" \
+  RL_KERNEL_FFN_CASE="${case_id}" \
+  RL_KERNEL_LOGP_CASE="${case_id}" \
+  TRANSFORMER_IMPL=transformer_engine \
+  ATTENTION_BACKEND="${ATTENTION_BACKEND:-auto}" \
+  VLLM_ENFORCE_EAGER=0 \
+  TP_SIZE=2 \
+  CP_SIZE=2 \
+  CP_COMM_TYPE="${cp_comm_type}" \
+  ACTOR_GPUS=4 \
+  ROLLOUT_GPUS=4 \
+  NUM_GPUS=8 \
+  ROLLOUT_GPUS_PER_ENGINE=2 \
+  ROLLOUT_BATCH_SIZE=1 \
+  N_SAMPLES_PER_PROMPT=2 \
+  MAX_RESPONSE_LEN=128 \
+  GLOBAL_BATCH_SIZE=2 \
+  MAX_TOKENS_PER_GPU=2048 \
+  NUM_ROLLOUT="${NUM_ROLLOUT:-3}" \
+  CI_TEST="${ci_test}" \
+  SAVE_OPTIM=0 \
+  SAVE_CHECKPOINT=0 \
+  VALIDATE_ARTIFACTS=0 \
+  TRACE_MODE=0 \
+  bash "${launcher}")
+
+if [[ "${TRACE_MODE}" == 0 ]]; then
+  "${run_case[@]}" >"${ARTIFACT_DIR}/run.log" 2>&1
+elif [[ "${TRACE_MODE}" == 1 ]]; then
+  command -v nsys >/dev/null || {
+    echo "TRACE_MODE=1 requires nsys" >&2
+    exit 3
+  }
+  trace_base="${ARTIFACT_DIR}/trace/full-stack"
+  session="rlkfair${MODE//-/}$$"
+  launch_pid=""
+  cleanup_trace() {
+    nsys stop --session="${session}" >/dev/null 2>&1 || true
+    [[ -z "${launch_pid}" ]] || kill "${launch_pid}" >/dev/null 2>&1 || true
+  }
+  mkdir -p "${ARTIFACT_DIR}/trace"
+  trap cleanup_trace EXIT
+  nsys launch \
+    --session-new="${session}" \
+    --trace=cuda,nvtx \
+    --cuda-graph-trace=node \
+    --trace-fork-before-exec=true \
+    --wait=primary \
+    --show-output=true \
+    "${run_case[@]}" >"${ARTIFACT_DIR}/run.log" 2>&1 &
+  launch_pid=$!
+  sleep 1
+  nsys start \
+    --session="${session}" \
+    --sample=none \
+    --cpuctxsw=none \
+    --force-overwrite=true \
+    --output="${trace_base}"
+  set +e
+  wait "${launch_pid}"
+  run_status=$?
+  set -e
+  launch_pid=""
+  nsys stop --session="${session}" || true
+  trap - EXIT
+  (( run_status == 0 )) || exit "${run_status}"
+  nsys stats --report cuda_gpu_kern_sum --format csv \
+    "${trace_base}.nsys-rep" >"${trace_base}-kernels.csv"
+  grep -Eq '^"?[0-9]+([.][0-9]+)?"?,' "${trace_base}-kernels.csv" || {
+    echo "Nsight trace contains no CUDA kernel data" >&2
+    exit 4
+  }
+else
+  echo "TRACE_MODE must be 0 or 1" >&2
+  exit 2
+fi
+
+if [[ "${validate_artifacts}" == 1 ]]; then
+  "${PYTHON_BIN}" \
+    "${RL_KERNEL_ROOT}/examples/vime_qwen3_8b_tp2_cp2/validate_artifacts.py" \
+    --readback-dir "${ARTIFACT_DIR}/readbacks" \
+    --train-data-dir "${ARTIFACT_DIR}/train-data" \
+    --output "${ARTIFACT_DIR}/bitwise-validation.json" \
+    --runtime-ci-zero-threshold-passed \
+    >>"${ARTIFACT_DIR}/run.log"
+fi
+
+printf 'MODE=%s\nRUN_ID=%s\nARTIFACT_DIR=%s\n' \
+  "${MODE}" "${RUN_ID}" "${ARTIFACT_DIR}"

--- a/examples/vime_qwen3_8b_tp2_cp2/validate_artifacts.py
+++ b/examples/vime_qwen3_8b_tp2_cp2/validate_artifacts.py
@@ -94,11 +94,16 @@ def _load_train_dump(path: Path) -> Mapping[str, Any]:
     return value
 
 
-def compare_train_rollout_logps(paths: list[Path]) -> dict[str, Any]:
+def compare_train_rollout_logps(
+    paths: list[Path],
+    *,
+    runtime_ci_zero_threshold_passed: bool = False,
+) -> dict[str, Any]:
     sample_count = 0
     element_count = 0
     mismatch_count = 0
     max_abs_diff = 0.0
+    runtime_asserted_sample_count = 0
     errors: list[str] = []
     for path in paths:
         payload = _load_train_dump(path)
@@ -110,10 +115,29 @@ def compare_train_rollout_logps(paths: list[Path]) -> dict[str, Any]:
                 continue
             training_values = rollout_data.get("log_probs")
             rollout_values = rollout_data.get("rollout_log_probs")
-            if not isinstance(training_values, (list, tuple)) or not isinstance(
-                rollout_values, (list, tuple)
-            ):
+            if not isinstance(rollout_values, (list, tuple)):
                 errors.append(f"{path} rollout_data lacks list log_probs/rollout_log_probs")
+                continue
+            if not isinstance(training_values, (list, tuple)):
+                if not runtime_ci_zero_threshold_passed:
+                    errors.append(
+                        f"{path} rollout_data lacks list log_probs and no successful "
+                        "zero-threshold runtime CI assertion was supplied"
+                    )
+                    continue
+                invalid = [
+                    index
+                    for index, value in enumerate(rollout_values)
+                    if not isinstance(value, torch.Tensor)
+                ]
+                if invalid:
+                    errors.append(
+                        f"{path} rollout_log_probs contains non-tensors at {invalid}"
+                    )
+                    continue
+                sample_count += len(rollout_values)
+                runtime_asserted_sample_count += len(rollout_values)
+                element_count += sum(value.numel() for value in rollout_values)
                 continue
             if len(training_values) != len(rollout_values):
                 errors.append(
@@ -167,15 +191,29 @@ def compare_train_rollout_logps(paths: list[Path]) -> dict[str, Any]:
         "max_abs_diff": max_abs_diff if math.isfinite(max_abs_diff) else None,
         "sample_count": sample_count,
         "element_count": element_count,
+        "comparison_mode": (
+            "runtime_ci_zero_threshold"
+            if runtime_asserted_sample_count and sample_count == runtime_asserted_sample_count
+            else "tensor_equality"
+        ),
+        "runtime_asserted_sample_count": runtime_asserted_sample_count,
         "errors": errors,
         "artifacts": [str(path) for path in paths],
     }
 
 
-def validate_artifacts(readback_dir: Path, train_data_dir: Path) -> dict[str, Any]:
+def validate_artifacts(
+    readback_dir: Path,
+    train_data_dir: Path,
+    *,
+    runtime_ci_zero_threshold_passed: bool = False,
+) -> dict[str, Any]:
     readbacks = validate_readbacks(load_readbacks(readback_dir))
     train_paths = sorted(train_data_dir.glob("*.pt"))
-    bitwise = compare_train_rollout_logps(train_paths)
+    bitwise = compare_train_rollout_logps(
+        train_paths,
+        runtime_ci_zero_threshold_passed=runtime_ci_zero_threshold_passed,
+    )
     return {
         "schema_version": "rlkernel.vime_cuda_bitwise_validation.v1",
         "passed": bool(readbacks["passed"] and bitwise["passed"]),
@@ -190,10 +228,22 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--readback-dir", type=Path, required=True)
     parser.add_argument("--train-data-dir", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--runtime-ci-zero-threshold-passed",
+        action="store_true",
+        help=(
+            "accept Vime's successful train/rollout absolute-difference assertion "
+            "at threshold 0 when train dumps omit computed log_probs"
+        ),
+    )
     args = parser.parse_args(argv)
 
     try:
-        report = validate_artifacts(args.readback_dir, args.train_data_dir)
+        report = validate_artifacts(
+            args.readback_dir,
+            args.train_data_dir,
+            runtime_ci_zero_threshold_passed=args.runtime_ci_zero_threshold_passed,
+        )
     except Exception as exc:
         report = {
             "schema_version": "rlkernel.vime_cuda_bitwise_validation.v1",

--- a/rl_engine/distributed/collectives.py
+++ b/rl_engine/distributed/collectives.py
@@ -14,6 +14,37 @@ import torch.distributed as dist
 _SUPPORTED_WORLD_SIZES = (1, 2, 4, 8)
 _DEFAULT_MAX_SIZE_BYTES = 64 * 1024 * 1024
 _REDUCTION_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+_COLLECTIVES: dict[tuple[int, int, int, int], DeterministicCollective] = {}
+DETERMINISTIC_ALL_REDUCE_OP = "rl_kernel::deterministic_all_reduce_"
+
+
+@torch.library.custom_op(DETERMINISTIC_ALL_REDUCE_OP, mutates_args={"input"})
+def _deterministic_all_reduce_(input: torch.Tensor, collective_handle: int) -> None:
+    """Expose the stateful IPC reduction as an explicit graph mutation."""
+
+    from rl_engine import _C
+
+    _C.deterministic_collective_stage(collective_handle, input)
+    _C.deterministic_collective_all_reduce(collective_handle, input)
+
+
+@_deterministic_all_reduce_.register_fake
+def _deterministic_all_reduce_fake(
+    input: torch.Tensor,
+    collective_handle: int,
+) -> None:
+    del input, collective_handle
+
+
+def deterministic_all_reduce_inplace(
+    input: torch.Tensor,
+    *,
+    collective_handle: int,
+) -> torch.Tensor:
+    """Run the graph-visible deterministic all-reduce in place."""
+
+    _deterministic_all_reduce_(input, collective_handle)
+    return input
 
 
 class DeterministicCollective:
@@ -26,9 +57,9 @@ class DeterministicCollective:
     node evaluates the lower logical subtree before the higher one.
 
     One instance owns a symmetric CUDA IPC staging buffer. All ranks must call
-    its methods in the same order with matching shapes and dtypes. Calls are
-    host-synchronizing by design; the first version prioritizes determinism and
-    lifetime safety over overlap or throughput.
+    its methods in the same order with matching shapes and dtypes. Device-side
+    IPC sequence fences order staging and payload access without a steady-state
+    host barrier and advance correctly during CUDA Graph replay.
     """
 
     def __init__(
@@ -39,7 +70,9 @@ class DeterministicCollective:
         max_size_bytes: int = _DEFAULT_MAX_SIZE_BYTES,
     ) -> None:
         if not dist.is_available() or not dist.is_initialized():
-            raise RuntimeError("torch.distributed must be initialized before collectives")
+            raise RuntimeError(
+                "torch.distributed must be initialized before collectives"
+            )
         if not torch.cuda.is_available():
             raise RuntimeError("deterministic collectives require CUDA")
         if max_size_bytes <= 0:
@@ -61,7 +94,9 @@ class DeterministicCollective:
         else:
             normalized_device = torch.device(device)
         if normalized_device.type != "cuda":
-            raise ValueError(f"deterministic collectives require a CUDA device, got {device!r}")
+            raise ValueError(
+                f"deterministic collectives require a CUDA device, got {device!r}"
+            )
         if normalized_device.index is None:
             normalized_device = torch.device("cuda", torch.cuda.current_device())
         if normalized_device.index != torch.cuda.current_device():
@@ -98,13 +133,16 @@ class DeterministicCollective:
         self._extension = _C
         self._lock = threading.Lock()
         self._handle = 0
-        self._staging = torch.empty(
-            self.max_size_bytes,
+        self._validated_signatures: set[tuple[Any, ...]] = set()
+        self._staging = torch.zeros(
+            self.max_size_bytes + 2 * 8,
             dtype=torch.uint8,
             device=self.device,
         )
 
-        handle, offset = self._extension.deterministic_collective_ipc_meta(self._staging)
+        handle, offset = self._extension.deterministic_collective_ipc_meta(
+            self._staging
+        )
         local_meta = {
             "handle": handle,
             "offset": int(offset),
@@ -138,6 +176,7 @@ class DeterministicCollective:
         input: torch.Tensor,
         *,
         out: torch.Tensor | None = None,
+        validate_signature: bool = True,
     ) -> torch.Tensor:
         """Return the TBIK-compatible fixed-tree sum on every rank.
 
@@ -153,11 +192,10 @@ class DeterministicCollective:
         self._validate_output(out, input)
 
         with self._lock:
-            self._validate_matching_signature("all_reduce", input)
+            if validate_signature:
+                self._validate_matching_signature("all_reduce", input)
             self._extension.deterministic_collective_stage(self._handle, input)
-            self._synchronize_ranks()
             self._extension.deterministic_collective_all_reduce(self._handle, out)
-            self._synchronize_ranks()
         return out
 
     def all_gather(
@@ -165,6 +203,7 @@ class DeterministicCollective:
         input: torch.Tensor,
         *,
         out: torch.Tensor | None = None,
+        validate_signature: bool = True,
     ) -> torch.Tensor:
         """Gather rank-ordered input bit patterns along dimension 0.
 
@@ -180,11 +219,10 @@ class DeterministicCollective:
         self._validate_sharded_output(out, input, output_shape)
 
         with self._lock:
-            self._validate_matching_signature("all_gather", input)
+            if validate_signature:
+                self._validate_matching_signature("all_gather", input)
             self._extension.deterministic_collective_stage(self._handle, input)
-            self._synchronize_ranks()
             self._extension.deterministic_collective_all_gather(self._handle, out)
-            self._synchronize_ranks()
         return out
 
     def reduce_scatter(
@@ -192,6 +230,7 @@ class DeterministicCollective:
         input: torch.Tensor,
         *,
         out: torch.Tensor | None = None,
+        validate_signature: bool = True,
     ) -> torch.Tensor:
         """TBIK-compatible fixed-tree sum, then a rank-ordered dimension-0 scatter.
 
@@ -214,11 +253,10 @@ class DeterministicCollective:
         self._validate_sharded_output(out, input, output_shape)
 
         with self._lock:
-            self._validate_matching_signature("reduce_scatter", input)
+            if validate_signature:
+                self._validate_matching_signature("reduce_scatter", input)
             self._extension.deterministic_collective_stage(self._handle, input)
-            self._synchronize_ranks()
             self._extension.deterministic_collective_reduce_scatter(self._handle, out)
-            self._synchronize_ranks()
         return out
 
     def close(self) -> None:
@@ -303,18 +341,23 @@ class DeterministicCollective:
         if output.dtype != input.dtype:
             raise TypeError("out must have the same dtype as input")
         if output.shape != output_shape:
-            raise ValueError(f"out must have shape {output_shape}, got {tuple(output.shape)}")
+            raise ValueError(
+                f"out must have shape {output_shape}, got {tuple(output.shape)}"
+            )
         if not output.is_contiguous():
             raise ValueError("out must be contiguous")
 
     def _validate_matching_signature(self, op_name: str, input: torch.Tensor) -> None:
         signature = (op_name, tuple(input.shape), str(input.dtype), input.numel())
+        if signature in self._validated_signatures:
+            return
         signatures: list[tuple[Any, ...] | None] = [None] * self.world_size
         dist.all_gather_object(signatures, signature, group=self.group)
         if any(peer_signature != signature for peer_signature in signatures):
             raise ValueError(
                 f"all ranks must call {op_name} with matching shapes and dtypes; got {signatures}"
             )
+        self._validated_signatures.add(signature)
 
     def _synchronize_ranks(self) -> None:
         torch.cuda.synchronize(self.device)
@@ -323,3 +366,46 @@ class DeterministicCollective:
             dist.barrier(group=self.group, device_ids=[self.device.index])
         else:
             dist.barrier(group=self.group)
+
+
+def collective_for_group(
+    group: dist.ProcessGroup | None,
+    *,
+    min_size_bytes: int = 0,
+    minimum_capacity_bytes: int = _DEFAULT_MAX_SIZE_BYTES,
+    device: torch.device | str | int | None = None,
+) -> DeterministicCollective | None:
+    """Return the process-local RL-Kernel collective shared by hot-path ops."""
+
+    if group is None:
+        return None
+    if min_size_bytes < 0:
+        raise ValueError("min_size_bytes must be non-negative")
+    if minimum_capacity_bytes <= 0:
+        raise ValueError("minimum_capacity_bytes must be positive")
+
+    rank = dist.get_rank(group=group)
+    world_size = dist.get_world_size(group=group)
+    if device is None:
+        device_index = torch.cuda.current_device()
+    else:
+        normalized_device = torch.device("cuda", device) if isinstance(device, int) else torch.device(device)
+        device_index = (
+            torch.cuda.current_device()
+            if normalized_device.index is None
+            else normalized_device.index
+        )
+    key = (id(group), rank, world_size, device_index)
+    cached = _COLLECTIVES.get(key)
+    if cached is not None and cached.max_size_bytes >= min_size_bytes:
+        return cached
+    if cached is not None:
+        cached.close()
+
+    collective = DeterministicCollective(
+        group=group,
+        device=device_index,
+        max_size_bytes=max(minimum_capacity_bytes, min_size_bytes),
+    )
+    _COLLECTIVES[key] = collective
+    return collective

--- a/rl_engine/integrations/__init__.py
+++ b/rl_engine/integrations/__init__.py
@@ -16,12 +16,22 @@ from rl_engine.integrations.megatron import MegatronIntegration
 from rl_engine.integrations.megatron_runtime import install_megatron_integration
 from rl_engine.integrations.vllm import VllmIntegration
 from rl_engine.integrations.vllm_runtime import configure_vllm_environment
+from rl_engine.runtime_mode import (
+    RLKernelMode,
+    RLKernelModePolicy,
+    rl_kernel_mode,
+    rl_kernel_mode_policy,
+    route_report_enabled,
+    strict_contract_enabled,
+)
 
 __all__ = [
     "Implementation",
     "IntegrationPlan",
     "MegatronIntegration",
     "OperatorAblationCase",
+    "RLKernelMode",
+    "RLKernelModePolicy",
     "VllmIntegration",
     "configure_integration_environment",
     "configure_vllm_environment",
@@ -29,4 +39,8 @@ __all__ = [
     "integration_plan_from_environment",
     "operator_ablation_case",
     "operator_ablation_cases",
+    "rl_kernel_mode",
+    "rl_kernel_mode_policy",
+    "route_report_enabled",
+    "strict_contract_enabled",
 ]

--- a/rl_engine/integrations/framework_operators.py
+++ b/rl_engine/integrations/framework_operators.py
@@ -16,8 +16,12 @@ from threading import Lock
 from typing import Any, Mapping, cast
 
 import torch
+
 from rl_engine.alignment.cross_config.operators import OperatorBridge, OperatorOverride
-from rl_engine.integrations.linear_logp import LinearLogpWrapper, take_rollout_linear_logp_context
+from rl_engine.integrations.linear_logp import (
+    LinearLogpWrapper,
+    take_rollout_linear_logp_context,
+)
 from rl_engine.kernels.attention_contract import (
     STRICT_ATTENTION_FA4_SCHEDULE_ID,
     STRICT_ATTENTION_PRODUCTION_CORE_ID,
@@ -25,17 +29,26 @@ from rl_engine.kernels.attention_contract import (
     AttentionDType,
     AttentionMode,
     AttentionRole,
+    SplitKVSpec,
 )
 from rl_engine.kernels.attention_contract import ReductionSpec as AttentionReductionSpec
 from rl_engine.kernels.attention_contract import ShardingSpec as AttentionShardingSpec
-from rl_engine.kernels.attention_contract import SplitKVSpec
-from rl_engine.kernels.logprob_contract import LogprobContract, LogprobDType, LogprobRole, MaskSpec
+from rl_engine.kernels.logprob_contract import (
+    LogprobContract,
+    LogprobDType,
+    LogprobRole,
+    MaskSpec,
+)
 from rl_engine.kernels.logprob_contract import ReductionSpec as LogprobReductionSpec
 from rl_engine.kernels.logprob_contract import ShardingSpec as LogprobShardingSpec
+from rl_engine.kernels.ops.cuda.matmul.det_gemm import det_gemm_backend_id
 from rl_engine.kernels.ops.pytorch.attention.ablation import AttentionAblationConfig
-from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import BACKEND_ID as LOGP_BACKEND_ID
-from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import DEFAULT_NUM_VOCAB_TILES
-from rl_engine.kernels.registry import kernel_registry
+from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import (
+    BACKEND_ID as LOGP_BACKEND_ID,
+)
+from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import (
+    DEFAULT_NUM_VOCAB_TILES,
+)
 from rl_engine.kernels.semantic_registry import OperatorRequirements
 
 ATTENTION_BACKEND_ID = "rlkernel.attention.deterministic.v1"
@@ -62,38 +75,15 @@ def _optional_env_int(name: str) -> int | None:
         return None
 
 
-def _tensor_debug_stats(tensor: torch.Tensor) -> dict[str, Any]:
-    detached = tensor.detach()
-    stats: dict[str, Any] = {
-        "shape": list(detached.shape),
-        "dtype": _dtype_name(detached),
-        "device": str(detached.device),
-        "numel": int(detached.numel()),
+def _tensor_metadata(tensor: torch.Tensor) -> dict[str, Any]:
+    """Describe a hot-path tensor without reading CUDA values on the host."""
+
+    return {
+        "shape": list(tensor.shape),
+        "dtype": _dtype_name(tensor),
+        "device": str(tensor.device),
+        "numel": int(tensor.numel()),
     }
-    if detached.numel() == 0:
-        return stats
-    values = detached.float()
-    stats.update(
-        {
-            "min": float(values.min().item()),
-            "max": float(values.max().item()),
-            "mean": float(values.mean().item()),
-        }
-    )
-    return stats
-
-
-def _diff_debug_stats(left: torch.Tensor, right: torch.Tensor) -> dict[str, Any]:
-    if left.shape != right.shape:
-        return {
-            "shape_mismatch": True,
-            "left_shape": list(left.shape),
-            "right_shape": list(right.shape),
-        }
-    diff = (left.detach().float() - right.detach().float()).abs()
-    stats = _tensor_debug_stats(diff)
-    stats["mismatch_count"] = int(torch.ne(left.detach(), right.detach()).sum().item())
-    return stats
 
 
 def _attention_dtype(tensor: torch.Tensor) -> AttentionDType:
@@ -123,8 +113,9 @@ class SemanticOperatorHandle:
         self.backend_id = backend_id
         self._bridge = OperatorBridge()
         self._instance: Any | None = None
-        self._requirements: OperatorRequirements | None = None
         self._provenance: dict[str, Any] | None = None
+        self._runtime_device: torch.device | None = None
+        self._runtime_dtype: torch.dtype | None = None
         self._lock = Lock()
 
     def get(
@@ -134,12 +125,6 @@ class SemanticOperatorHandle:
         topology: Mapping[str, Any],
         factory_kwargs: Mapping[str, Any] | None = None,
     ) -> Any:
-        requirements = OperatorRequirements(
-            device=_device_name(tensor),
-            dtype=_dtype_name(tensor),
-            topology=topology,
-            alignment_properties={"deterministic": True},
-        )
         # This method is called from vLLM model forwards that may be captured
         # by torch.compile.  A Lock context manager is unsupported in a
         # Dynamo fullgraph, so keep the hot-path lookup lock-free.  Handles
@@ -152,14 +137,20 @@ class SemanticOperatorHandle:
             # TP=2. The operator receives the live group at invocation time;
             # keep device and dtype strict, but do not reject this topology
             # transition after the semantic instance is resolved.
-            if self._requirements is not None and (
-                requirements.device != self._requirements.device
-                or requirements.dtype != self._requirements.dtype
+            if (
+                tensor.device != self._runtime_device
+                or tensor.dtype != self._runtime_dtype
             ):
                 raise RuntimeError(
                     f"{self.semantic_op} runtime device/dtype changed after resolution"
                 )
             return self._instance
+        requirements = OperatorRequirements(
+            device=_device_name(tensor),
+            dtype=_dtype_name(tensor),
+            topology=topology,
+            alignment_properties={"deterministic": True},
+        )
         target = cast(Any, self.target)
         resolved = self._bridge.resolve_override(
             OperatorOverride.for_target(
@@ -188,8 +179,9 @@ class SemanticOperatorHandle:
                 f"{actual_backend!r}"
             )
         self._instance = instance
-        self._requirements = requirements
         self._provenance = provenance.to_dict()
+        self._runtime_device = tensor.device
+        self._runtime_dtype = tensor.dtype
         return instance
 
     @property
@@ -206,9 +198,40 @@ def _weight(module: Any, name: str) -> torch.Tensor:
     return value
 
 
-def _split_gate_up(weight: torch.Tensor, name: str) -> tuple[torch.Tensor, torch.Tensor]:
+def _fused_rms_norm_input(
+    projection: Any,
+    hidden_states: torch.Tensor,
+    name: str,
+) -> torch.Tensor:
+    """Recover the RMSNorm hidden by TE's LayerNormLinear wrapper."""
+
+    weight = getattr(projection, "layer_norm_weight", None)
+    if weight is None:
+        return hidden_states
+    if not isinstance(weight, torch.Tensor):
+        raise RuntimeError(f"{name}.layer_norm_weight must be a tensor")
+    if getattr(projection, "normalization", None) != "RMSNorm":
+        raise RuntimeError(f"strict {name} requires fused RMSNorm")
+    if getattr(projection, "layer_norm_bias", None) is not None:
+        raise RuntimeError(f"strict {name} RMSNorm must be bias-free")
+    if bool(getattr(projection, "zero_centered_gamma", False)):
+        raise RuntimeError(f"strict {name} does not support zero-centered gamma")
+    eps = float(getattr(projection, "eps"))
+    return torch.nn.functional.rms_norm(
+        hidden_states,
+        (hidden_states.shape[-1],),
+        weight,
+        eps,
+    )
+
+
+def _split_gate_up(
+    weight: torch.Tensor, name: str
+) -> tuple[torch.Tensor, torch.Tensor]:
     if weight.size(0) % 2:
-        raise RuntimeError(f"{name}.weight first dimension must contain equal gate/up shards")
+        raise RuntimeError(
+            f"{name}.weight first dimension must contain equal gate/up shards"
+        )
     gate, up = weight.chunk(2, dim=0)
     return gate.contiguous(), up.contiguous()
 
@@ -251,35 +274,61 @@ def _packed_local_sequence_layout(
     """Recover local THD sequence offsets from Megatron's global cu_seqlens."""
 
     if str(getattr(packed_seq_params, "qkv_format", "")).lower() != "thd":
-        raise RuntimeError("strict RL-Kernel packed Attention requires qkv_format='thd'")
+        raise RuntimeError(
+            "strict RL-Kernel packed Attention requires qkv_format='thd'"
+        )
     query_cu = getattr(packed_seq_params, "cu_seqlens_q", None)
     kv_cu = getattr(packed_seq_params, "cu_seqlens_kv", None)
     if not isinstance(query_cu, torch.Tensor) or not isinstance(kv_cu, torch.Tensor):
-        raise RuntimeError("packed Attention requires tensor cu_seqlens_q/cu_seqlens_kv")
+        raise RuntimeError(
+            "packed Attention requires tensor cu_seqlens_q/cu_seqlens_kv"
+        )
     query_offsets = tuple(
-        int(value) for value in query_cu.detach().to(device="cpu", dtype=torch.int64).tolist()
+        int(value)
+        for value in query_cu.detach().to(device="cpu", dtype=torch.int64).tolist()
     )
     kv_offsets = tuple(
-        int(value) for value in kv_cu.detach().to(device="cpu", dtype=torch.int64).tolist()
+        int(value)
+        for value in kv_cu.detach().to(device="cpu", dtype=torch.int64).tolist()
     )
     if query_offsets != kv_offsets:
-        raise RuntimeError("strict self-Attention requires identical Q and KV cu_seqlens")
+        raise RuntimeError(
+            "strict self-Attention requires identical Q and KV cu_seqlens"
+        )
     if len(query_offsets) < 2 or query_offsets[0] != 0:
         raise RuntimeError("packed Attention cu_seqlens must start at zero")
     global_lengths = tuple(
-        right - left for left, right in zip(query_offsets[:-1], query_offsets[1:], strict=True)
+        right - left
+        for left, right in zip(query_offsets[:-1], query_offsets[1:], strict=True)
     )
     if any(length <= 0 for length in global_lengths):
         raise RuntimeError("packed Attention cu_seqlens must be strictly increasing")
     if any(length % cp_world_size for length in global_lengths):
-        raise RuntimeError("packed Attention sequence lengths must be divisible by CP size")
+        raise RuntimeError(
+            "packed Attention sequence lengths must be divisible by CP size"
+        )
     local_lengths = tuple(length // cp_world_size for length in global_lengths)
     local_offsets = [0]
     for length in local_lengths:
         local_offsets.append(local_offsets[-1] + length)
     if local_offsets[-1] != local_query_tokens or local_offsets[-1] != local_kv_tokens:
-        raise RuntimeError("packed Attention cu_seqlens do not cover the local Q/KV token rows")
+        raise RuntimeError(
+            "packed Attention cu_seqlens do not cover the local Q/KV token rows"
+        )
     return tuple(local_offsets), global_lengths
+
+
+def _tensor_cache_token(tensor: torch.Tensor) -> tuple[Any, ...]:
+    """Identify one tensor value while it is reused across framework layers."""
+
+    return (
+        tensor.data_ptr(),
+        tuple(tensor.shape),
+        tensor.dtype,
+        tensor.device.type,
+        tensor.device.index,
+        int(tensor._version),
+    )
 
 
 def _compact_attention_provenance(value: Mapping[str, Any]) -> dict[str, Any]:
@@ -360,6 +409,50 @@ class MegatronAttentionOperator:
             target="training", semantic_op="attention", backend_id=self.backend_id
         )
         self._last_provenance: dict[str, Any] = {}
+        self._packed_layout_owner: Any | None = None
+        self._packed_layout_key: tuple[Any, ...] | None = None
+        self._packed_layout_value: tuple[tuple[int, ...], tuple[int, ...]] | None = None
+
+    def _packed_layout(
+        self,
+        packed_seq_params: Any,
+        *,
+        cp_world_size: int,
+        local_query_tokens: int,
+        local_kv_tokens: int,
+    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
+        query_cu = getattr(packed_seq_params, "cu_seqlens_q", None)
+        kv_cu = getattr(packed_seq_params, "cu_seqlens_kv", None)
+        if not isinstance(query_cu, torch.Tensor) or not isinstance(
+            kv_cu, torch.Tensor
+        ):
+            raise RuntimeError(
+                "packed Attention requires tensor cu_seqlens_q/cu_seqlens_kv"
+            )
+        key = (
+            _tensor_cache_token(query_cu),
+            _tensor_cache_token(kv_cu),
+            cp_world_size,
+            local_query_tokens,
+            local_kv_tokens,
+        )
+        if (
+            self._packed_layout_owner is packed_seq_params
+            and self._packed_layout_key == key
+        ):
+            if self._packed_layout_value is None:
+                raise RuntimeError("packed Attention layout cache is empty")
+            return self._packed_layout_value
+        value = _packed_local_sequence_layout(
+            packed_seq_params,
+            cp_world_size=cp_world_size,
+            local_query_tokens=local_query_tokens,
+            local_kv_tokens=local_kv_tokens,
+        )
+        self._packed_layout_owner = packed_seq_params
+        self._packed_layout_key = key
+        self._packed_layout_value = value
+        return value
 
     @property
     def provenance(self) -> Mapping[str, Any]:
@@ -386,9 +479,15 @@ class MegatronAttentionOperator:
         if num_splits not in (None, 1):
             raise RuntimeError("strict RL-Kernel Attention requires num_splits=1")
         if attention_mask is not None and attention_mask.numel() > 1:
-            raise RuntimeError("strict RL-Kernel Attention supports only its causal contract")
+            raise RuntimeError(
+                "strict RL-Kernel Attention supports only its causal contract"
+            )
         expected_ndim = 3 if packed_seq_params is not None else 4
-        if query.ndim != expected_ndim or key.ndim != expected_ndim or value.ndim != expected_ndim:
+        if (
+            query.ndim != expected_ndim
+            or key.ndim != expected_ndim
+            or value.ndim != expected_ndim
+        ):
             layout = "[T, H, D]" if packed_seq_params is not None else "[S, B, H, D]"
             raise RuntimeError(f"Megatron Attention Q/K/V must use {layout}")
         _require_nvidia_cuda(query, "Attention")
@@ -417,10 +516,12 @@ class MegatronAttentionOperator:
             *,
             global_sequence_length: int,
         ) -> Any:
-            positions, block_indices, block_starts, block_offsets = _megatron_zigzag_layout(
-                q_ready.size(2),
-                cp_rank=cp_rank,
-                cp_world_size=cp_world,
+            positions, block_indices, block_starts, block_offsets = (
+                _megatron_zigzag_layout(
+                    q_ready.size(2),
+                    cp_rank=cp_rank,
+                    cp_world_size=cp_world,
+                )
             )
             position_ids = torch.tensor(
                 positions,
@@ -473,14 +574,13 @@ class MegatronAttentionOperator:
                 "operator": _compact_attention_provenance(result.provenance),
             }
         else:
-            local_offsets, global_lengths = _packed_local_sequence_layout(
+            local_offsets, global_lengths = self._packed_layout(
                 packed_seq_params,
                 cp_world_size=cp_world,
                 local_query_tokens=query.size(0),
                 local_kv_tokens=key.size(0),
             )
-            outputs: list[torch.Tensor] = []
-            sequence_provenance: list[dict[str, Any]] = []
+            grouped_sequences: dict[tuple[int, int], list[tuple[int, int, int]]] = {}
             for sequence_index, (start, end, global_length) in enumerate(
                 zip(
                     local_offsets[:-1],
@@ -489,30 +589,68 @@ class MegatronAttentionOperator:
                     strict=True,
                 )
             ):
-                q_ready = query[start:end].permute(1, 0, 2).unsqueeze(0).contiguous()
-                k_ready = key[start:end].permute(1, 0, 2).unsqueeze(0).contiguous()
-                v_ready = value[start:end].permute(1, 0, 2).unsqueeze(0).contiguous()
+                grouped_sequences.setdefault((end - start, global_length), []).append(
+                    (sequence_index, start, end)
+                )
+
+            outputs: list[torch.Tensor | None] = [None] * len(global_lengths)
+            sequence_provenance: list[dict[str, Any] | None] = [None] * len(
+                global_lengths
+            )
+            launch_group_count = 0
+            for (local_length, global_length), sequences in grouped_sequences.items():
+                q_ready = (
+                    torch.stack(
+                        [query[start:end] for _index, start, end in sequences], dim=0
+                    )
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+                k_ready = (
+                    torch.stack(
+                        [key[start:end] for _index, start, end in sequences], dim=0
+                    )
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
+                v_ready = (
+                    torch.stack(
+                        [value[start:end] for _index, start, end in sequences], dim=0
+                    )
+                    .permute(0, 2, 1, 3)
+                    .contiguous()
+                )
                 result = execute_sequence(
                     q_ready,
                     k_ready,
                     v_ready,
                     global_sequence_length=global_length,
                 )
-                outputs.append(
-                    result.out.squeeze(0).permute(1, 0, 2).contiguous().flatten(start_dim=1)
+                group_output = (
+                    result.out.permute(0, 2, 1, 3).contiguous().flatten(start_dim=2)
                 )
-                sequence_provenance.append(
-                    {
+                operator_provenance = _compact_attention_provenance(result.provenance)
+                for batch_index, (sequence_index, _start, _end) in enumerate(sequences):
+                    outputs[sequence_index] = group_output[batch_index]
+                    sequence_provenance[sequence_index] = {
                         "sequence_index": sequence_index,
-                        "local_tokens": end - start,
+                        "local_tokens": local_length,
                         "global_tokens": global_length,
-                        "operator": _compact_attention_provenance(result.provenance),
+                        "operator": operator_provenance,
                     }
+                launch_group_count += 1
+            if any(item is None for item in outputs) or any(
+                item is None for item in sequence_provenance
+            ):
+                raise RuntimeError(
+                    "packed Attention failed to materialize every sequence"
                 )
-            output = torch.cat(outputs, dim=0)
+            output = torch.cat(cast(list[torch.Tensor], outputs), dim=0)
             execution_provenance = {
                 "packed_sequence_count": len(global_lengths),
-                "sequences": sequence_provenance,
+                "launch_group_count": launch_group_count,
+                "sequence_batching": "equal_length_rows",
+                "sequences": cast(list[dict[str, Any]], sequence_provenance),
             }
         self._last_provenance = {
             "framework_layout": (
@@ -563,16 +701,26 @@ class MegatronFFNOperator:
                 if name != "padding_mask" or value is not None
             }
             if unexpected:
-                raise RuntimeError("strict dense Qwen3 FFN does not accept expert token scaling")
+                raise RuntimeError(
+                    "strict dense Qwen3 FFN does not accept expert token scaling"
+                )
         if per_token_scale is not None:
-            raise RuntimeError("strict dense Qwen3 FFN does not accept expert token scaling")
+            raise RuntimeError(
+                "strict dense Qwen3 FFN does not accept expert token scaling"
+            )
         _require_nvidia_cuda(hidden_states, "FFN")
         config = module.config
         if bool(getattr(config, "add_bias_linear", False)):
             raise RuntimeError("strict Qwen3 FFN requires bias-free projections")
         if not bool(getattr(config, "gated_linear_unit", False)):
             raise RuntimeError("strict Qwen3 FFN requires a gated linear unit")
-        gate, up = _split_gate_up(_weight(module.linear_fc1, "linear_fc1"), "linear_fc1")
+        hidden_states = _fused_rms_norm_input(
+            module.linear_fc1,
+            hidden_states,
+            "linear_fc1",
+        )
+        fused_gate_up = _weight(module.linear_fc1, "linear_fc1").contiguous()
+        gate, up = _split_gate_up(fused_gate_up, "linear_fc1")
         down = _weight(module.linear_fc2, "linear_fc2").contiguous()
         parallel_state = _megatron_parallel_state()
         cp_world = int(parallel_state.get_context_parallel_world_size())
@@ -602,6 +750,8 @@ class MegatronFFNOperator:
             "tp_world_size": tp_world,
             "runtime_platform": "cuda",
             "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
+            "gemm_backend": det_gemm_backend_id(),
+            "gate_up_projection": "separate_strict_launches",
             "triton_used": False,
         }
         return output, None
@@ -633,7 +783,8 @@ def _vllm_kv_cache_views(
         key_cache, value_cache = kv_cache.unbind(0)
         return key_cache, value_cache
     raise RuntimeError(
-        "vLLM FlashAttention KV cache must use " "[blocks, kv_heads, block, 2 * head_size]"
+        "vLLM FlashAttention KV cache must use "
+        "[blocks, kv_heads, block, 2 * head_size]"
     )
 
 
@@ -647,28 +798,29 @@ class VllmAttentionOperator:
             target="rollout", semantic_op="attention", backend_id=self.backend_id
         )
         self._last_provenance: dict[str, Any] = {}
-        self._prime_semantic_handle()
+        self._tp_coordinates: tuple[int, int, Any] | None = None
+        self._metadata_cache_key: tuple[Any, ...] | None = None
+        self._metadata_cache_owners: set[int] = set()
+        self._metadata_cache_value: (
+            tuple[list[dict[str, Any]], dict[str, Any]] | None
+        ) = None
 
-    def _prime_semantic_handle(self) -> None:
-        # vLLM wraps model execution in torch.compile. Resolve the semantic
-        # descriptor before graph capture so JSON/inspect-based provenance
-        # never runs inside Dynamo's fullgraph region.
-        if not torch.cuda.is_available():
+    def bind_inference(self) -> None:
+        """Resolve the backend after vLLM has selected the worker CUDA device."""
+
+        if self._tp_coordinates is not None:
             return
-        try:
-            tp_world, _rank, _group = _vllm_tp_coordinates()
-            self._handle.get(
-                torch.empty((1,), device="cuda", dtype=torch.bfloat16),
-                topology={
-                    "world_size": tp_world,
-                    "tensor_parallel_size": tp_world,
-                    "context_parallel_size": 1,
-                },
-            )
-        except (RuntimeError, ValueError, ImportError):
-            # API-server/plugin construction can precede worker CUDA setup;
-            # the worker retries during initialization before graph capture.
-            return
+        tp_world, tp_rank, tp_group = _vllm_tp_coordinates()
+        device = torch.device("cuda", torch.cuda.current_device())
+        self._handle.get(
+            torch.empty((1,), device=device, dtype=torch.bfloat16),
+            topology={
+                "world_size": tp_world,
+                "tensor_parallel_size": tp_world,
+                "context_parallel_size": 1,
+            },
+        )
+        self._tp_coordinates = (tp_world, tp_rank, tp_group)
 
     @property
     def provenance(self) -> Mapping[str, Any]:
@@ -685,6 +837,114 @@ class VllmAttentionOperator:
                 return value
         raise RuntimeError(f"vLLM Attention metadata is missing {'/'.join(names)}")
 
+    def _materialization_groups(
+        self,
+        attn_metadata: Any,
+        *,
+        query: torch.Tensor,
+        block_table: torch.Tensor,
+        block_size: int,
+        num_actual: int,
+        cache_owner: Any | None = None,
+    ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+        """Build one paged launch from vLLM's graph-replayable GPU metadata."""
+
+        query_starts_source = self._metadata_tensor(
+            attn_metadata, "query_start_loc", "query_start_loc_cpu"
+        )
+        seq_lens_source = self._metadata_tensor(
+            attn_metadata, "seq_lens", "seq_lens_cpu"
+        )
+        if num_actual == 0:
+            return [], {
+                "row_count": 0,
+                "query_position_range": [None, None],
+                "kv_token_range": [None, None],
+                "launch_group_count": 0,
+                "metadata_source": "vllm_gpu",
+            }
+
+        query_starts = query_starts_source.to(
+            device=query.device, dtype=torch.int32
+        )
+        seq_lens = seq_lens_source.to(device=query.device, dtype=torch.int32)
+        query_indices = torch.arange(
+            num_actual, dtype=torch.int32, device=query.device
+        )
+        query_ends = query_starts[1:]
+        request_indices = torch.searchsorted(
+            query_ends, query_indices, right=True
+        ).to(dtype=torch.long)
+        active_queries = query_indices < query_starts[-1]
+        request_indices = request_indices.clamp_max(seq_lens.numel() - 1)
+        request_query_ends = query_ends.index_select(0, request_indices)
+        request_seq_lens = seq_lens.index_select(0, request_indices)
+        seqused_k = request_seq_lens - (request_query_ends - query_indices) + 1
+        seqused_k = torch.where(
+            active_queries,
+            seqused_k,
+            torch.ones_like(seqused_k),
+        )
+
+        max_seq_len = int(
+            getattr(attn_metadata, "max_seq_len", block_table.size(1) * block_size)
+        )
+        page_count = min(
+            block_table.size(1), (max_seq_len + block_size - 1) // block_size
+        )
+        cache_key = (
+            _tensor_cache_token(query_starts_source),
+            _tensor_cache_token(seq_lens_source),
+            _tensor_cache_token(block_table),
+            query.device.type,
+            query.device.index,
+            num_actual,
+            block_size,
+            page_count,
+        )
+        owner_id = id(cache_owner) if cache_owner is not None else None
+        if (
+            owner_id is not None
+            and self._metadata_cache_key == cache_key
+            and owner_id not in self._metadata_cache_owners
+            and self._metadata_cache_value is not None
+        ):
+            self._metadata_cache_owners.add(owner_id)
+            groups, cached_summary = self._metadata_cache_value
+            return groups, {**cached_summary, "metadata_reused_across_layers": True}
+
+        pages = (
+            block_table.index_select(0, request_indices)[:, :page_count]
+            .to(dtype=torch.int32)
+            .contiguous()
+        )
+        groups = [
+            {
+                "page_count": page_count,
+                "pages": pages,
+                "query_indices": query_indices,
+                "query_start": 0,
+                "query_count": num_actual,
+                "query_contiguous": True,
+                "seqused_k": seqused_k,
+            }
+        ]
+        summary = {
+            "row_count": num_actual,
+            "query_position_range": "device_dynamic",
+            "kv_token_range": "device_dynamic",
+            "launch_group_count": 1,
+            "metadata_source": "vllm_gpu",
+            "metadata_reused_across_layers": False,
+        }
+        if owner_id is not None:
+            # The first repeated layer marks the next model forward (or graph
+            # capture), so dynamic metadata is re-derived instead of frozen.
+            self._metadata_cache_key = cache_key
+            self._metadata_cache_owners = {owner_id}
+            self._metadata_cache_value = (groups, summary)
+        return groups, summary
+
     def __call__(
         self,
         impl: Any,
@@ -698,9 +958,11 @@ class VllmAttentionOperator:
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        del layer, key, value
+        del key, value
         if output_scale is not None or output_block_scale is not None:
-            raise RuntimeError("strict vLLM Attention does not support quantized output")
+            raise RuntimeError(
+                "strict vLLM Attention does not support quantized output"
+            )
         if attn_metadata is None:
             if output is None:
                 raise RuntimeError("vLLM profiling Attention requires an output buffer")
@@ -715,26 +977,25 @@ class VllmAttentionOperator:
         if key_cache.dtype != query.dtype or value_cache.dtype != query.dtype:
             raise RuntimeError("strict vLLM Attention requires an unquantized KV cache")
 
-        query_starts = self._metadata_tensor(
-            attn_metadata, "query_start_loc", "query_start_loc_cpu"
-        ).to(device="cpu", dtype=torch.long)
-        seq_lens = self._metadata_tensor(attn_metadata, "seq_lens").to(
-            device="cpu", dtype=torch.long
-        )
-        block_table = self._metadata_tensor(attn_metadata, "block_table", "block_table_tensor").to(
-            device="cpu", dtype=torch.long
+        block_table = self._metadata_tensor(
+            attn_metadata, "block_table", "block_table_tensor"
         )
         num_actual = int(getattr(attn_metadata, "num_actual_tokens", query.size(0)))
+        if num_actual < 0 or num_actual > query.size(0):
+            raise RuntimeError("vLLM num_actual_tokens is outside the query buffer")
         if output is None:
             output = torch.empty(
                 (query.size(0), impl.num_heads * impl.head_size),
                 dtype=query.dtype,
                 device=query.device,
             )
-        output.zero_()
+        if output.size(0) < num_actual:
+            raise RuntimeError("vLLM output buffer is smaller than num_actual_tokens")
         output_heads = output.view(output.size(0), impl.num_heads, impl.head_size)
         block_size = key_cache.size(1)
-        tp_world, tp_rank, tp_group = _vllm_tp_coordinates()
+        if self._tp_coordinates is None:
+            self._tp_coordinates = _vllm_tp_coordinates()
+        tp_world, tp_rank, tp_group = self._tp_coordinates
         operator = self._handle.get(
             query,
             topology={
@@ -743,97 +1004,62 @@ class VllmAttentionOperator:
                 "context_parallel_size": 1,
             },
         )
-        operator.bind_cuda_runtime()
-        row_count = 0
-        first_query_position: int | None = None
-        last_query_position: int | None = None
-        min_kv_tokens: int | None = None
-        max_kv_tokens: int | None = None
+        runtime = operator.bind_cuda_runtime()
+        groups, metadata_summary = self._materialization_groups(
+            attn_metadata,
+            query=query,
+            block_table=block_table,
+            block_size=block_size,
+            num_actual=num_actual,
+            cache_owner=layer,
+        )
         last_operator_provenance: dict[str, Any] = {}
-        for request_index in range(seq_lens.numel()):
-            q_start = int(query_starts[request_index])
-            q_end = min(int(query_starts[request_index + 1]), num_actual)
-            if q_start >= q_end:
-                continue
-            final_seq_len = int(seq_lens[request_index])
-            first_query_position = final_seq_len - (q_end - q_start)
-            for token_offset, query_index in enumerate(range(q_start, q_end)):
-                kv_len = first_query_position + token_offset + 1
-                page_count = (kv_len + block_size - 1) // block_size
-                page_ids = block_table[request_index, :page_count].tolist()
-                if any(page < 0 for page in page_ids):
-                    raise RuntimeError("vLLM block table contains an unallocated page")
-                pages = torch.tensor(page_ids, device=key_cache.device, dtype=torch.long)
-                k_row = key_cache.index_select(0, pages).reshape(
-                    -1, impl.num_kv_heads, impl.head_size
-                )[:kv_len]
-                v_row = value_cache.index_select(0, pages).reshape(
-                    -1, impl.num_kv_heads, impl.head_size
-                )[:kv_len]
-                q_ready = query[query_index : query_index + 1].permute(1, 0, 2).unsqueeze(0)
-                k_ready = k_row.permute(1, 0, 2).unsqueeze(0).contiguous()
-                v_ready = v_row.permute(1, 0, 2).unsqueeze(0).contiguous()
-                query_positions = torch.tensor(
-                    [[kv_len - 1]],
-                    dtype=torch.int64,
-                    device=query.device,
-                )
-                key_positions = torch.arange(
-                    kv_len,
-                    dtype=torch.int64,
-                    device=query.device,
-                ).unsqueeze(0)
-                result = operator(
-                    q_ready.contiguous(),
-                    k_ready,
-                    v_ready,
-                    contract=_dense_attention_contract(
-                        q_ready,
-                        k_ready,
-                        role=AttentionRole.INFER,
-                        # The causal prefix is already materialized as one dense row.
-                        causal=False,
-                        tp_rank=tp_rank,
-                        tp_world_size=tp_world,
-                        mode=AttentionMode.CHUNKED_PREFILL,
-                        global_sequence_length=kv_len,
-                        global_block_token_starts=(kv_len - 1,),
-                    ),
-                    config=AttentionAblationConfig(
-                        strict_core_id=STRICT_ATTENTION_PRODUCTION_CORE_ID,
-                        strict_schedule=STRICT_ATTENTION_FA4_SCHEDULE_ID,
-                    ),
-                    return_lse=True,
-                    query_position_ids=query_positions,
-                    key_position_ids=key_positions,
-                    scale=float(impl.scale),
-                )
-                output_heads[query_index].copy_(result.out[0, :, 0, :])
-                query_position = kv_len - 1
-                row_count += 1
-                first_query_position = (
-                    query_position
-                    if first_query_position is None
-                    else min(first_query_position, query_position)
-                )
-                last_query_position = (
-                    query_position
-                    if last_query_position is None
-                    else max(last_query_position, query_position)
-                )
-                min_kv_tokens = kv_len if min_kv_tokens is None else min(min_kv_tokens, kv_len)
-                max_kv_tokens = kv_len if max_kv_tokens is None else max(max_kv_tokens, kv_len)
-                last_operator_provenance = _compact_attention_provenance(result.provenance)
+        next_query_row = 0
+        for group in groups:
+            if not group["query_contiguous"] or group["query_start"] != next_query_row:
+                break
+            next_query_row += int(group["query_count"])
+        direct_output_buffer = bool(groups) and next_query_row == num_actual
+        if not direct_output_buffer:
+            output.zero_()
+        elif num_actual < output.size(0):
+            output[num_actual:].zero_()
+        for group in groups:
+            page_count = int(group["page_count"])
+            pages = group["pages"]
+            query_indices = group["query_indices"]
+            if group["query_contiguous"]:
+                query_start = int(group["query_start"])
+                query_count = int(group["query_count"])
+                q_ready = query.narrow(0, query_start, query_count).unsqueeze(2)
+                out_ready = output_heads.narrow(
+                    0, query_start, query_count
+                ).unsqueeze(2)
+            else:
+                q_ready = query.index_select(0, query_indices).unsqueeze(2).contiguous()
+                out_ready = None
+            result = runtime.forward_paged_with_lse(
+                q_ready,
+                key_cache,
+                value_cache,
+                page_table=pages,
+                seqused_k=group["seqused_k"],
+                max_seqlen_k=page_count * block_size,
+                scale=float(impl.scale),
+                out=out_ready,
+            )
+            if out_ready is None:
+                output_heads.index_copy_(0, query_indices, result.out.squeeze(2))
+            last_operator_provenance = _compact_attention_provenance(result.provenance)
         self._last_provenance = {
             "framework_layout": "vllm_paged_kv",
-            "materialization": "one_causal_prefix_per_query_row",
+            "materialization": "direct_paged_fa4",
             "tp_world_size": tp_world,
             "tp_group_bound": tp_group is not None,
             "runtime_platform": "cuda",
             "triton_used": False,
-            "row_count": row_count,
-            "query_position_range": [first_query_position, last_query_position],
-            "kv_token_range": [min_kv_tokens, max_kv_tokens],
+            "direct_output_buffer": direct_output_buffer,
+            **metadata_summary,
             "operator": last_operator_provenance,
         }
         return output
@@ -847,28 +1073,8 @@ class VllmFFNOperator:
             target="rollout", semantic_op="ffn", backend_id=self.backend_id
         )
         self._last_provenance: dict[str, Any] = {}
-        self._prime_semantic_handle()
-
-    def _prime_semantic_handle(self) -> None:
-        # vLLM wraps model execution in torch.compile. Resolve the semantic
-        # descriptor before graph capture so JSON/inspect-based provenance
-        # never runs inside Dynamo's fullgraph region.
-        if not torch.cuda.is_available():
-            return
-        try:
-            tp_world, _rank, _group = _vllm_tp_coordinates()
-            self._handle.get(
-                torch.empty((1,), device="cuda", dtype=torch.bfloat16),
-                topology={
-                    "world_size": tp_world,
-                    "tensor_parallel_size": tp_world,
-                    "context_parallel_size": 1,
-                },
-            )
-        except (RuntimeError, ValueError, ImportError):
-            # API-server/plugin construction can precede worker CUDA setup;
-            # the worker retries during initialization before graph capture.
-            return
+        self._packed_inference_binding: tuple[int, int] | None = None
+        self._tp_coordinates: tuple[int, int, Any] | None = None
 
     @property
     def provenance(self) -> Mapping[str, Any]:
@@ -877,11 +1083,50 @@ class VllmFFNOperator:
             "execution": dict(self._last_provenance),
         }
 
+    def bind_packed_inference(self, module: Any) -> tuple[int, int]:
+        """Bind vLLM's TP group before torch.compile captures the model."""
+
+        fused_gate_up = _weight(module.gate_up_proj, "gate_up_proj")
+        down = _weight(module.down_proj, "down_proj")
+        tp_world, tp_rank, tp_group = _vllm_tp_coordinates()
+        self._tp_coordinates = (tp_world, tp_rank, tp_group)
+        operator = self._handle.get(
+            fused_gate_up,
+            topology={
+                "world_size": tp_world,
+                "tensor_parallel_size": tp_world,
+                "context_parallel_size": 1,
+            },
+        )
+        prepare = getattr(operator, "prepare_packed_inference", None)
+        if not callable(prepare):
+            raise RuntimeError("strict FFN backend lacks packed inference preparation")
+        self._packed_inference_binding = prepare(
+            fused_gate_up,
+            down,
+            tp_group=tp_group,
+        )
+        self._set_runtime_provenance(tp_world)
+        return self._packed_inference_binding
+
+    def _set_runtime_provenance(self, tp_world: int) -> None:
+        self._last_provenance = {
+            "framework_layout": "vllm_tensor_parallel",
+            "tp_world_size": tp_world,
+            "runtime_platform": "cuda",
+            "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
+            "gemm_backend": det_gemm_backend_id(),
+            "gate_up_projection": "packed_single_launch",
+            "triton_used": False,
+        }
+
     def __call__(self, module: Any, hidden_states: torch.Tensor) -> torch.Tensor:
         _require_nvidia_cuda(hidden_states, "FFN")
-        gate, up = _split_gate_up(_weight(module.gate_up_proj, "gate_up_proj"), "gate_up_proj")
+        fused_gate_up = _weight(module.gate_up_proj, "gate_up_proj").contiguous()
         down = _weight(module.down_proj, "down_proj").contiguous()
-        tp_world, _tp_rank, tp_group = _vllm_tp_coordinates()
+        if self._tp_coordinates is None:
+            self._tp_coordinates = _vllm_tp_coordinates()
+        tp_world, _tp_rank, tp_group = self._tp_coordinates
         operator = self._handle.get(
             hidden_states,
             topology={
@@ -890,22 +1135,36 @@ class VllmFFNOperator:
                 "context_parallel_size": 1,
             },
         )
-        output = operator(
-            hidden_states,
-            gate,
-            up,
-            down,
-            tp_group=tp_group,
-            sequence_parallel=False,
-            deterministic=True,
-        )
-        self._last_provenance = {
-            "framework_layout": "vllm_tensor_parallel",
-            "tp_world_size": tp_world,
-            "runtime_platform": "cuda",
-            "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
-            "triton_used": False,
-        }
+        self._set_runtime_provenance(tp_world)
+        if torch._dynamo.is_compiling():
+            if self._packed_inference_binding is None:
+                raise RuntimeError(
+                    "packed rollout FFN was not bound before torch.compile capture"
+                )
+            collective_handle, bound_tp_world = self._packed_inference_binding
+            if bound_tp_world != tp_world:
+                raise RuntimeError(
+                    "packed rollout FFN TP topology changed after binding"
+                )
+            output = operator.packed_inference(
+                hidden_states,
+                fused_gate_up,
+                down,
+                collective_handle=collective_handle,
+                tp_world_size=bound_tp_world,
+            )
+        else:
+            gate, up = _split_gate_up(fused_gate_up, "gate_up_proj")
+            output = operator(
+                hidden_states,
+                gate,
+                up,
+                down,
+                fused_gate_up_weight=fused_gate_up,
+                tp_group=tp_group,
+                sequence_parallel=False,
+                deterministic=True,
+            )
         return output
 
 
@@ -1081,21 +1340,27 @@ class VllmLogpOperator:
                 "strict vLLM logp selected output is not aligned with sampled tokens"
             )
         matches = ids == token_ids.unsqueeze(1)
-        if not bool(matches.any(dim=1).all().item()):
-            raise RuntimeError("vLLM logprob result does not contain every sampled token")
-        columns = matches.to(torch.int64).argmax(dim=1)
-        native_selected = values[
-            torch.arange(values.size(0), device=values.device), columns
-        ].clone()
-        values[torch.arange(values.size(0), device=values.device), columns] = selected
+        every_sample_present = matches.any(dim=1).all()
+        if every_sample_present.is_cuda:
+            torch._assert_async(
+                every_sample_present,
+                "vLLM logprob result does not contain every sampled token",
+            )
+        elif not bool(every_sample_present):
+            raise RuntimeError(
+                "vLLM logprob result does not contain every sampled token"
+            )
+        # vLLM prepends the sampled token and then appends top-k tokens. When
+        # the sample is also in top-k, its API conversion keeps the last
+        # duplicate, so every matching column must carry the strict value.
+        values = torch.where(matches, selected.unsqueeze(1), values)
         self._last_provenance = {
             **dict(provenance),
-            "sampled_token_ids": _tensor_debug_stats(token_ids),
+            "sampled_token_ids": _tensor_metadata(token_ids),
             "logprobs_shape": list(values.shape),
             "logprob_token_ids_shape": list(ids.shape),
-            "native_selected_logp_stats": _tensor_debug_stats(native_selected),
-            "rlkernel_selected_logp_stats": _tensor_debug_stats(selected),
-            "native_vs_rlkernel_selected_diff": _diff_debug_stats(native_selected, selected),
+            "strict_selected_logp": _tensor_metadata(selected),
+            "native_reference_compared": False,
         }
         if hasattr(logprobs_tensors, "_replace"):
             updated_tensors = logprobs_tensors._replace(logprobs=values)
@@ -1111,8 +1376,48 @@ class VllmLogpOperator:
         predict_bonus_token: bool = False,
         logprobs_mode_override: Any = None,
     ) -> Any:
-        source_logits = logits.clone()
+        # Native sampling owns logits; strict selected-logp preserves its raw
+        # local shard before the sampler applies in-place transformations.
+        source_logits = logits
         _require_nvidia_cuda(source_logits, "Logp")
+        context = None
+        local_logits = None
+        if self._strict_linear_logp:
+            context = take_rollout_linear_logp_context()
+            if source_logits.ndim != 2:
+                raise RuntimeError("vLLM sampler logits must be [tokens, vocab]")
+            if context.hidden.size(0) != source_logits.size(0):
+                raise RuntimeError(
+                    "strict rollout linear_logp hidden/logits row mismatch: "
+                    f"{context.hidden.size(0)} != {source_logits.size(0)}"
+                )
+            if source_logits.size(1) < context.real_vocab_size:
+                raise RuntimeError(
+                    "strict rollout source logits do not cover the real vocabulary: "
+                    f"{source_logits.size(1)} < {context.real_vocab_size}"
+                )
+            local_vocab = int(context.lm_head_weight.size(0))
+            available = max(
+                0,
+                min(
+                    local_vocab,
+                    source_logits.size(1) - context.vocab_start_index,
+                ),
+            )
+            # Preserve raw model logits before vLLM's sampler transforms its
+            # input in place (temperature, penalties, and masking).
+            local_logits = source_logits.new_full(
+                (source_logits.size(0), local_vocab),
+                float("-inf"),
+            )
+            if available:
+                local_logits[:, :available].copy_(
+                    source_logits.narrow(
+                        1,
+                        context.vocab_start_index,
+                        available,
+                    )
+                )
         if self._worker_sampler:
             result = self._native_forward(sampler, logits, sampling_metadata)
         else:
@@ -1132,25 +1437,16 @@ class VllmLogpOperator:
         token_ids = result.sampled_token_ids.reshape(-1).to(torch.long)
 
         if self._strict_linear_logp:
-            context = take_rollout_linear_logp_context()
-            if source_logits.ndim != 2:
-                raise RuntimeError("vLLM sampler logits must be [tokens, vocab]")
-            if context.hidden.size(0) != source_logits.size(0):
-                raise RuntimeError(
-                    "strict rollout linear_logp hidden/logits row mismatch: "
-                    f"{context.hidden.size(0)} != {source_logits.size(0)}"
-                )
+            assert context is not None and local_logits is not None
             if context.hidden.size(0) != token_ids.numel():
                 raise RuntimeError(
                     "strict rollout linear_logp hidden/sample row mismatch: "
                     f"{context.hidden.size(0)} != {token_ids.numel()}"
                 )
             assert self._linear_logp is not None
-            selected = self._linear_logp(
-                context.hidden,
-                context.lm_head_weight,
+            selected = self._linear_logp.from_local_logits(
+                local_logits,
                 token_ids,
-                context.lm_head_bias,
                 tp_group=context.tp_group,
                 vocab_start_index=context.vocab_start_index,
                 global_vocab_size=context.global_vocab_size,
@@ -1165,9 +1461,10 @@ class VllmLogpOperator:
                 "execution": {
                     "role": "vllm_rollout_linear_logprob",
                     "strict_backend": True,
-                    "sampling_logits_source": "native_vllm",
+                    "sampling_logits_source": "rlkernel_det_gemm_vllm",
                     "logits_materialized": True,
                     "padded_lm_head_alignment": True,
+                    "duplicate_lm_head_gemm": False,
                 },
                 "source_logits_shape": list(source_logits.shape),
                 "source_logits_dtype": _dtype_name(source_logits),
@@ -1187,7 +1484,11 @@ class VllmLogpOperator:
                 f"{DEFAULT_NUM_VOCAB_TILES}"
             )
         contract = _full_vocab_contract(source_logits)
-        dispatch = kernel_registry.get_logprob_op(contract, requested_backend=self.backend_id)
+        from rl_engine.kernels.registry import kernel_registry
+
+        dispatch = kernel_registry.get_logprob_op(
+            contract, requested_backend=self.backend_id
+        )
         if (
             dispatch.provenance["actual_backend"] != self.backend_id
             or dispatch.provenance["fallback"]
@@ -1243,7 +1544,10 @@ class VllmLogpOperator:
                                     logprobs_tensors.logprobs.size(0),
                                     device=logprobs_tensors.logprobs.device,
                                 ),
-                                (logprobs_tensors.logprob_token_ids == token_ids.unsqueeze(1))
+                                (
+                                    logprobs_tensors.logprob_token_ids
+                                    == token_ids.unsqueeze(1)
+                                )
                                 .to(torch.int64)
                                 .argmax(dim=1),
                             ],

--- a/rl_engine/integrations/framework_operators.py
+++ b/rl_engine/integrations/framework_operators.py
@@ -50,6 +50,7 @@ from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import (
     DEFAULT_NUM_VOCAB_TILES,
 )
 from rl_engine.kernels.semantic_registry import OperatorRequirements
+from rl_engine.runtime_mode import strict_contract_enabled
 
 ATTENTION_BACKEND_ID = "rlkernel.attention.deterministic.v1"
 FFN_BACKEND_ID = "rlkernel.ffn.qwen3.deterministic.v1"
@@ -457,6 +458,9 @@ class MegatronAttentionOperator:
     @property
     def provenance(self) -> Mapping[str, Any]:
         return {
+            "interface": "megatron.attention.forward",
+            "operator": self.backend_id,
+            "fallback": False,
             "semantic_instance": self._handle.provenance,
             "execution": dict(self._last_provenance),
         }
@@ -680,6 +684,9 @@ class MegatronFFNOperator:
     @property
     def provenance(self) -> Mapping[str, Any]:
         return {
+            "interface": "megatron.mlp.forward",
+            "operator": self.backend_id,
+            "fallback": False,
             "semantic_instance": self._handle.provenance,
             "execution": dict(self._last_provenance),
         }
@@ -751,6 +758,7 @@ class MegatronFFNOperator:
             "runtime_platform": "cuda",
             "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
             "gemm_backend": det_gemm_backend_id(),
+            "fallback": False,
             "gate_up_projection": "separate_strict_launches",
             "triton_used": False,
         }
@@ -825,6 +833,9 @@ class VllmAttentionOperator:
     @property
     def provenance(self) -> Mapping[str, Any]:
         return {
+            "interface": "vllm.attention.forward",
+            "operator": self.backend_id,
+            "fallback": False,
             "semantic_instance": self._handle.provenance,
             "execution": dict(self._last_provenance),
         }
@@ -1079,6 +1090,9 @@ class VllmFFNOperator:
     @property
     def provenance(self) -> Mapping[str, Any]:
         return {
+            "interface": "vllm.qwen3.mlp.forward",
+            "operator": self.backend_id,
+            "fallback": False,
             "semantic_instance": self._handle.provenance,
             "execution": dict(self._last_provenance),
         }
@@ -1116,6 +1130,7 @@ class VllmFFNOperator:
             "runtime_platform": "cuda",
             "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
             "gemm_backend": det_gemm_backend_id(),
+            "fallback": False,
             "gate_up_projection": "packed_single_launch",
             "triton_used": False,
         }
@@ -1194,18 +1209,17 @@ class MegatronLogpOperator:
     def __call__(self, request: Any) -> Any:
         logits = getattr(request, "logits", None)
         hidden = getattr(request, "hidden", None)
-        strict = os.getenv("VIME_RL_KERNEL_STRICT", "").strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+        strict = strict_contract_enabled()
         if isinstance(hidden, torch.Tensor):
             if self._linear_logp is None:
                 raise RuntimeError("Megatron linear_logp route is not installed")
             _require_nvidia_cuda(hidden, "linear_logp")
             result = self._provider(request, linear_logp=self._linear_logp)
             self._last_provenance = {
+                "interface": "vime.selected_logprob_provider",
+                "operator": self.backend_id,
+                "actual_backend": self.backend_id,
+                "fallback": False,
                 "runtime_platform": "cuda",
                 "triton_used": False,
                 "provider": dict(getattr(result, "provenance", {})),
@@ -1222,6 +1236,10 @@ class MegatronLogpOperator:
         _require_nvidia_cuda(logits, "Logp")
         result = self._provider(request)
         self._last_provenance = {
+            "interface": "vime.selected_logprob_provider",
+            "operator": self.backend_id,
+            "actual_backend": self.backend_id,
+            "fallback": False,
             "runtime_platform": "cuda",
             "triton_used": False,
             "provider": dict(getattr(result, "provenance", {})),
@@ -1356,6 +1374,10 @@ class VllmLogpOperator:
         values = torch.where(matches, selected.unsqueeze(1), values)
         self._last_provenance = {
             **dict(provenance),
+            "interface": "vllm.sampler.selected_logprob",
+            "operator": self.backend_id,
+            "actual_backend": self.backend_id,
+            "fallback": False,
             "sampled_token_ids": _tensor_metadata(token_ids),
             "logprobs_shape": list(values.shape),
             "logprob_token_ids_shape": list(ids.shape),

--- a/rl_engine/integrations/linear_logp.py
+++ b/rl_engine/integrations/linear_logp.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+
 from rl_engine.integrations.ablation import operator_ablation_case
 
 
@@ -23,6 +24,12 @@ class RolloutLinearLogpContext:
 
 
 _ROLLOUT_CONTEXT: RolloutLinearLogpContext | None = None
+
+
+def _gemm_backend_id() -> str:
+    from rl_engine.kernels.ops.cuda.matmul.det_gemm import det_gemm_backend_id
+
+    return det_gemm_backend_id()
 
 
 def publish_rollout_linear_logp_context(
@@ -157,7 +164,10 @@ class LinearLogpWrapper:
                 raise ValueError(
                     f"temperature must be scalar or one value per row, got {value.numel()}"
                 )
-            if bool((value <= 0).any().item()):
+            positive = torch.all(value > 0)
+            if positive.is_cuda:
+                torch._assert_async(positive, "temperature must be positive")
+            elif not bool(positive):
                 raise ValueError("temperature must be positive")
             return value
         value = float(temperature)
@@ -175,7 +185,13 @@ class LinearLogpWrapper:
             raise TypeError("linear_logp target_ids must use an integer dtype")
         if target_ids.numel():
             target_long = target_ids.to(dtype=torch.long)
-            if bool(((target_long < 0) | (target_long >= real_vocab_size)).any().item()):
+            valid = torch.all((target_long >= 0) & (target_long < real_vocab_size))
+            if valid.is_cuda:
+                torch._assert_async(
+                    valid,
+                    f"linear_logp target_ids must be in [0, {real_vocab_size})",
+                )
+            elif not bool(valid):
                 raise ValueError(
                     f"linear_logp target_ids must be in [0, {real_vocab_size}), got invalid ids"
                 )
@@ -245,6 +261,83 @@ class LinearLogpWrapper:
             )
         cls._validate_targets(target_ids, rows=hidden.size(0), real_vocab_size=real)
         return tensor_parallel, requested_global, real
+
+    def from_local_logits(
+        self,
+        local_logits: torch.Tensor,
+        target_ids: torch.Tensor,
+        *,
+        tp_group: Any,
+        vocab_start_index: int,
+        global_vocab_size: int,
+        real_vocab_size: int,
+        target: str = "rollout",
+        temperature: float | torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Score deterministic local LM-head logits without a duplicate GEMM."""
+
+        if local_logits.ndim != 2 or local_logits.dtype != torch.bfloat16:
+            raise TypeError("strict reused LM-head logits must be 2-D bfloat16")
+        if not local_logits.is_cuda or torch.version.hip is not None:
+            raise RuntimeError("strict reused LM-head logits require NVIDIA CUDA")
+        if target_ids.device != local_logits.device:
+            raise ValueError("linear_logp target_ids must share the logits device")
+        rank, world = self._tp_coordinates(tp_group)
+        if tp_group is None or world <= 1:
+            raise ValueError("reused rollout LM-head logits require a multi-rank TP group")
+        local_vocab = int(local_logits.size(1))
+        requested_global = int(global_vocab_size)
+        expected_global = local_vocab * world
+        expected_start = rank * local_vocab
+        if requested_global != expected_global or int(vocab_start_index) != expected_start:
+            raise ValueError(
+                "reused rollout LM-head logits must use equal rank-ordered TP shards"
+            )
+        real = int(real_vocab_size)
+        if not 0 < real <= requested_global:
+            raise ValueError("real_vocab_size must be within the padded global vocabulary")
+        self._validate_targets(
+            target_ids,
+            rows=local_logits.size(0),
+            real_vocab_size=real,
+        )
+        temperature_tensor = self._temperature_tensor(
+            temperature,
+            rows=local_logits.size(0),
+            device=local_logits.device,
+        )
+        from rl_engine.kernels.ops.cuda.loss.linear_logp import (
+            sm90_deterministic_logp_from_local_logits_tp,
+        )
+
+        result, _lse = sm90_deterministic_logp_from_local_logits_tp(
+            local_logits.contiguous(),
+            target_ids,
+            tp_group=tp_group,
+            vocab_start_index=int(vocab_start_index),
+            global_vocab_size=requested_global,
+            real_vocab_size=real,
+            temperature=temperature_tensor,
+        )
+        self._last_provenance = {
+            **self._mismatch_provenance(),
+            "target": target,
+            "runtime_platform": "cuda",
+            "triton_used": False,
+            "actual_backend": self.backend_id,
+            "local_logits_shape": list(local_logits.shape),
+            "target_shape": list(target_ids.shape),
+            "tp_group_present": True,
+            "vocab_start_index": int(vocab_start_index),
+            "global_vocab_size": requested_global,
+            "real_vocab_size": real,
+            "temperature": None if temperature is None else "provided",
+            "contract_version": "strict-gemm-linear-logp-sm90-contract-v3",
+            "gemm_backend": _gemm_backend_id(),
+            "logits_materialized": True,
+            "lm_head_result_reused": True,
+        }
+        return result
 
     @staticmethod
     def _mismatch_provenance() -> dict[str, Any]:
@@ -353,7 +446,8 @@ class LinearLogpWrapper:
             "real_vocab_size": real,
             "requested_real_vocab_size": None if real_vocab_size is None else int(real_vocab_size),
             "temperature": None if temperature is None else "provided",
-            "contract_version": "cuda-det-gemm-linear-logp-sm90-contract-v2",
+            "contract_version": "strict-gemm-linear-logp-sm90-contract-v3",
+            "gemm_backend": _gemm_backend_id(),
             "logits_materialized": True,
         }
         return result

--- a/rl_engine/integrations/megatron_runtime.py
+++ b/rl_engine/integrations/megatron_runtime.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 import importlib
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
+from types import MethodType
 from typing import Any
+
+import torch
 
 from rl_engine.integrations.ablation import Implementation, IntegrationPlan
 from rl_engine.integrations.framework_operators import (
     MegatronAttentionOperator,
     MegatronFFNOperator,
     MegatronLogpOperator,
+    _fused_rms_norm_input,
 )
 from rl_engine.integrations.linear_logp import LinearLogpWrapper
 from rl_engine.integrations.megatron import MegatronIntegration
@@ -21,6 +25,9 @@ from rl_engine.integrations.state import get_active_integration, set_active_inte
 from rl_engine.integrations.vime.logp import _provider_impl
 
 _PATCH_MARKER = "__rl_kernel_original_forward__"
+_STRICT_ATTENTION_PATCH_MARKER = "__rl_kernel_original_strict_attention_init__"
+_STRICT_ATTENTION_PROJECTION_MARKER = "__rl_kernel_strict_attention_projection__"
+_STRICT_TE_RMS_NORM_PATCH_MARKER = "__rl_kernel_original_strict_rms_norm_forward__"
 
 
 def _optional_class(path: str) -> type[Any] | None:
@@ -72,6 +79,151 @@ def _patch_forward(
     cls.forward = wrapped
 
 
+def _patch_strict_attention_projections(
+    *,
+    self_attention_cls: type[Any] | None = None,
+    column_linear_cls: type[Any] | None = None,
+    row_linear_cls: type[Any] | None = None,
+    det_gemm: Any | None = None,
+    copy_to_tp: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    reduce_from_tp: Callable[[torch.Tensor], torch.Tensor] | None = None,
+) -> None:
+    """Use the shared deterministic GEMM for Megatron Attention projections."""
+
+    if self_attention_cls is None or column_linear_cls is None or row_linear_cls is None:
+        from megatron.core.tensor_parallel.layers import (
+            ColumnParallelLinear,
+            RowParallelLinear,
+        )
+        from megatron.core.transformer.attention import SelfAttention
+
+        self_attention_cls = SelfAttention
+        column_linear_cls = ColumnParallelLinear
+        row_linear_cls = RowParallelLinear
+    if hasattr(self_attention_cls, _STRICT_ATTENTION_PATCH_MARKER):
+        return
+    if det_gemm is None:
+        from rl_engine.kernels.ops.cuda.matmul.det_gemm import DetGemmOp
+
+        det_gemm = DetGemmOp()
+
+    attention_init = self_attention_cls.__init__
+    column_forward_impl = column_linear_cls._forward_impl
+    row_forward_impl = row_linear_cls._forward_impl
+
+    def tp_mappings() -> tuple[
+        Callable[[torch.Tensor], torch.Tensor],
+        Callable[[torch.Tensor], torch.Tensor],
+    ]:
+        if copy_to_tp is not None and reduce_from_tp is not None:
+            return copy_to_tp, reduce_from_tp
+        from megatron.core.tensor_parallel.mappings import (
+            copy_to_tensor_model_parallel_region,
+            reduce_from_tensor_model_parallel_region,
+        )
+
+        return (
+            copy_to_tensor_model_parallel_region,
+            reduce_from_tensor_model_parallel_region,
+        )
+
+    def deterministic_projection(
+        input_value: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        input_2d = input_value.reshape(-1, input_value.shape[-1])
+        linear = getattr(det_gemm, "linear", None)
+        output_2d = (
+            linear(input_2d, weight)
+            if linear is not None
+            else det_gemm(input_2d, weight.t().contiguous())
+        )
+        output = output_2d.reshape(*input_value.shape[:-1], weight.shape[0])
+        return output if bias is None else output + bias
+
+    def attention_init_wrapped(instance: Any, *args: Any, **kwargs: Any) -> None:
+        attention_init(instance, *args, **kwargs)
+        qkv = instance.linear_qkv
+        projection = instance.linear_proj
+        setattr(qkv, _STRICT_ATTENTION_PROJECTION_MARKER, "qkv")
+        setattr(projection, _STRICT_ATTENTION_PROJECTION_MARKER, "o_proj")
+        if hasattr(qkv, "layer_norm_weight"):
+            tp_copy, tp_reduce = tp_mappings()
+
+            def te_qkv_forward(module: Any, input_value: torch.Tensor) -> Any:
+                normalized = _fused_rms_norm_input(module, input_value, "linear_qkv")
+                normalized = tp_copy(normalized)
+                return deterministic_projection(normalized, module.weight, None), None
+
+            def te_projection_forward(module: Any, input_value: torch.Tensor) -> Any:
+                output = deterministic_projection(input_value, module.weight, None)
+                return tp_reduce(output), None
+
+            qkv.forward = MethodType(te_qkv_forward, qkv)
+            projection.forward = MethodType(te_projection_forward, projection)
+        else:
+            # The local ColumnParallelLinear wrapper already owns TP dgrad.
+            qkv.allreduce_dgrad = False
+
+    def column_forward_impl_wrapped(
+        instance: Any,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if hasattr(instance, _STRICT_ATTENTION_PROJECTION_MARKER):
+            return deterministic_projection(input, weight, kwargs.get("bias"))
+        return column_forward_impl(instance, input, weight, *args, **kwargs)
+
+    def row_forward_impl_wrapped(
+        instance: Any,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if hasattr(instance, _STRICT_ATTENTION_PROJECTION_MARKER):
+            return deterministic_projection(input, weight, kwargs.get("bias"))
+        return row_forward_impl(instance, input, weight, *args, **kwargs)
+
+    setattr(self_attention_cls, _STRICT_ATTENTION_PATCH_MARKER, attention_init)
+    self_attention_cls.__init__ = attention_init_wrapped
+    column_linear_cls._forward_impl = column_forward_impl_wrapped
+    row_linear_cls._forward_impl = row_forward_impl_wrapped
+
+
+def _patch_strict_te_rms_norm(rms_norm_cls: type[Any] | None = None) -> None:
+    """Match standalone TE RMSNorm modules to the strict rollout arithmetic."""
+
+    if rms_norm_cls is None:
+        try:
+            from transformer_engine.pytorch import RMSNorm
+        except ImportError:
+            return
+
+        rms_norm_cls = RMSNorm
+    if hasattr(rms_norm_cls, _STRICT_TE_RMS_NORM_PATCH_MARKER):
+        return
+    original = rms_norm_cls.forward
+
+    def wrapped(instance: Any, input_value: torch.Tensor, *args: Any, **kwargs: Any) -> Any:
+        if args or kwargs:
+            raise RuntimeError("strict TE RMSNorm does not accept extra forward arguments")
+        if bool(getattr(instance, "zero_centered_gamma", False)):
+            raise RuntimeError("strict TE RMSNorm does not support zero-centered gamma")
+        return torch.nn.functional.rms_norm(
+            input_value,
+            (input_value.shape[-1],),
+            instance.weight,
+            float(instance.eps),
+        )
+
+    setattr(rms_norm_cls, _STRICT_TE_RMS_NORM_PATCH_MARKER, original)
+    rms_norm_cls.forward = wrapped
+
+
 def install_megatron_integration(
     plan: IntegrationPlan,
     *,
@@ -88,17 +240,17 @@ def install_megatron_integration(
             raise RuntimeError("Megatron integration is already installed with another plan")
         return existing
 
-    integration = MegatronIntegration(
-        plan,
-        rl_kernel_operators={
-            "attention": MegatronAttentionOperator(),
-            "ffn": MegatronFFNOperator(),
-            "logp": MegatronLogpOperator(
-                _provider_impl,
-                linear_logp=LinearLogpWrapper(),
-            ),
-        },
-    )
+    rl_kernel_operators: dict[str, Any] = {}
+    if plan.implementation_for("attention", "training") is Implementation.RL_KERNEL:
+        rl_kernel_operators["attention"] = MegatronAttentionOperator()
+    if plan.implementation_for("ffn", "training") is Implementation.RL_KERNEL:
+        rl_kernel_operators["ffn"] = MegatronFFNOperator()
+    if plan.implementation_for("logp", "training") is Implementation.RL_KERNEL:
+        rl_kernel_operators["logp"] = MegatronLogpOperator(
+            _provider_impl,
+            linear_logp=LinearLogpWrapper(),
+        )
+    integration = MegatronIntegration(plan, rl_kernel_operators=rl_kernel_operators)
     resolved_attention = _unique_classes(
         _discover_attention_classes() if attention_classes is None else attention_classes
     )
@@ -112,6 +264,10 @@ def install_megatron_integration(
         raise RuntimeError("R/R Megatron FFN selected but no supported class was found")
 
     set_active_integration("megatron", integration)
+    if plan.implementation_for("attention", "training") is Implementation.RL_KERNEL:
+        _patch_strict_attention_projections()
+        if plan.implementation_for("ffn", "training") is Implementation.RL_KERNEL:
+            _patch_strict_te_rms_norm()
     for cls in resolved_attention:
         _patch_forward(cls, integration=integration, module="attention")
     if resolved_attention:

--- a/rl_engine/integrations/megatron_runtime.py
+++ b/rl_engine/integrations/megatron_runtime.py
@@ -282,7 +282,9 @@ def install_megatron_integration(
             "ffn",
             ",".join(f"{cls.__module__}.{cls.__name__}.forward" for cls in resolved_ffn),
         )
-    integration.record_installed_hook("logp", "rl_engine.integrations.vime.logp.provider")
+    integration.record_installed_hook(
+        "logp", "rl_engine.integrations.vime.linear_logp.provider"
+    )
     return integration
 
 

--- a/rl_engine/integrations/runtime.py
+++ b/rl_engine/integrations/runtime.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import atexit
 import json
 import os
 from collections import Counter
@@ -27,6 +28,7 @@ class OperatorReadback:
     implementation: str
     backend_id: str
     call_count: int
+    execution_mode: str = "eager"
     provenance: Mapping[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -54,7 +56,11 @@ class FrameworkOperatorIntegration:
         self._readbacks: dict[str, OperatorReadback] = {}
         self._installed_hooks: dict[str, str] = {}
         self._fallbacks: list[dict[str, str]] = []
+        self._reported_routes: set[str] = set()
+        self._persisted_route_fingerprints: dict[str, tuple[Any, ...]] = {}
         self._lock = Lock()
+        if os.getenv("RL_KERNEL_READBACK_DIR", "").strip():
+            atexit.register(self._persist_readback)
 
     def install_operator(self, module: str, operator: Callable[..., Any]) -> None:
         normalized = module.strip().lower()
@@ -112,6 +118,29 @@ class FrameworkOperatorIntegration:
         # inside the captured graph.
         if torch._dynamo.is_compiling():
             return result
+        self.record_execution(normalized, selected)
+        return result
+
+    def record_execution(
+        self,
+        module: str,
+        selected: Callable[..., Any],
+        *,
+        execution_mode: str = "eager",
+    ) -> None:
+        """Record one eager or custom-op execution outside Dynamo tracing."""
+
+        normalized = module.strip().lower()
+        implementation = self.plan.implementation_for(normalized, self.target)
+        if implementation is Implementation.RL_KERNEL and (
+            selected is not self._rl_kernel_operators.get(normalized)
+        ):
+            raise RuntimeError(
+                f"{self.framework} {normalized} execution evidence did not use "
+                "the installed RL-Kernel operator"
+            )
+        if execution_mode not in {"eager", "compiled_cuda_graph"}:
+            raise ValueError(f"unknown execution mode {execution_mode!r}")
         backend_id = getattr(selected, "backend_id", None)
         if not isinstance(backend_id, str) or not backend_id.strip():
             backend_id = (
@@ -121,6 +150,17 @@ class FrameworkOperatorIntegration:
             )
         raw_provenance = getattr(selected, "provenance", {})
         provenance = dict(raw_provenance) if isinstance(raw_provenance, Mapping) else {}
+        actual_backend = _actual_backend(provenance) or backend_id
+        fallback = _contains_fallback(provenance)
+        should_report = False
+        route_changed = False
+        route_fingerprint = (
+            implementation.value,
+            backend_id,
+            actual_backend,
+            fallback,
+            _runtime_platform(provenance),
+        )
         with self._lock:
             self._counts[normalized] += 1
             case = self.plan.cases[normalized]
@@ -132,10 +172,30 @@ class FrameworkOperatorIntegration:
                 implementation=implementation.value,
                 backend_id=backend_id,
                 call_count=self._counts[normalized],
+                execution_mode=execution_mode,
                 provenance=provenance,
             )
-        self._persist_readback()
-        return result
+            if normalized not in self._reported_routes:
+                self._reported_routes.add(normalized)
+                should_report = _route_report_enabled()
+            if self._persisted_route_fingerprints.get(normalized) != route_fingerprint:
+                self._persisted_route_fingerprints[normalized] = route_fingerprint
+                route_changed = True
+        if route_changed:
+            self._persist_readback()
+        if should_report:
+            print(
+                "[RL-Kernel][route] "
+                f"framework={self.framework} target={self.target} module={normalized} "
+                f"requested={implementation.value} actual={actual_backend} "
+                f"fallback={str(fallback).lower()}",
+                flush=True,
+            )
+        if implementation is Implementation.RL_KERNEL and fallback:
+            self.record_fallback(normalized, f"operator provenance selected {actual_backend}")
+            raise RuntimeError(
+                f"{self.framework} {normalized} strict RL-Kernel route reported fallback"
+            )
 
     def readback(self) -> dict[str, Any]:
         with self._lock:
@@ -220,6 +280,55 @@ def _contains_triton(value: Any) -> bool:
     if isinstance(value, (list, tuple)):
         return any(_contains_triton(item) for item in value)
     return False
+
+
+def _contains_fallback(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized_key = str(key).strip().lower()
+            if normalized_key in {
+                "fallback",
+                "fallback_used",
+                "split_kv_fallback",
+                "used_fallback",
+            } and item not in (False, None, "", 0):
+                return True
+            if _contains_fallback(item):
+                return True
+        return False
+    if isinstance(value, (list, tuple)):
+        return any(_contains_fallback(item) for item in value)
+    return False
+
+
+def _actual_backend(value: Any) -> str | None:
+    if not isinstance(value, Mapping):
+        return None
+    direct = value.get("actual_backend")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+    for item in value.values():
+        nested = _actual_backend(item)
+        if nested is not None:
+            return nested
+    return None
+
+
+def _route_report_enabled() -> bool:
+    enabled = os.getenv("RL_KERNEL_ROUTE_REPORT", "1").strip().lower()
+    if enabled in {"0", "false", "no", "off"}:
+        return False
+    all_ranks = os.getenv("RL_KERNEL_ROUTE_REPORT_ALL_RANKS", "0").strip().lower()
+    if all_ranks in {"1", "true", "yes", "on"}:
+        return True
+    for name in ("RANK", "LOCAL_RANK"):
+        value = os.getenv(name, "").strip()
+        if value:
+            try:
+                return int(value) == 0
+            except ValueError:
+                continue
+    return True
 
 
 def _runtime_platform(value: Any) -> str | None:

--- a/rl_engine/integrations/runtime.py
+++ b/rl_engine/integrations/runtime.py
@@ -16,7 +16,13 @@ from threading import Lock
 from typing import Any
 
 import torch
+
 from rl_engine.integrations.ablation import Implementation, IntegrationPlan
+from rl_engine.runtime_mode import (
+    rl_kernel_mode,
+    rl_kernel_mode_policy,
+    route_report_enabled,
+)
 
 
 @dataclass(frozen=True)
@@ -152,6 +158,7 @@ class FrameworkOperatorIntegration:
         provenance = dict(raw_provenance) if isinstance(raw_provenance, Mapping) else {}
         actual_backend = _actual_backend(provenance) or backend_id
         fallback = _contains_fallback(provenance)
+        runtime_mode = rl_kernel_mode()
         should_report = False
         route_changed = False
         route_fingerprint = (
@@ -177,7 +184,7 @@ class FrameworkOperatorIntegration:
             )
             if normalized not in self._reported_routes:
                 self._reported_routes.add(normalized)
-                should_report = _route_report_enabled()
+                should_report = route_report_enabled()
             if self._persisted_route_fingerprints.get(normalized) != route_fingerprint:
                 self._persisted_route_fingerprints[normalized] = route_fingerprint
                 route_changed = True
@@ -186,16 +193,19 @@ class FrameworkOperatorIntegration:
         if should_report:
             print(
                 "[RL-Kernel][route] "
-                f"framework={self.framework} target={self.target} module={normalized} "
+                f"mode={runtime_mode.value} framework={self.framework} "
+                f"target={self.target} module={normalized} "
+                f"{_interface_route_fields(provenance)}"
                 f"requested={implementation.value} actual={actual_backend} "
                 f"fallback={str(fallback).lower()}",
                 flush=True,
             )
         if implementation is Implementation.RL_KERNEL and fallback:
             self.record_fallback(normalized, f"operator provenance selected {actual_backend}")
-            raise RuntimeError(
-                f"{self.framework} {normalized} strict RL-Kernel route reported fallback"
-            )
+            if rl_kernel_mode_policy(runtime_mode).fail_on_fallback:
+                raise RuntimeError(
+                    f"{self.framework} {normalized} strict RL-Kernel route reported fallback"
+                )
 
     def readback(self) -> dict[str, Any]:
         with self._lock:
@@ -314,21 +324,15 @@ def _actual_backend(value: Any) -> str | None:
     return None
 
 
-def _route_report_enabled() -> bool:
-    enabled = os.getenv("RL_KERNEL_ROUTE_REPORT", "1").strip().lower()
-    if enabled in {"0", "false", "no", "off"}:
-        return False
-    all_ranks = os.getenv("RL_KERNEL_ROUTE_REPORT_ALL_RANKS", "0").strip().lower()
-    if all_ranks in {"1", "true", "yes", "on"}:
-        return True
-    for name in ("RANK", "LOCAL_RANK"):
-        value = os.getenv(name, "").strip()
-        if value:
-            try:
-                return int(value) == 0
-            except ValueError:
-                continue
-    return True
+def _interface_route_fields(provenance: Mapping[str, Any]) -> str:
+    interface = provenance.get("interface")
+    operator = provenance.get("operator")
+    fields = []
+    if isinstance(interface, str) and interface.strip():
+        fields.append(f"interface={interface.strip()}")
+    if isinstance(operator, str) and operator.strip():
+        fields.append(f"operator={operator.strip()}")
+    return "" if not fields else " ".join(fields) + " "
 
 
 def _runtime_platform(value: Any) -> str | None:

--- a/rl_engine/integrations/vime/linear_logp.py
+++ b/rl_engine/integrations/vime/linear_logp.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
 
-"""Vime adapter entry points without a Vime runtime dependency."""
+"""Canonical Vime adapter for RL-Kernel's ``linear_logp`` operator."""
 
-from .linear_logp import ProviderResult, SelectedLogprobProviderUnavailable, provider
+from .logp import ProviderResult, SelectedLogprobProviderUnavailable, provider
 
 __all__ = ["ProviderResult", "SelectedLogprobProviderUnavailable", "provider"]

--- a/rl_engine/integrations/vime/logp.py
+++ b/rl_engine/integrations/vime/logp.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import torch
+
 from rl_engine.integrations.ablation import Implementation, operator_ablation_case
 from rl_engine.kernels.logprob_contract import (
     LogprobContract,
@@ -31,7 +32,6 @@ from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import (
     BACKEND_ID,
     DEFAULT_NUM_VOCAB_TILES,
 )
-from rl_engine.kernels.registry import kernel_registry
 
 
 class SelectedLogprobProviderUnavailable(RuntimeError):
@@ -56,6 +56,12 @@ class ProviderResult:
 
 
 _DEFAULT_STRICT_LINEAR_LOGP: Any | None = None
+
+
+def _kernel_registry() -> Any:
+    from rl_engine.kernels.registry import kernel_registry
+
+    return kernel_registry
 
 
 def _default_strict_linear_logp() -> Any:
@@ -247,7 +253,7 @@ def _provider_impl(request: Any, *, linear_logp: Any = None) -> ProviderResult:
             # explicit TP vocab reduction for the full-vocabulary entropy
             # requested by Vime's policy loss.
             entropy_contract, entropy_tiles = _contract_for_request(request)
-            entropy_dispatch = kernel_registry.get_logprob_op(
+            entropy_dispatch = _kernel_registry().get_logprob_op(
                 entropy_contract, requested_backend=BACKEND_ID
             )
             if (
@@ -314,7 +320,7 @@ def _provider_impl(request: Any, *, linear_logp: Any = None) -> ProviderResult:
         )
 
     contract, num_vocab_tiles = _contract_for_request(request)
-    dispatch = kernel_registry.get_logprob_op(contract, requested_backend=BACKEND_ID)
+    dispatch = _kernel_registry().get_logprob_op(contract, requested_backend=BACKEND_ID)
     if dispatch.provenance["actual_backend"] != BACKEND_ID or dispatch.provenance["fallback"]:
         raise RuntimeError("explicit WS2 backend dispatch changed during materialization")
     if getattr(request, "with_entropy", False):
@@ -378,10 +384,13 @@ def provider(request: Any) -> ProviderResult:
 
     # PR230's P/R axis is selected independently for training and rollout.
     # The Megatron provider is only the training boundary, so a production
-    # training side must bypass the RL-Kernel integration entirely.
+    # training side must request Vime's native implementation. Returning an
+    # RL-Kernel result here would make P/P and P/R silently execute R/* logp.
     case = operator_ablation_case("logp", os.getenv("RL_KERNEL_LOGP_CASE", "P/P"))
     if case.training is Implementation.PRODUCTION:
-        return _provider_impl(request)
+        raise SelectedLogprobProviderUnavailable(
+            "production Megatron logp selected; use Vime's native implementation"
+        )
 
     from rl_engine.integrations.state import get_active_integration
 

--- a/rl_engine/integrations/vime/logp.py
+++ b/rl_engine/integrations/vime/logp.py
@@ -32,6 +32,7 @@ from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import (
     BACKEND_ID,
     DEFAULT_NUM_VOCAB_TILES,
 )
+from rl_engine.runtime_mode import strict_contract_enabled
 
 
 class SelectedLogprobProviderUnavailable(RuntimeError):
@@ -216,7 +217,7 @@ def _provider_impl(request: Any, *, linear_logp: Any = None) -> ProviderResult:
     distribution semantics.
     """
 
-    strict = os.getenv("VIME_RL_KERNEL_STRICT", "").strip().lower() in {"1", "true", "yes", "on"}
+    strict = strict_contract_enabled()
     if strict and not isinstance(getattr(request, "hidden", None), torch.Tensor):
         raise RuntimeError(
             "strict Vime linear_logp request is missing hidden/LM-head structural inputs"

--- a/rl_engine/integrations/vllm_runtime.py
+++ b/rl_engine/integrations/vllm_runtime.py
@@ -5,10 +5,14 @@
 
 from __future__ import annotations
 
+import importlib
 import os
+import sys
 from typing import Any
 
 import torch
+
+from rl_engine.distributed.collectives import DETERMINISTIC_ALL_REDUCE_OP
 from rl_engine.integrations.ablation import (
     Implementation,
     IntegrationPlan,
@@ -26,10 +30,22 @@ from rl_engine.integrations.linear_logp import (
 )
 from rl_engine.integrations.state import get_active_integration, set_active_integration
 from rl_engine.integrations.vllm import VllmIntegration
+from rl_engine.kernels.ops.pytorch.ffn.ffn import register_packed_inference_observer
+from rl_engine.kernels.ops.pytorch.norm.rms_norm import (
+    strict_add_rms_norm,
+    strict_rms_norm,
+)
 
 _PATCH_MARKER = "__rl_kernel_original_forward__"
+_STRICT_MODEL_PATCH_MARKER = "__rl_kernel_original_strict_model_init__"
+_STRICT_PROJECTION_MARKER = "__rl_kernel_strict_attention_projection__"
+_STRICT_FFN_INIT_MARKER = "__rl_kernel_original_strict_ffn_init__"
+_STRICT_RMS_NORM_INIT_MARKER = "__rl_kernel_original_strict_rms_norm_init__"
+_STRICT_ROTARY_INIT_MARKER = "__rl_kernel_original_strict_rotary_init__"
+_STRICT_LM_HEAD_LINEAR_PATCH_MARKER = "__rl_kernel_original_lm_head_linear_apply__"
 _RLK_ATTENTION_BACKEND: type[Any] | None = None
 _RLK_ATTENTION_IMPL: type[Any] | None = None
+_RLK_ATTENTION_BUILDER: type[Any] | None = None
 
 
 def _is_worker_sampler_profile_batch(value: Any) -> bool:
@@ -80,7 +96,9 @@ def plan_from_environment() -> IntegrationPlan:
     return integration_plan_from_environment()
 
 
-def configure_vllm_environment(plan: IntegrationPlan, *, readback_dir: str | None = None) -> None:
+def configure_vllm_environment(
+    plan: IntegrationPlan, *, readback_dir: str | None = None
+) -> None:
     """Export the plan inherited by Vime's vLLM server subprocess."""
 
     os.environ["RL_KERNEL_VLLM_INTEGRATION"] = "1"
@@ -118,7 +136,9 @@ def _patch_qwen_lm_head_padding() -> None:
     original = ParallelLMHead.__init__
     original_weight_loader = VocabParallelEmbedding.weight_loader
 
-    def strict_weight_loader(instance: Any, param: Any, loaded_weight: torch.Tensor) -> None:
+    def strict_weight_loader(
+        instance: Any, param: Any, loaded_weight: torch.Tensor
+    ) -> None:
         strict_real_vocab = getattr(instance, "_rl_kernel_real_vocab_size", None)
         output_dim = getattr(param, "output_dim", None)
         packed_dim = getattr(param, "packed_dim", None)
@@ -163,7 +183,9 @@ def _patch_qwen_lm_head_padding() -> None:
 
     setattr(ParallelLMHead, _PATCH_MARKER, original)
     if not hasattr(VocabParallelEmbedding, "__rl_kernel_original_weight_loader__"):
-        VocabParallelEmbedding.__rl_kernel_original_weight_loader__ = original_weight_loader
+        VocabParallelEmbedding.__rl_kernel_original_weight_loader__ = (
+            original_weight_loader
+        )
         VocabParallelEmbedding.weight_loader = strict_weight_loader
     ParallelLMHead.__init__ = wrapped
 
@@ -188,14 +210,23 @@ def _patch_qwen_compute_logits(integration: VllmIntegration) -> None:
             *,
             _original: Any = original,
         ) -> Any:
+            lm_head = getattr(instance, "lm_head", None)
+            if lm_head is None:
+                raise RuntimeError("strict rollout linear_logp requires a Qwen LM-head")
+            setattr(lm_head, _STRICT_PROJECTION_MARKER, "lm_head")
             logits = _original(instance, hidden_states)
             if not get_pp_group().is_last_rank:
                 return logits
-            lm_head = getattr(instance, "lm_head", None)
             shard_indices = getattr(lm_head, "shard_indices", None)
             weight = getattr(lm_head, "weight", None)
-            if lm_head is None or shard_indices is None or not isinstance(weight, torch.Tensor):
-                raise RuntimeError("strict rollout linear_logp requires a real Qwen LM-head shard")
+            if (
+                lm_head is None
+                or shard_indices is None
+                or not isinstance(weight, torch.Tensor)
+            ):
+                raise RuntimeError(
+                    "strict rollout linear_logp requires a real Qwen LM-head shard"
+                )
             tp = get_tp_group()
             tp_world = int(tp.world_size)
             publish_rollout_linear_logp_context(
@@ -206,7 +237,9 @@ def _patch_qwen_compute_logits(integration: VllmIntegration) -> None:
                 vocab_start_index=int(shard_indices.padded_org_vocab_start_index),
                 global_vocab_size=int(lm_head.num_embeddings_padded),
                 real_vocab_size=int(
-                    getattr(lm_head, "_rl_kernel_real_vocab_size", lm_head.org_vocab_size)
+                    getattr(
+                        lm_head, "_rl_kernel_real_vocab_size", lm_head.org_vocab_size
+                    )
                 ),
             )
             return logits
@@ -218,13 +251,110 @@ def _patch_qwen_compute_logits(integration: VllmIntegration) -> None:
         integration.record_installed_hook("logp", ",".join(installed))
 
 
+def _patch_strict_lm_head_linear(
+    *,
+    linear_method_cls: type[Any] | None = None,
+    det_gemm: Any | None = None,
+) -> None:
+    """Route vLLM's existing LM-head projection through RL-Kernel det_gemm."""
+
+    if linear_method_cls is None:
+        from vllm.model_executor.layers.vocab_parallel_embedding import (
+            UnquantizedEmbeddingMethod,
+        )
+
+        linear_method_cls = UnquantizedEmbeddingMethod
+    if hasattr(linear_method_cls, _STRICT_LM_HEAD_LINEAR_PATCH_MARKER):
+        return
+    previous_apply = linear_method_cls.apply
+    if det_gemm is None:
+        from rl_engine.kernels.ops.cuda.matmul.det_gemm import DetGemmOp
+
+        det_gemm = DetGemmOp()
+
+    def wrapped(
+        method: Any,
+        layer: Any,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if getattr(layer, _STRICT_PROJECTION_MARKER, None) != "lm_head":
+            return previous_apply(method, layer, x, bias)
+        x_2d = x.reshape(-1, x.shape[-1])
+        output_2d = det_gemm.linear(x_2d, layer.weight)
+        output = output_2d.reshape(*x.shape[:-1], layer.weight.size(0))
+        return output if bias is None else output + bias
+
+    setattr(
+        linear_method_cls,
+        _STRICT_LM_HEAD_LINEAR_PATCH_MARKER,
+        previous_apply,
+    )
+    linear_method_cls.apply = wrapped
+
+
+def _configure_strict_ffn_compilation(vllm_config: Any | None = None) -> None:
+    """Keep the graph-safe TP reduction inside vLLM CUDA graphs."""
+
+    if vllm_config is None:
+        from vllm.config import get_current_vllm_config_or_none
+
+        vllm_config = get_current_vllm_config_or_none()
+    if vllm_config is None:
+        raise RuntimeError(
+            "strict TP FFN initialization requires an active vLLM config"
+        )
+
+    compilation = vllm_config.compilation_config
+    splitting_ops = compilation.splitting_ops
+    if splitting_ops is None:
+        raise RuntimeError(
+            "vLLM splitting operators were not finalized before model init"
+        )
+    # Older strict runtimes split this op because their host-owned sequence
+    # value was frozen at graph capture. Sequence allocation is now device
+    # owned, so remove stale entries and preserve the user's graph mode.
+    splitting_ops[:] = [
+        op for op in splitting_ops if op != DETERMINISTIC_ALL_REDUCE_OP
+    ]
+
+
 def _patch_qwen_ffn(integration: VllmIntegration) -> None:
     from vllm.model_executor.models.qwen2 import Qwen2MLP
 
-    integration.install_operator("ffn", VllmFFNOperator())
+    operator: VllmFFNOperator | None = None
+    if (
+        integration.plan.implementation_for("ffn", "rollout")
+        is Implementation.RL_KERNEL
+    ):
+        operator = VllmFFNOperator()
+        integration.install_operator("ffn", operator)
     if hasattr(Qwen2MLP, _PATCH_MARKER):
         raise RuntimeError("vLLM Qwen2MLP is already RL-Kernel patched")
     original = Qwen2MLP.forward
+
+    if operator is not None:
+        if hasattr(Qwen2MLP, _STRICT_FFN_INIT_MARKER):
+            raise RuntimeError("vLLM Qwen2MLP init is already RL-Kernel patched")
+        original_init = Qwen2MLP.__init__
+        compiled_evidence_armed = False
+
+        def wrapped_init(instance: Any, *args: Any, **kwargs: Any) -> None:
+            nonlocal compiled_evidence_armed
+            original_init(instance, *args, **kwargs)
+            _handle, tp_world_size = operator.bind_packed_inference(instance)
+            if not compiled_evidence_armed:
+                register_packed_inference_observer(
+                    lambda: integration.record_execution(
+                        "ffn", operator, execution_mode="compiled_cuda_graph"
+                    )
+                )
+                compiled_evidence_armed = True
+            if tp_world_size > 1:
+                _configure_strict_ffn_compilation()
+
+        setattr(Qwen2MLP, _STRICT_FFN_INIT_MARKER, original_init)
+        Qwen2MLP.__init__ = wrapped_init
 
     def wrapped(instance: Any, hidden_states: Any) -> Any:
         def native(_module: Any, value: Any) -> Any:
@@ -234,7 +364,137 @@ def _patch_qwen_ffn(integration: VllmIntegration) -> None:
 
     setattr(Qwen2MLP, _PATCH_MARKER, original)
     Qwen2MLP.forward = wrapped
-    integration.record_installed_hook("ffn", "vllm.model_executor.models.qwen2.Qwen2MLP.forward")
+    integration.record_installed_hook(
+        "ffn", "vllm.model_executor.models.qwen2.Qwen2MLP.forward"
+    )
+
+
+def _install_flash_attn_ops_compatibility() -> None:
+    """Supply the legacy rotary import tree when an FA4-only package is installed."""
+
+    try:
+        importlib.import_module("flash_attn.ops.triton.rotary")
+        return
+    except (ImportError, OSError, RuntimeError):
+        pass
+
+    from vllm.vllm_flash_attn import ops as bundled_ops
+    from vllm.vllm_flash_attn.ops import triton as bundled_triton
+    from vllm.vllm_flash_attn.ops.triton import rotary as bundled_rotary
+
+    sys.modules.setdefault("flash_attn.ops", bundled_ops)
+    sys.modules.setdefault("flash_attn.ops.triton", bundled_triton)
+    sys.modules.setdefault("flash_attn.ops.triton.rotary", bundled_rotary)
+
+
+def _patch_qwen3_strict_model(
+    *,
+    rms_norm_cls: type[Any] | None = None,
+    rotary_cls: type[Any] | None = None,
+    linear_method_cls: type[Any] | None = None,
+    attention_cls: type[Any] | None = None,
+    det_gemm: Any | None = None,
+) -> None:
+    """Align vLLM's RMSNorm and Attention projections with Megatron."""
+
+    production_classes = (
+        rms_norm_cls is None or linear_method_cls is None or attention_cls is None
+    )
+    if production_classes:
+        from vllm.model_executor.layers.layernorm import RMSNorm
+        from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+        from vllm.model_executor.layers.rotary_embedding import RotaryEmbedding
+        from vllm.model_executor.models.qwen3 import Qwen3Attention
+
+        rms_norm_cls = RMSNorm
+        rotary_cls = RotaryEmbedding
+        linear_method_cls = UnquantizedLinearMethod
+        attention_cls = Qwen3Attention
+    assert rms_norm_cls is not None
+    assert linear_method_cls is not None
+    assert attention_cls is not None
+    if det_gemm is None:
+        from rl_engine.kernels.ops.cuda.matmul.det_gemm import DetGemmOp
+
+        det_gemm = DetGemmOp()
+
+    attention_init = attention_cls.__init__
+    unquantized_apply = linear_method_cls.apply
+    original_rms_forward_native = rms_norm_cls.forward_native
+
+    def deterministic_linear_apply(
+        method: Any,
+        layer: Any,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if not hasattr(layer, _STRICT_PROJECTION_MARKER):
+            return unquantized_apply(method, layer, x, bias)
+        x_2d = x.reshape(-1, x.shape[-1])
+        linear = getattr(det_gemm, "linear", None)
+        output_2d = (
+            linear(x_2d, layer.weight)
+            if linear is not None
+            else det_gemm(x_2d, layer.weight.t().contiguous())
+        )
+        output = output_2d.reshape(*x.shape[:-1], layer.weight.shape[0])
+        return output if bias is None else output + bias
+
+    def strict_rms_norm_forward_cuda(
+        instance: Any,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if instance.variance_size_override is not None:
+            return original_rms_forward_native(instance, x, residual)
+        weight = instance.weight.data if instance.has_weight else None
+        if weight is None:
+            return original_rms_forward_native(instance, x, residual)
+        if residual is None:
+            return strict_rms_norm(
+                x,
+                weight,
+                eps=instance.variance_epsilon,
+            )
+        return strict_add_rms_norm(
+            x,
+            residual,
+            weight,
+            eps=instance.variance_epsilon,
+        )
+
+    if not hasattr(rms_norm_cls, _STRICT_RMS_NORM_INIT_MARKER):
+        rms_norm_init = rms_norm_cls.__init__
+
+        def rms_norm_init_wrapped(instance: Any, *args: Any, **kwargs: Any) -> None:
+            rms_norm_init(instance, *args, **kwargs)
+            instance._forward_method = instance.forward_cuda
+
+        setattr(rms_norm_cls, _STRICT_RMS_NORM_INIT_MARKER, rms_norm_init)
+        rms_norm_cls.__init__ = rms_norm_init_wrapped
+        rms_norm_cls.forward_cuda = strict_rms_norm_forward_cuda
+
+    if rotary_cls is not None and not hasattr(rotary_cls, _STRICT_ROTARY_INIT_MARKER):
+        rotary_init = rotary_cls.__init__
+
+        def rotary_init_wrapped(instance: Any, *args: Any, **kwargs: Any) -> None:
+            rotary_init(instance, *args, **kwargs)
+            instance._forward_method = instance.forward_cuda
+
+        setattr(rotary_cls, _STRICT_ROTARY_INIT_MARKER, rotary_init)
+        rotary_cls.__init__ = rotary_init_wrapped
+
+    if hasattr(attention_cls, _STRICT_MODEL_PATCH_MARKER):
+        return
+
+    def attention_init_wrapped(instance: Any, *args: Any, **kwargs: Any) -> None:
+        attention_init(instance, *args, **kwargs)
+        setattr(instance.qkv_proj, _STRICT_PROJECTION_MARKER, "qkv")
+        setattr(instance.o_proj, _STRICT_PROJECTION_MARKER, "o_proj")
+
+    setattr(attention_cls, _STRICT_MODEL_PATCH_MARKER, attention_init)
+    linear_method_cls.apply = deterministic_linear_apply
+    attention_cls.__init__ = attention_init_wrapped
 
 
 def _patch_sampler(integration: VllmIntegration, *, strict_linear_logp: bool) -> None:
@@ -243,8 +503,9 @@ def _patch_sampler(integration: VllmIntegration, *, strict_linear_logp: bool) ->
     if hasattr(Sampler, _PATCH_MARKER):
         raise RuntimeError("vLLM Sampler is already RL-Kernel patched")
     original = Sampler.forward
-    operator = VllmLogpOperator(original, strict_linear_logp=strict_linear_logp)
-    integration.install_operator("logp", operator)
+    if strict_linear_logp:
+        operator = VllmLogpOperator(original, strict_linear_logp=True)
+        integration.install_operator("logp", operator)
 
     def wrapped(instance: Any, *args: Any, **kwargs: Any) -> Any:
         sampling_metadata = kwargs.get("sampling_metadata")
@@ -269,7 +530,9 @@ def _patch_sampler(integration: VllmIntegration, *, strict_linear_logp: bool) ->
     integration.record_installed_hook("logp", "vllm.v1.sample.sampler.Sampler.forward")
 
 
-def _patch_worker_sampler(integration: VllmIntegration, *, strict_linear_logp: bool) -> None:
+def _patch_worker_sampler(
+    integration: VllmIntegration, *, strict_linear_logp: bool
+) -> None:
     """Patch the CUDA worker sampler used by vLLM 0.27's V1 runner.
 
     vLLM has two sampler implementations: the graph-friendly
@@ -296,47 +559,85 @@ def _patch_worker_sampler(integration: VllmIntegration, *, strict_linear_logp: b
         def native(_sampler: Any, *call_args: Any, **call_kwargs: Any) -> Any:
             return original(instance, *call_args, **call_kwargs)
 
-        if args and _is_worker_sampler_profile_batch(args[1] if len(args) > 1 else None):
+        if args and _is_worker_sampler_profile_batch(
+            args[1] if len(args) > 1 else None
+        ):
             return original(instance, *args, **kwargs)
         return integration.execute("logp", native, instance, *args, **kwargs)
 
     setattr(Sampler, _PATCH_MARKER, original)
     Sampler.__call__ = wrapped
-    integration.record_installed_hook("logp", "vllm.v1.worker.gpu.sample.sampler.Sampler.__call__")
+    integration.record_installed_hook(
+        "logp", "vllm.v1.worker.gpu.sample.sampler.Sampler.__call__"
+    )
 
 
 def _register_attention_backend(integration: VllmIntegration) -> None:
-    global _RLK_ATTENTION_BACKEND, _RLK_ATTENTION_IMPL
+    global _RLK_ATTENTION_BACKEND, _RLK_ATTENTION_BUILDER, _RLK_ATTENTION_IMPL
 
-    from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend, FlashAttentionImpl
-    from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+    from vllm.v1.attention.backends.flash_attn import (
+        FlashAttentionBackend,
+        FlashAttentionImpl,
+        FlashAttentionMetadataBuilder,
+    )
+    from vllm.v1.attention.backends.registry import (
+        AttentionBackendEnum,
+        register_backend,
+    )
 
-    operator = VllmAttentionOperator()
-    integration.install_operator("attention", operator)
+    operator: VllmAttentionOperator | None = None
+    if (
+        integration.plan.implementation_for("attention", "rollout")
+        is Implementation.RL_KERNEL
+    ):
+        operator = VllmAttentionOperator()
+        integration.install_operator("attention", operator)
 
     class RlKernelFlashAttentionImpl(FlashAttentionImpl):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            if operator is not None:
+                operator.bind_inference()
+
         def forward(self, *args: Any, **kwargs: Any) -> Any:
             active = get_active_integration("vllm")
             if active is not integration:
-                raise RuntimeError("vLLM Attention executed without its installed integration")
+                raise RuntimeError(
+                    "vLLM Attention executed without its installed integration"
+                )
 
             def native(_impl: Any, *call_args: Any, **call_kwargs: Any) -> Any:
                 return FlashAttentionImpl.forward(self, *call_args, **call_kwargs)
 
             return integration.execute("attention", native, self, *args, **kwargs)
 
+    class RlKernelFlashAttentionMetadataBuilder(FlashAttentionMetadataBuilder):
+        pass
+
     class RlKernelFlashAttentionBackend(FlashAttentionBackend):
         @staticmethod
         def get_impl_cls() -> type[Any]:
             return RlKernelFlashAttentionImpl
 
+        @staticmethod
+        def get_builder_cls() -> type[Any]:
+            return RlKernelFlashAttentionMetadataBuilder
+
     RlKernelFlashAttentionImpl.__module__ = __name__
     RlKernelFlashAttentionImpl.__qualname__ = "RlKernelFlashAttentionImpl"
+    RlKernelFlashAttentionMetadataBuilder.__module__ = __name__
+    RlKernelFlashAttentionMetadataBuilder.__qualname__ = (
+        "RlKernelFlashAttentionMetadataBuilder"
+    )
     RlKernelFlashAttentionBackend.__module__ = __name__
     RlKernelFlashAttentionBackend.__qualname__ = "RlKernelFlashAttentionBackend"
     _RLK_ATTENTION_IMPL = RlKernelFlashAttentionImpl
+    _RLK_ATTENTION_BUILDER = RlKernelFlashAttentionMetadataBuilder
     _RLK_ATTENTION_BACKEND = RlKernelFlashAttentionBackend
     globals()["RlKernelFlashAttentionImpl"] = RlKernelFlashAttentionImpl
+    globals()[
+        "RlKernelFlashAttentionMetadataBuilder"
+    ] = RlKernelFlashAttentionMetadataBuilder
     globals()["RlKernelFlashAttentionBackend"] = RlKernelFlashAttentionBackend
     # vLLM 0.27 selects FLASH_ATTN for Qwen on CUDA before custom third-party
     # names are considered. Override the selected enum in-place so the launcher
@@ -345,7 +646,9 @@ def _register_attention_backend(integration: VllmIntegration) -> None:
         AttentionBackendEnum.FLASH_ATTN,
         f"{__name__}.RlKernelFlashAttentionBackend",
     )
-    integration.record_installed_hook("attention", f"{__name__}.RlKernelFlashAttentionBackend")
+    integration.record_installed_hook(
+        "attention", f"{__name__}.RlKernelFlashAttentionBackend"
+    )
 
 
 def install_vllm_integration(plan: IntegrationPlan) -> VllmIntegration:
@@ -356,13 +659,27 @@ def install_vllm_integration(plan: IntegrationPlan) -> VllmIntegration:
         if not isinstance(existing, VllmIntegration):
             raise RuntimeError("active vLLM integration has an unexpected type")
         if existing.plan != plan:
-            raise RuntimeError("vLLM integration is already installed with another plan")
+            raise RuntimeError(
+                "vLLM integration is already installed with another plan"
+            )
         return existing
     integration = VllmIntegration(plan, rl_kernel_operators={})
     set_active_integration("vllm", integration)
-    strict_linear_logp = plan.implementation_for("logp", "rollout") is Implementation.RL_KERNEL
+    # vLLM imports this legacy rotary path even when every operator is routed
+    # to production. FA4-only installations need the bundled compatibility
+    # namespace before any attention backend is imported.
+    _install_flash_attn_ops_compatibility()
+    strict_linear_logp = (
+        plan.implementation_for("logp", "rollout") is Implementation.RL_KERNEL
+    )
+    strict_attention = (
+        plan.implementation_for("attention", "rollout") is Implementation.RL_KERNEL
+    )
+    if strict_attention:
+        _patch_qwen3_strict_model()
     if strict_linear_logp:
         _patch_qwen_lm_head_padding()
+        _patch_strict_lm_head_linear()
         _patch_qwen_compute_logits(integration)
 
     # Patch every boundary so P/R cases also produce production readback. The

--- a/rl_engine/kernels/ops/cuda/attention/flash_attn.py
+++ b/rl_engine/kernels/ops/cuda/attention/flash_attn.py
@@ -24,8 +24,13 @@ from rl_engine.kernels.ops.cuda.attention.deterministic_attn import (
 from rl_engine.utils.logger import logger
 
 _FA4_API_SOURCE = "flash_attn.cute.interface"
+_FA4_COMPAT_API_SOURCE = "vllm.vllm_flash_attn.cute.interface"
+_FA4_API_SOURCES = (_FA4_API_SOURCE, _FA4_COMPAT_API_SOURCE)
 _FA4_REQUIRED_PARAMETERS = frozenset(
     {"softmax_scale", "causal", "num_splits", "pack_gqa", "deterministic", "return_lse"}
+)
+_FA4_PAGED_REQUIRED_PARAMETERS = _FA4_REQUIRED_PARAMETERS | frozenset(
+    {"page_table", "seqused_k", "max_seqlen_k"}
 )
 
 
@@ -33,19 +38,28 @@ class StrictFlashAttentionUnavailable(RuntimeError):
     """Raised when the exact FlashAttention production contract is unavailable."""
 
 
-def _load_fa4_cute_op() -> tuple[Callable[..., Any], str]:
-    try:
-        module = importlib.import_module(_FA4_API_SOURCE)
-        op = getattr(module, "flash_attn_func")
-    except (AttributeError, ImportError, OSError, RuntimeError) as exc:
-        raise StrictFlashAttentionUnavailable(
-            "strict CUDA Attention requires flash_attn.cute.interface.flash_attn_func"
-        ) from exc
-    try:
-        package_version = importlib.metadata.version("flash-attn")
-    except importlib.metadata.PackageNotFoundError:
-        package_version = "unknown"
-    return op, package_version
+def _load_fa4_cute_op() -> tuple[Callable[..., Any], str, str]:
+    errors: list[str] = []
+    for api_source in _FA4_API_SOURCES:
+        try:
+            module = importlib.import_module(api_source)
+            op = getattr(module, "flash_attn_func")
+        except (AttributeError, ImportError, OSError, RuntimeError) as exc:
+            errors.append(f"{api_source}: {exc}")
+            continue
+
+        package_name = "vllm" if api_source == _FA4_COMPAT_API_SOURCE else "flash-attn"
+        try:
+            package_version = importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError:
+            package_version = "unknown"
+        return op, package_version, api_source
+
+    raise StrictFlashAttentionUnavailable(
+        "strict CUDA Attention requires a FlashAttention CuTe API; tried "
+        + ", ".join(_FA4_API_SOURCES)
+        + (f" ({'; '.join(errors)})" if errors else "")
+    )
 
 
 class StrictFlashAttention4Core:
@@ -70,6 +84,7 @@ class StrictFlashAttention4Core:
         *,
         split_kv: SplitKVSpec | None = None,
         _op: Callable[..., Any] | None = None,
+        _paged_op: Callable[..., Any] | None = None,
         _package_version: str | None = None,
     ) -> None:
         requested = SplitKVSpec.disabled() if split_kv is None else split_kv
@@ -78,14 +93,23 @@ class StrictFlashAttention4Core:
         if requested.mode is not SplitKVMode.DISABLED:
             raise ValueError("strict FA4 Attention requires Split-KV to be disabled")
         if _op is None:
-            op, package_version = _load_fa4_cute_op()
+            op, package_version, api_source = _load_fa4_cute_op()
+            paged_op = getattr(
+                importlib.import_module(api_source), "flash_attn_varlen_func", None
+            )
         else:
             op = _op
+            paged_op = _paged_op
             package_version = "test-double" if _package_version is None else _package_version
+            api_source = _FA4_API_SOURCE
         self._validate_api(op)
+        if paged_op is not None:
+            self._validate_paged_api(paged_op)
         self.split_kv = requested
         self.package_version = package_version
+        self.api_source = api_source
         self._op = op
+        self._paged_op = paged_op
 
     @staticmethod
     def _validate_api(op: Callable[..., Any]) -> None:
@@ -99,6 +123,21 @@ class StrictFlashAttention4Core:
         if missing:
             raise StrictFlashAttentionUnavailable(
                 "FlashAttention CuTe API is missing strict controls: " + ", ".join(missing)
+            )
+
+    @staticmethod
+    def _validate_paged_api(op: Callable[..., Any]) -> None:
+        try:
+            parameters = inspect.signature(op).parameters
+        except (TypeError, ValueError) as exc:
+            raise StrictFlashAttentionUnavailable(
+                "cannot inspect the FlashAttention CuTe paged API signature"
+            ) from exc
+        missing = sorted(_FA4_PAGED_REQUIRED_PARAMETERS.difference(parameters))
+        if missing:
+            raise StrictFlashAttentionUnavailable(
+                "FlashAttention CuTe paged API is missing strict controls: "
+                + ", ".join(missing)
             )
 
     def __call__(
@@ -138,14 +177,57 @@ class StrictFlashAttention4Core:
         q_fa = q.transpose(1, 2).contiguous()
         k_fa = k.transpose(1, 2).contiguous()
         v_fa = v.transpose(1, 2).contiguous()
-        result = self._op(
+        result = self.forward_bshd_with_lse(
             q_fa,
             k_fa,
             v_fa,
+            causal=causal,
+            scale=scale,
+            key_padding_mask=key_padding_mask,
+            query_position_ids=query_position_ids,
+            key_position_ids=key_position_ids,
+            output_dtype=resolved_dtype,
+        )
+        return DeterministicAttentionCoreResult(
+            out=result.out.transpose(1, 2).contiguous(),
+            lse=result.lse,
+            provenance=result.provenance,
+        )
+
+    def forward_bshd_with_lse(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        causal: bool = True,
+        scale: float | None = None,
+        key_padding_mask: torch.Tensor | None = None,
+        query_position_ids: torch.Tensor | None = None,
+        key_position_ids: torch.Tensor | None = None,
+        output_dtype: torch.dtype | None = None,
+    ) -> DeterministicAttentionCoreResult:
+        """Run strict FA4 on tensors already laid out as [B, S, H, D]."""
+        self._validate_bshd_inputs(q, k, v, key_padding_mask)
+        RLKernelDeterministicAttentionCore._validate_positions(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            causal=causal,
+            query_position_ids=query_position_ids,
+            key_position_ids=key_position_ids,
+        )
+        resolved_dtype = q.dtype if output_dtype is None else output_dtype
+        if resolved_dtype != q.dtype:
+            raise ValueError("strict Attention output_dtype must match the Q/K/V input dtype")
+
+        result = self._op(
+            q,
+            k,
+            v,
             softmax_scale=scale,
             causal=causal,
             num_splits=self.num_splits,
-            pack_gqa=q.size(1) > k.size(1),
+            pack_gqa=q.size(2) > k.size(2),
             deterministic=self.deterministic_backward,
             return_lse=True,
         )
@@ -156,9 +238,9 @@ class StrictFlashAttention4Core:
         out_fa, lse = result
         if not isinstance(out_fa, torch.Tensor) or not isinstance(lse, torch.Tensor):
             raise StrictFlashAttentionUnavailable("FlashAttention CuTe returned non-tensor output")
-        expected_out_shape = q_fa.shape
-        expected_lse_shape = (q.size(0), q.size(1), q.size(2))
-        if tuple(out_fa.shape) != tuple(expected_out_shape):
+        expected_out_shape = q.shape
+        expected_lse_shape = (q.size(0), q.size(2), q.size(1))
+        if tuple(out_fa.shape) != expected_out_shape:
             raise StrictFlashAttentionUnavailable(
                 f"FlashAttention output must have shape {tuple(expected_out_shape)}"
             )
@@ -175,9 +257,8 @@ class StrictFlashAttention4Core:
                 "FlashAttention attention-domain LSE must be FP32"
             )
 
-        out = out_fa.transpose(1, 2).contiguous()
         return DeterministicAttentionCoreResult(
-            out=out,
+            out=out_fa,
             lse=lse.contiguous(),
             provenance={
                 "strict_core_id": self.core_id,
@@ -188,7 +269,7 @@ class StrictFlashAttention4Core:
                 "num_splits": self.num_splits,
                 "deterministic_backward": self.deterministic_backward,
                 "dropout_p": 0.0,
-                "split_kv": self.split_kv.resolve(k.size(2), backend=self.backend_id).to_dict(),
+                "split_kv": self.split_kv.resolve(k.size(1), backend=self.backend_id).to_dict(),
                 "merge_order": self.merge_order,
                 "accum_dtype": self.accum_dtype,
                 "downcast_at": self.downcast_at,
@@ -199,6 +280,171 @@ class StrictFlashAttention4Core:
                 "reference_only": self.reference_only,
             },
         )
+
+    def forward_paged_bshd_with_lse(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        *,
+        page_table: torch.Tensor,
+        seqused_k: torch.Tensor,
+        max_seqlen_k: int,
+        scale: float | None = None,
+        output_dtype: torch.dtype | None = None,
+        out: torch.Tensor | None = None,
+    ) -> DeterministicAttentionCoreResult:
+        """Run the strict FA4 schedule directly over a paged KV cache."""
+
+        if self._paged_op is None:
+            raise StrictFlashAttentionUnavailable(
+                "strict paged Attention requires flash_attn_varlen_func"
+            )
+        self._validate_paged_bshd_inputs(
+            q,
+            k_cache,
+            v_cache,
+            page_table=page_table,
+            seqused_k=seqused_k,
+            max_seqlen_k=max_seqlen_k,
+        )
+        resolved_dtype = q.dtype if output_dtype is None else output_dtype
+        if resolved_dtype != q.dtype:
+            raise ValueError("strict Attention output_dtype must match the Q/K/V input dtype")
+        if out is not None:
+            if out.shape != q.shape:
+                raise ValueError("paged Attention out must have the same shape as q")
+            if out.dtype != resolved_dtype or out.device != q.device:
+                raise ValueError("paged Attention out must match the requested dtype and device")
+            if not out.is_contiguous():
+                raise ValueError("paged Attention out must be contiguous")
+
+        paged_kwargs = {
+            "page_table": page_table,
+            "seqused_k": seqused_k,
+            "max_seqlen_k": max_seqlen_k,
+            "softmax_scale": scale,
+            "causal": False,
+            "num_splits": self.num_splits,
+            "pack_gqa": q.size(2) > k_cache.size(2),
+            "deterministic": self.deterministic_backward,
+            "return_lse": True,
+        }
+        if out is not None:
+            paged_kwargs["out"] = out
+        out_fa, lse = self._paged_op(
+            q,
+            k_cache,
+            v_cache,
+            **paged_kwargs,
+        )
+        expected_lse_shape = (q.size(0), q.size(2), q.size(1))
+        if not isinstance(out_fa, torch.Tensor) or tuple(out_fa.shape) != tuple(q.shape):
+            raise StrictFlashAttentionUnavailable(
+                f"paged FlashAttention output must have shape {tuple(q.shape)}"
+            )
+        if not isinstance(lse, torch.Tensor) or tuple(lse.shape) != expected_lse_shape:
+            raise StrictFlashAttentionUnavailable(
+                f"paged FlashAttention LSE must have shape {expected_lse_shape}"
+            )
+        if out_fa.dtype != resolved_dtype or lse.dtype != torch.float32:
+            raise StrictFlashAttentionUnavailable(
+                "paged FlashAttention returned an incompatible output dtype"
+            )
+        if out is not None and out_fa.data_ptr() != out.data_ptr():
+            raise StrictFlashAttentionUnavailable(
+                "paged FlashAttention did not write to the requested output buffer"
+            )
+        return DeterministicAttentionCoreResult(
+            out=out_fa,
+            lse=lse.contiguous(),
+            provenance={
+                "strict_core_id": self.core_id,
+                "strict_schedule": self.strict_schedule,
+                "attention_backend": f"{self.backend_id}.paged",
+                "fa_api_source": self.api_source,
+                "fa_package_version": self.package_version,
+                "num_splits": self.num_splits,
+                "deterministic_backward": self.deterministic_backward,
+                "dropout_p": 0.0,
+                "split_kv": self.split_kv.resolve(
+                    max_seqlen_k, backend=self.backend_id
+                ).to_dict(),
+                "merge_order": self.merge_order,
+                "accum_dtype": self.accum_dtype,
+                "downcast_at": self.downcast_at,
+                "kv_layout": "paged_direct",
+                "output_buffer_reused": out is not None,
+                "fallback": False,
+                "fallback_reason": None,
+                "native_attention_arithmetic": True,
+                "production_ready": True,
+                "reference_only": False,
+            },
+        )
+
+    @staticmethod
+    def _validate_paged_bshd_inputs(
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        *,
+        page_table: torch.Tensor,
+        seqused_k: torch.Tensor,
+        max_seqlen_k: int,
+    ) -> None:
+        if q.ndim != 4 or q.size(1) != 1:
+            raise ValueError("paged q must use [B, 1, H, D]")
+        if k_cache.ndim != 4 or v_cache.shape != k_cache.shape:
+            raise ValueError("paged k/v must use [pages, page_size, H, D]")
+        if q.size(2) % k_cache.size(2) != 0 or q.size(3) != k_cache.size(3):
+            raise ValueError("paged q/k head counts or head dimensions are incompatible")
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("strict paged Attention supports FP16/BF16 only")
+        if k_cache.dtype != q.dtype or v_cache.dtype != q.dtype:
+            raise ValueError("paged q/k/v must share one dtype")
+        if not (q.is_cuda and k_cache.is_cuda and v_cache.is_cuda):
+            raise ValueError("strict paged Attention requires CUDA tensors")
+        if not (q.device == k_cache.device == v_cache.device):
+            raise ValueError("paged q/k/v must be on one CUDA device")
+        if page_table.shape[0] != q.size(0) or page_table.dtype != torch.int32:
+            raise ValueError("page_table must be int32 with one row per query")
+        if seqused_k.shape != (q.size(0),) or seqused_k.dtype != torch.int32:
+            raise ValueError("seqused_k must be int32 with one length per query")
+        if page_table.device != q.device or seqused_k.device != q.device:
+            raise ValueError("paged Attention metadata must be on the Q device")
+        if max_seqlen_k <= 0 or max_seqlen_k > page_table.size(1) * k_cache.size(1):
+            raise ValueError("max_seqlen_k exceeds the page table capacity")
+
+    @staticmethod
+    def _validate_bshd_inputs(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        key_padding_mask: torch.Tensor | None,
+    ) -> None:
+        if key_padding_mask is not None:
+            raise ValueError(
+                "strict FA4 core does not accept padding masks; materialize each logical row"
+            )
+        if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+            raise ValueError("q/k/v must be 4-D [B, S, H, D]")
+        if q.size(0) < 1:
+            raise ValueError("strict FA4 core requires at least one logical batch row")
+        if k.size(0) != q.size(0) or v.size(0) != q.size(0):
+            raise ValueError("q/k/v batch sizes must match")
+        if k.shape != v.shape or q.size(3) != k.size(3):
+            raise ValueError("k/v shapes and q/k/v head dimensions must match")
+        if q.size(2) % k.size(2) != 0:
+            raise ValueError("Q heads must be divisible by KV heads for GQA")
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("strict FA4 core supports FP16/BF16 only")
+        if k.dtype != q.dtype or v.dtype != q.dtype:
+            raise ValueError("q/k/v must share one dtype")
+        if not (q.is_cuda and k.is_cuda and v.is_cuda):
+            raise ValueError("strict FA4 core requires CUDA tensors")
+        if not (q.device == k.device == v.device):
+            raise ValueError("q/k/v must be on one CUDA device")
 
     @staticmethod
     def _validate_inputs(
@@ -213,9 +459,9 @@ class StrictFlashAttention4Core:
             )
         if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
             raise ValueError("q/k/v must be 4-D [B, H, S, D]")
-        if q.size(0) != 1:
-            raise ValueError("strict FA4 core executes one logical batch row at a time")
-        if k.size(0) != 1 or v.size(0) != 1:
+        if q.size(0) < 1:
+            raise ValueError("strict FA4 core requires at least one logical batch row")
+        if k.size(0) != q.size(0) or v.size(0) != q.size(0):
             raise ValueError("q/k/v batch sizes must match")
         if k.shape != v.shape or q.size(3) != k.size(3):
             raise ValueError("k/v shapes and q/k/v head dimensions must match")
@@ -273,7 +519,10 @@ class FlashAttentionOp:
             k: (batch, seqlen, nheads_k, headdim)
             v: (batch, seqlen, nheads_k, headdim)
         """
-        assert q.dtype in [torch.float16, torch.bfloat16], "FlashAttention requires FP16 or BF16"
+        assert q.dtype in [
+            torch.float16,
+            torch.bfloat16,
+        ], "FlashAttention requires FP16 or BF16"
         assert q.is_cuda and k.is_cuda and v.is_cuda, "Inputs must be on CUDA device"
 
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()

--- a/rl_engine/kernels/ops/cuda/attention/strict_runtime.py
+++ b/rl_engine/kernels/ops/cuda/attention/strict_runtime.py
@@ -73,6 +73,7 @@ class StrictCUDAAttentionRuntime:
         cp_world_size: int,
         query_position_ids: torch.Tensor,
         key_position_ids: torch.Tensor,
+        positions_are_sorted: bool = False,
     ) -> StrictCUDAAttentionResult:
         self._require_nvidia_cuda(q)
         if cp_world_size != contract.sharding.cp_world_size:
@@ -97,10 +98,21 @@ class StrictCUDAAttentionRuntime:
             communication_backend = "cuda_ag_rs"
             self.communication_executed = True
 
-        q_sorted, q_positions_sorted, q_sort = self._sort_by_position(global_q, global_q_positions)
-        k_sorted, k_positions_sorted, _ = self._sort_by_position(global_k, global_k_positions)
-        v_sorted = self._gather_sequence(global_v, torch.argsort(global_k_positions, dim=1))
-        self._validate_global_positions(q_positions_sorted, k_positions_sorted, causal)
+        if positions_are_sorted:
+            if cp_world_size != 1:
+                raise RuntimeError("pre-sorted Attention positions are supported only at CP=1")
+            q_sorted, k_sorted, v_sorted = global_q, global_k, global_v
+            q_positions_sorted, k_positions_sorted = global_q_positions, global_k_positions
+            q_sort = None
+        else:
+            q_sorted, q_positions_sorted, q_sort = self._sort_by_position(
+                global_q, global_q_positions
+            )
+            k_sorted, k_positions_sorted, k_sort = self._sort_by_position(
+                global_k, global_k_positions
+            )
+            v_sorted = self._gather_sequence(global_v, k_sort)
+            self._validate_global_positions(q_positions_sorted, k_positions_sorted, causal)
 
         # FA4 consumes [B, S, H, D]. Materialize that layout once for every
         # logical sequence instead of once per causal prefix.
@@ -108,57 +120,31 @@ class StrictCUDAAttentionRuntime:
         k_fa = k_sorted.transpose(1, 2).contiguous()
         v_fa = v_sorted.transpose(1, 2).contiguous()
 
-        batch_outputs: list[torch.Tensor] = []
-        batch_lses: list[torch.Tensor] = []
-        core_rows: list[dict[str, Any]] = []
-        for batch_index in range(q_sorted.size(0)):
-            query_outputs: list[torch.Tensor] = []
-            query_lses: list[torch.Tensor] = []
-            for query_index in range(q_sorted.size(2)):
-                query_position = q_positions_sorted[batch_index, query_index]
-                if causal:
-                    prefix_tokens = int(
-                        torch.searchsorted(
-                            k_positions_sorted[batch_index],
-                            query_position,
-                            right=True,
-                        ).item()
-                    )
-                else:
-                    prefix_tokens = k_sorted.size(2)
-                result = self._core.forward_bshd_with_lse(
-                    q_fa[batch_index : batch_index + 1, query_index : query_index + 1],
-                    k_fa[batch_index : batch_index + 1, :prefix_tokens],
-                    v_fa[batch_index : batch_index + 1, :prefix_tokens],
-                    # Prefix materialization is the mask. Both framework sides
-                    # therefore launch the exact same one-query FA4 shape.
-                    causal=False,
-                    scale=scale,
-                    query_position_ids=q_positions_sorted[
-                        batch_index : batch_index + 1,
-                        query_index : query_index + 1,
-                    ],
-                    key_position_ids=k_positions_sorted[
-                        batch_index : batch_index + 1,
-                        :prefix_tokens,
-                    ],
-                    output_dtype=q.dtype,
-                )
-                query_outputs.append(result.out)
-                query_lses.append(result.lse)
-                core_rows.append(
-                    {
-                        **dict(result.provenance),
-                        "query_position": int(query_position.item()),
-                        "kv_tokens": prefix_tokens,
-                    }
-                )
-            batch_outputs.append(torch.cat(query_outputs, dim=1))
-            batch_lses.append(torch.cat(query_lses, dim=2))
-        out_sorted = torch.cat(batch_outputs, dim=0).transpose(1, 2).contiguous()
-        lse_sorted = torch.cat(batch_lses, dim=0)
+        # FA4's full causal schedule produces the same output, LSE, and dQ as
+        # launching one single-query prefix at a time. Keeping all query rows
+        # in one launch removes O(sequence_length) Python and CUDA dispatches;
+        # deterministic=True still pins the backward implementation.
+        result = self._core.forward_bshd_with_lse(
+            q_fa,
+            k_fa,
+            v_fa,
+            causal=causal,
+            scale=scale,
+            query_position_ids=q_positions_sorted,
+            key_position_ids=k_positions_sorted,
+            output_dtype=q.dtype,
+        )
+        out_sorted = result.out.transpose(1, 2).contiguous()
+        lse_sorted = result.lse
+        backend = (
+            result.provenance.get("actual_backend")
+            or result.provenance.get("attention_backend")
+            or getattr(self._core, "backend_id", None)
+        )
 
         if cp_world_size > 1:
+            if q_sort is None:
+                raise RuntimeError("CP Attention requires a framework position reorder")
             inverse_q_sort = torch.argsort(q_sort, dim=1)
             out_rank_packed = self._gather_sequence(out_sorted, inverse_q_sort)
             lse_rank_packed = self._gather_sequence(lse_sorted, inverse_q_sort)
@@ -187,8 +173,71 @@ class StrictCUDAAttentionRuntime:
                 "reference_only": False,
                 "split_kv": "disabled",
                 "framework_position_reorder": True,
-                "query_schedule": "single_query_causal_prefix",
-                "core_rows": core_rows,
+                "query_schedule": "full_sequence_causal_single_launch",
+                "backward_schedule": "fa4_deterministic_full_sequence",
+                "core_row_count": q_sorted.size(0) * q_sorted.size(2),
+                "core_launch_count": 1,
+                "core_batch_size": q_sorted.size(0),
+                "core_query_length": q_sorted.size(2),
+                "core_actual_backends": [] if backend is None else [str(backend)],
+            },
+        )
+
+    def forward_paged_with_lse(
+        self,
+        q: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        *,
+        page_table: torch.Tensor,
+        seqused_k: torch.Tensor,
+        max_seqlen_k: int,
+        scale: float | None,
+        out: torch.Tensor | None = None,
+    ) -> StrictCUDAAttentionResult:
+        """Run strict inference Attention without materializing paged KV rows."""
+
+        self._require_nvidia_cuda(q)
+        if out is not None and (
+            out.shape != q.shape or out.dtype != q.dtype or out.device != q.device
+        ):
+            raise ValueError("paged Attention out must match q shape, dtype, and device")
+        result = self._core.forward_paged_bshd_with_lse(
+            q.transpose(1, 2).contiguous(),
+            k_cache,
+            v_cache,
+            page_table=page_table,
+            seqused_k=seqused_k,
+            max_seqlen_k=max_seqlen_k,
+            scale=scale,
+            output_dtype=q.dtype,
+            out=None if out is None else out.transpose(1, 2),
+        )
+        self.communication_executed = False
+        return StrictCUDAAttentionResult(
+            out=result.out.transpose(1, 2).contiguous(),
+            lse=result.lse,
+            provenance={
+                **result.provenance,
+                "strict_core_id": self.core_id,
+                "strict_schedule": self.strict_schedule,
+                "actual_backend": self.backend_id,
+                "communication_backend": "none",
+                "communication_executed": False,
+                "native_attention_arithmetic": True,
+                "production_ready": True,
+                "fallback": False,
+                "fallback_reason": None,
+                "reference_only": False,
+                "query_schedule": "paged_single_query_batch",
+                "core_row_count": q.size(0),
+                "core_launch_count": 1,
+                "core_batch_size": q.size(0),
+                "core_actual_backends": [
+                    result.provenance.get(
+                        "attention_backend", "flash_attention_4.cute.paged"
+                    )
+                ],
             },
         )
 
@@ -285,13 +334,19 @@ class StrictCUDAAttentionRuntime:
             (query_positions, "query"),
             (key_positions, "key"),
         ):
-            if positions.size(1) > 1 and bool((positions[:, 1:] <= positions[:, :-1]).any()):
-                raise RuntimeError(f"global {name} positions must be unique and increasing")
-        if causal and not torch.equal(
-            query_positions,
-            key_positions[:, -query_positions.size(1) :],
-        ):
-            raise RuntimeError("causal Attention queries must be the trailing global KV positions")
+            if positions.size(1) > 1:
+                torch._assert_async(
+                    torch.all(positions[:, 1:] > positions[:, :-1]),
+                    f"global {name} positions must be unique and increasing",
+                )
+        if causal:
+            torch._assert_async(
+                torch.all(
+                    query_positions
+                    == key_positions[:, -query_positions.size(1) :]
+                ),
+                "causal Attention queries must be the trailing global KV positions",
+            )
 
 
 __all__ = ["StrictCUDAAttentionResult", "StrictCUDAAttentionRuntime"]

--- a/rl_engine/kernels/ops/cuda/loss/linear_logp.py
+++ b/rl_engine/kernels/ops/cuda/loss/linear_logp.py
@@ -9,9 +9,13 @@ from typing import Any, Optional
 import torch
 
 from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
+from rl_engine.kernels.ops.cuda.matmul.det_gemm import det_gemm_linear
 from rl_engine.kernels.ops.pytorch.loss.linear_logp import (
+    _assert_global_targets_async,
+    _deterministic_tp_all_reduce_,
     _merge_tp_local_logp,
     _require_distributed_initialized,
+    _validate_even_tp_vocab_partition_local,
     _validate_global_targets,
     _validate_tp_targets_enabled,
     _validate_tp_vocab_partition_cached,
@@ -189,8 +193,7 @@ def _sm90_linear_logp_backward(
         grad_hidden = None
         if compute_grad_hidden:
             if tp_group is not None:
-                dist = _require_distributed_initialized()
-                dist.all_reduce(grad_hidden_t, op=dist.ReduceOp.SUM, group=tp_group)
+                _deterministic_tp_all_reduce_(grad_hidden_t, tp_group)
             grad_hidden = grad_hidden_t.to(hidden_dtype).reshape(
                 (*tuple(lead_shape), hidden_2d.size(1))
             )
@@ -335,8 +338,7 @@ class _TensorParallelLinearLogpSaveProbsBF16Function(torch.autograd.Function):
             grad_weight = probs.t().matmul(hidden_2d)
         if ctx.needs_input_grad[0]:
             grad_hidden_2d = probs.matmul(weight)
-            dist = _require_distributed_initialized()
-            dist.all_reduce(grad_hidden_2d, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+            _deterministic_tp_all_reduce_(grad_hidden_2d, ctx.tp_group)
             grad_hidden = grad_hidden_2d.reshape((*tuple(ctx.lead_shape), weight.size(1)))
         return grad_hidden, grad_weight, None, None, None, None
 
@@ -536,8 +538,7 @@ class _TensorParallelLinearLogpFusedTileBF16Function(torch.autograd.Function):
                     )
         grad_hidden = None
         if grad_hidden_2d is not None:
-            dist = _require_distributed_initialized()
-            dist.all_reduce(grad_hidden_2d, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+            _deterministic_tp_all_reduce_(grad_hidden_2d, ctx.tp_group)
             grad_hidden = grad_hidden_2d.to(ctx.hidden_dtype).reshape(
                 (*tuple(ctx.lead_shape), hidden_2d.size(1))
             )
@@ -1063,7 +1064,7 @@ class _StrictLinearLogpAutograd(torch.autograd.Function):
         )
 
 
-STRICT_LINEAR_LOGP_CONTRACT_VERSION = "cuda-det-gemm-linear-logp-sm90-contract-v2"
+STRICT_LINEAR_LOGP_CONTRACT_VERSION = "strict-gemm-linear-logp-sm90-contract-v3"
 
 
 def _strict_tp_run(
@@ -1079,7 +1080,7 @@ def _strict_tp_run(
     tp_group,
 ):
     required = (
-        "det_gemm_fwd",
+        "det_gemm_fwd_weight",
         "linear_logp_local_bf16_forward",
         "linear_logp_logits_bf16_to_dlogits",
     )
@@ -1091,24 +1092,33 @@ def _strict_tp_run(
     target = target.reshape(-1).to(device=hidden.device, dtype=torch.long).contiguous()
     if hidden_2d.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
         raise TypeError("strict TP linear_logp requires BF16 hidden and weight")
-    global_vocab = _validate_tp_vocab_partition_cached(
+    global_vocab = _validate_even_tp_vocab_partition_local(
         tp_group=tp_group,
-        device=hidden.device,
         vocab_start_index=int(vocab_start),
         local_vocab_size=weight.size(0),
         global_vocab_size=int(global_vocab),
     )
     if not 0 < int(real_vocab) <= global_vocab:
         raise ValueError(f"invalid real_vocab_size={real_vocab} for padded vocab={global_vocab}")
-    _validate_global_targets(target, int(real_vocab), tp_group)
-    dist = _require_distributed_initialized()
-    owners = (
-        (target >= int(vocab_start)) & (target < int(vocab_start) + weight.size(0))
-    ).to(torch.int32)
-    dist.all_reduce(owners, op=dist.ReduceOp.SUM, group=tp_group)
-    if bool((owners != 1).any().item()):
-        raise ValueError("each selected target must have exactly one TP LM-head owner")
-    logits = _C.det_gemm_fwd(hidden_2d, weight.t().contiguous())
+    if _validate_tp_targets_enabled():
+        # Opt-in diagnostics retain the synchronized cross-rank checks. The
+        # cached contiguous [0, V) partition plus a valid target already prove
+        # unique ownership during normal execution.
+        _validate_global_targets(target, int(real_vocab), tp_group)
+        dist = _require_distributed_initialized()
+        owners = (
+            (target >= int(vocab_start)) & (target < int(vocab_start) + weight.size(0))
+        ).to(torch.int32)
+        dist.all_reduce(owners, op=dist.ReduceOp.SUM, group=tp_group)
+        if bool((owners != 1).any().item()):
+            raise ValueError("each selected target must have exactly one TP LM-head owner")
+    else:
+        _assert_global_targets_async(target, int(real_vocab))
+    logits = det_gemm_linear(
+        hidden_2d,
+        weight,
+        native_op=_C.det_gemm_fwd_weight,
+    )
     temp = hidden_2d.new_empty(0, dtype=torch.float32)
     if bias is not None:
         logits = (logits.float() + bias.float().reshape(1, -1)).to(torch.bfloat16)
@@ -1116,8 +1126,12 @@ def _strict_tp_run(
         temp = temperature.to(device=hidden.device, dtype=torch.float32).reshape(-1)
         if temp.numel() == 1:
             temp = temp.expand(hidden_2d.size(0)).contiguous()
-        if temp.numel() != hidden_2d.size(0) or bool((temp <= 0).any().item()):
+        if temp.numel() != hidden_2d.size(0):
             raise ValueError("temperature must be positive and scalar or per-token")
+        torch._assert_async(
+            (temp > 0).all(),
+            "temperature must be positive and scalar or per-token",
+        )
         logits = (logits.float() / temp.reshape(-1, 1)).to(torch.bfloat16)
     local_real = max(0, min(weight.size(0), int(real_vocab) - int(vocab_start)))
     if local_real < weight.size(0):
@@ -1129,6 +1143,74 @@ def _strict_tp_run(
     )
     logp, lse = _merge_tp_local_logp(local_lse, local_target, tp_group=tp_group)
     return logp, lse, hidden_2d, weight, target, logits, temp
+
+
+def sm90_deterministic_logp_from_local_logits_tp(
+    local_logits: torch.Tensor,
+    target_ids: torch.Tensor,
+    *,
+    vocab_start_index: int,
+    global_vocab_size: int,
+    real_vocab_size: int = -1,
+    temperature: Optional[torch.Tensor] = None,
+    tp_group: Any,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Merge a deterministic TP LM-head result without recomputing its GEMM."""
+
+    required = "linear_logp_local_bf16_forward"
+    if not (_EXT_AVAILABLE and hasattr(_C, required)):
+        raise RuntimeError(f"strict TP logits logp missing CUDA symbol: {required}")
+    if local_logits.ndim != 2 or local_logits.dtype != torch.bfloat16:
+        raise TypeError("strict TP logits logp requires 2-D BF16 local logits")
+    if not local_logits.is_cuda or not local_logits.is_contiguous():
+        raise ValueError("strict TP logits logp requires contiguous CUDA logits")
+
+    vocab_start = int(vocab_start_index)
+    global_vocab = _validate_even_tp_vocab_partition_local(
+        tp_group=tp_group,
+        vocab_start_index=vocab_start,
+        local_vocab_size=local_logits.size(1),
+        global_vocab_size=int(global_vocab_size),
+    )
+    real_vocab = global_vocab if int(real_vocab_size) < 0 else int(real_vocab_size)
+    if not 0 < real_vocab <= global_vocab:
+        raise ValueError(
+            f"invalid real_vocab_size={real_vocab} for padded vocab={global_vocab}"
+        )
+    target = (
+        target_ids.reshape(-1)
+        .to(device=local_logits.device, dtype=torch.long)
+        .contiguous()
+    )
+    if target.numel() != local_logits.size(0):
+        raise ValueError("target_ids must contain one id per local-logits row")
+    _assert_global_targets_async(target, real_vocab)
+
+    logits = local_logits
+    if temperature is not None:
+        temp = temperature.to(device=logits.device, dtype=torch.float32).reshape(-1)
+        if temp.numel() == 1:
+            temp = temp.expand(logits.size(0)).contiguous()
+        if temp.numel() != logits.size(0):
+            raise ValueError("temperature must be positive and scalar or per-token")
+        torch._assert_async(
+            (temp > 0).all(),
+            "temperature must be positive and scalar or per-token",
+        )
+        logits = (logits.float() / temp.reshape(-1, 1)).to(torch.bfloat16)
+    local_real = max(0, min(logits.size(1), real_vocab - vocab_start))
+    if local_real < logits.size(1):
+        logits = logits.clone()
+        logits[:, local_real:] = float("-inf")
+    logits = logits.contiguous()
+    local_target, local_lse = _C.linear_logp_local_bf16_forward(
+        logits,
+        target,
+        vocab_start,
+    )
+    logp, lse = _merge_tp_local_logp(local_lse, local_target, tp_group=tp_group)
+    lead_shape = target_ids.shape
+    return logp.reshape(lead_shape), lse.reshape(lead_shape)
 
 
 class _StrictTensorParallelLinearLogpAutograd(torch.autograd.Function):
@@ -1189,8 +1271,7 @@ class _StrictTensorParallelLinearLogpAutograd(torch.autograd.Function):
         grad_hidden = grad_weight = None
         if ctx.needs_input_grad[0]:
             grad_hidden = _C.det_gemm_fwd(dlogits, weight)
-            dist = _require_distributed_initialized()
-            dist.all_reduce(grad_hidden, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+            _deterministic_tp_all_reduce_(grad_hidden, ctx.tp_group)
             grad_hidden = grad_hidden.reshape(ctx.lead_shape + (weight.size(1),)).to(
                 ctx.hidden_dtype
             )

--- a/rl_engine/kernels/ops/cuda/matmul/det_gemm.py
+++ b/rl_engine/kernels/ops/cuda/matmul/det_gemm.py
@@ -9,17 +9,20 @@ backend selection never falls back silently. Tensor-parallel GEMM is WS2.
 """
 import os
 from collections.abc import Callable
+from threading import Lock
 
 import torch
 
 from rl_engine.kernels.ops.backward_runtime import record_backward
 from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
-from rl_engine.utils.logger import logger
+from rl_engine.runtime_mode import rl_kernel_mode, route_report_enabled
 
 _BACKEND_ENV = "RL_KERNEL_DET_GEMM_BACKEND"
 _SM90_BACKEND = "sm90"
 _CUBLASLT_BACKEND = "cublaslt_nosplitk"
 _CUBLASLT_CONFIGURED = False
+_ROUTE_REPORTED = False
+_ROUTE_REPORT_LOCK = Lock()
 
 
 def det_gemm_backend() -> str:
@@ -57,6 +60,22 @@ def det_gemm_backend_id() -> str:
     return "rlkernel.det_gemm.sm90.v1"
 
 
+def _report_strict_route_once() -> None:
+    global _ROUTE_REPORTED
+    if not route_report_enabled():
+        return
+    with _ROUTE_REPORT_LOCK:
+        if _ROUTE_REPORTED:
+            return
+        _ROUTE_REPORTED = True
+    print(
+        f"[RL-Kernel][route] mode={rl_kernel_mode().value} module=gemm "
+        "requested=strict "
+        f"actual={det_gemm_backend_id()} fallback=false",
+        flush=True,
+    )
+
+
 def _configure_cublaslt_nosplitk(a: torch.Tensor | None = None) -> None:
     """Validate the Hopper batch-invariant cuBLASLt contract once per process."""
 
@@ -85,7 +104,6 @@ def _configure_cublaslt_nosplitk(a: torch.Tensor | None = None) -> None:
     torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
     torch.backends.cuda.preferred_blas_library("cublaslt")
     _CUBLASLT_CONFIGURED = True
-    logger.info("Using RL-Kernel strict cuBLASLt no-split-K GEMM backend.")
 
 
 def det_gemm_linear(
@@ -98,7 +116,9 @@ def det_gemm_linear(
 
     if det_gemm_backend() == _CUBLASLT_BACKEND:
         _configure_cublaslt_nosplitk(a)
+        _report_strict_route_once()
         return torch.mm(a, weight.t())
+    _report_strict_route_once()
     if native_op is not None:
         return native_op(a, weight)
     return _det_gemm_fwd_weight(a, weight)
@@ -216,32 +236,28 @@ class DetGemmOp:
         backend = det_gemm_backend()
         if backend == _CUBLASLT_BACKEND:
             _configure_cublaslt_nosplitk()
-        if _EXT_AVAILABLE and hasattr(_C, "det_gemm_fwd"):
-            if backend == _SM90_BACKEND and os.getenv(
-                "RL_KERNEL_DET_GEMM_SM90_ONLY", ""
-            ).strip().lower() in {
-                "1",
-                "true",
-                "yes",
-                "on",
-            } and not (
-                hasattr(_C, "det_gemm_sm90_compiled") and _C.det_gemm_sm90_compiled()
-            ):
-                raise RuntimeError(
-                    "RL_KERNEL_DET_GEMM_SM90_ONLY=1 requires an extension built with "
-                    "KERNEL_ALIGN_DET_GEMM_SM90=1"
-                )
-            self.op = _C.det_gemm_fwd
-            self.has_hardware_op = True
-            logger.info(
-                "Successfully linked RL-Kernel det_gemm backend %s.",
-                det_gemm_backend_id(),
+        if not (_EXT_AVAILABLE and hasattr(_C, "det_gemm_fwd")):
+            raise RuntimeError(
+                "strict RL-Kernel GEMM requires the compiled CUDA extension; "
+                "refusing non-strict fallback"
             )
-        else:
-            logger.warning(
-                "RL-Kernel _C.det_gemm_fwd unavailable; DetGemmOp requires the "
-                "compiled CUDA extension and has no batch-invariant fallback."
+        if backend == _SM90_BACKEND and os.getenv(
+            "RL_KERNEL_DET_GEMM_SM90_ONLY", ""
+        ).strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        } and not (
+            hasattr(_C, "det_gemm_sm90_compiled") and _C.det_gemm_sm90_compiled()
+        ):
+            raise RuntimeError(
+                "RL_KERNEL_DET_GEMM_SM90_ONLY=1 requires an extension built with "
+                "KERNEL_ALIGN_DET_GEMM_SM90=1; refusing non-strict fallback"
             )
+        self.op = _C.det_gemm_fwd
+        self.has_hardware_op = True
+        _report_strict_route_once()
 
     def __call__(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         assert a.dtype == torch.bfloat16 and b.dtype == torch.bfloat16, "BF16 only"

--- a/rl_engine/kernels/ops/cuda/matmul/det_gemm.py
+++ b/rl_engine/kernels/ops/cuda/matmul/det_gemm.py
@@ -1,17 +1,122 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
-"""Batch-invariant deterministic GEMM, CUDA path (WS1 #146).
+"""Batch-invariant deterministic GEMM backends (WS1 #146).
 
 Hand-written kernel (csrc/cuda/gemm/det_gemm_kernel.cu): fixed K-accumulation
-order, FP32 accumulation, no split-K. A row's output is invariant to batch size,
-chunked-prefill, and padding. No PyTorch fallback -- a generic matmul (cuBLAS)
-would silently break invariance (see NativeGemmOp). Tensor-parallel GEMM is WS2.
+order, FP32 accumulation, no split-K. On Hopper, an explicitly configured
+cuBLASLt no-split-K backend is also available. Both are strict implementations;
+backend selection never falls back silently. Tensor-parallel GEMM is WS2.
 """
+import os
+from collections.abc import Callable
+
 import torch
 
 from rl_engine.kernels.ops.backward_runtime import record_backward
 from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
 from rl_engine.utils.logger import logger
+
+_BACKEND_ENV = "RL_KERNEL_DET_GEMM_BACKEND"
+_SM90_BACKEND = "sm90"
+_CUBLASLT_BACKEND = "cublaslt_nosplitk"
+_CUBLASLT_CONFIGURED = False
+
+
+def det_gemm_backend() -> str:
+    """Return the selected strict GEMM implementation.
+
+    The aligned runtime contract selects the same Hopper cuBLASLt path as vLLM.
+    Other environments retain the self-contained SM90 backend unless overridden.
+    """
+
+    aligned_default = (
+        os.getenv("VLLM_BATCH_INVARIANT", "").strip().lower()
+        in {"1", "true", "yes", "on"}
+        and os.getenv("CUBLAS_WORKSPACE_CONFIG", "").strip() == ":16:8"
+        and os.getenv("CUBLASLT_WORKSPACE_SIZE", "").strip() == "1"
+    )
+    default = _CUBLASLT_BACKEND if aligned_default else _SM90_BACKEND
+    value = os.getenv(_BACKEND_ENV, default).strip().lower()
+    aliases = {
+        "cuda": _SM90_BACKEND,
+        "cublaslt": _CUBLASLT_BACKEND,
+    }
+    value = aliases.get(value, value)
+    if value not in {_SM90_BACKEND, _CUBLASLT_BACKEND}:
+        raise RuntimeError(
+            f"{_BACKEND_ENV} must be '{_SM90_BACKEND}' or "
+            f"'{_CUBLASLT_BACKEND}', got {value!r}"
+        )
+    return value
+
+
+def det_gemm_backend_id() -> str:
+    backend = det_gemm_backend()
+    if backend == _CUBLASLT_BACKEND:
+        return "rlkernel.det_gemm.cublaslt_nosplitk.v1"
+    return "rlkernel.det_gemm.sm90.v1"
+
+
+def _configure_cublaslt_nosplitk(a: torch.Tensor | None = None) -> None:
+    """Validate the Hopper batch-invariant cuBLASLt contract once per process."""
+
+    global _CUBLASLT_CONFIGURED
+    if _CUBLASLT_CONFIGURED:
+        return
+    if torch._dynamo.is_compiling():
+        raise RuntimeError(
+            "cublaslt_nosplitk must be configured before torch.compile tracing"
+        )
+    device = None if a is None else a.device
+    if torch.cuda.get_device_capability(device)[0] != 9:
+        raise RuntimeError("cublaslt_nosplitk is currently validated only on SM90")
+    workspace = os.getenv("CUBLAS_WORKSPACE_CONFIG", "").strip()
+    if workspace != ":16:8":
+        raise RuntimeError(
+            "cublaslt_nosplitk requires CUBLAS_WORKSPACE_CONFIG=:16:8 before "
+            "the process starts"
+        )
+    if os.getenv("CUBLASLT_WORKSPACE_SIZE", "").strip() != "1":
+        raise RuntimeError(
+            "cublaslt_nosplitk requires CUBLASLT_WORKSPACE_SIZE=1 before the "
+            "process starts"
+        )
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+    torch.backends.cuda.matmul.allow_fp16_reduced_precision_reduction = False
+    torch.backends.cuda.preferred_blas_library("cublaslt")
+    _CUBLASLT_CONFIGURED = True
+    logger.info("Using RL-Kernel strict cuBLASLt no-split-K GEMM backend.")
+
+
+def det_gemm_linear(
+    a: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    native_op: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
+) -> torch.Tensor:
+    """Apply a native [N,K] weight through the selected strict backend."""
+
+    if det_gemm_backend() == _CUBLASLT_BACKEND:
+        _configure_cublaslt_nosplitk(a)
+        return torch.mm(a, weight.t())
+    if native_op is not None:
+        return native_op(a, weight)
+    return _det_gemm_fwd_weight(a, weight)
+
+
+@torch.library.custom_op("rl_kernel::det_gemm_fwd_weight", mutates_args=())
+def _det_gemm_fwd_weight(a: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+    """Expose the native-weight SM90 GEMM through the PyTorch dispatcher."""
+
+    return _C.det_gemm_fwd_weight(a, weight)
+
+
+@_det_gemm_fwd_weight.register_fake
+def _det_gemm_fwd_weight_fake(
+    a: torch.Tensor,
+    weight: torch.Tensor,
+) -> torch.Tensor:
+    return a.new_empty((*a.shape[:-1], weight.shape[0]))
 
 
 class _DetGemmFn(torch.autograd.Function):
@@ -20,7 +125,9 @@ class _DetGemmFn(torch.autograd.Function):
         ctx.save_for_backward(a, b)
         if output_fp32:
             if not hasattr(_C, "det_gemm_fwd_fp32"):
-                raise RuntimeError("FP32 deterministic GEMM output requires the rebuilt extension")
+                raise RuntimeError(
+                    "FP32 deterministic GEMM output requires the rebuilt extension"
+                )
             return _C.det_gemm_fwd_fp32(a, b)
         return _C.det_gemm_fwd(a, b)
 
@@ -39,6 +146,31 @@ class _DetGemmFn(torch.autograd.Function):
             family="cuda",
         )
         return da, db, None
+
+
+class _DetLinearFn(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, a, weight):
+        ctx.save_for_backward(a, weight)
+        return det_gemm_linear(a, weight)
+
+    @staticmethod
+    def backward(ctx, grad_out):
+        a, weight = ctx.saved_tensors
+        grad_out = grad_out.contiguous()
+        if grad_out.dtype != torch.bfloat16:
+            grad_out = grad_out.to(torch.bfloat16)
+        da = (
+            _C.det_gemm_da_weight(grad_out, weight) if ctx.needs_input_grad[0] else None
+        )
+        dweight = _C.det_gemm_dw(a, grad_out) if ctx.needs_input_grad[1] else None
+        record_backward(
+            "det_gemm",
+            kernel_id="rl_engine._C.det_gemm_da_weight+rl_engine._C.det_gemm_dw",
+            impl="cuda_det_gemm",
+            family="cuda",
+        )
+        return da, dweight
 
 
 class _DetGemmAccumFn(torch.autograd.Function):
@@ -81,10 +213,30 @@ class DetGemmOp:
 
     def __init__(self):
         self.has_hardware_op = False
+        backend = det_gemm_backend()
+        if backend == _CUBLASLT_BACKEND:
+            _configure_cublaslt_nosplitk()
         if _EXT_AVAILABLE and hasattr(_C, "det_gemm_fwd"):
+            if backend == _SM90_BACKEND and os.getenv(
+                "RL_KERNEL_DET_GEMM_SM90_ONLY", ""
+            ).strip().lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            } and not (
+                hasattr(_C, "det_gemm_sm90_compiled") and _C.det_gemm_sm90_compiled()
+            ):
+                raise RuntimeError(
+                    "RL_KERNEL_DET_GEMM_SM90_ONLY=1 requires an extension built with "
+                    "KERNEL_ALIGN_DET_GEMM_SM90=1"
+                )
             self.op = _C.det_gemm_fwd
             self.has_hardware_op = True
-            logger.info("Successfully linked to RL-Kernel _C.det_gemm_fwd.")
+            logger.info(
+                "Successfully linked RL-Kernel det_gemm backend %s.",
+                det_gemm_backend_id(),
+            )
         else:
             logger.warning(
                 "RL-Kernel _C.det_gemm_fwd unavailable; DetGemmOp requires the "
@@ -100,6 +252,17 @@ class DetGemmOp:
                 "batch-invariant fallback exists. Build the extension first."
             )
         return _DetGemmFn.apply(a.contiguous(), b.contiguous(), False)
+
+    def linear(self, a: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        """Apply a native [N,K] linear weight without materializing weight.T."""
+        assert a.dtype == torch.bfloat16 and weight.dtype == torch.bfloat16, "BF16 only"
+        assert a.is_cuda and weight.is_cuda, "Inputs must be on CUDA device"
+        required = ("det_gemm_fwd_weight", "det_gemm_da_weight", "det_gemm_dw")
+        if not self.has_hardware_op or any(not hasattr(_C, name) for name in required):
+            raise RuntimeError(
+                "DetGemmOp.linear requires the rebuilt native-weight CUDA extension"
+            )
+        return _DetLinearFn.apply(a.contiguous(), weight.contiguous())
 
     def forward_fp32(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         assert a.dtype == torch.bfloat16 and b.dtype == torch.bfloat16, "BF16 only"

--- a/rl_engine/kernels/ops/pytorch/ffn/ffn.py
+++ b/rl_engine/kernels/ops/pytorch/ffn/ffn.py
@@ -4,33 +4,125 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 import torch
 from torch import Tensor
 
+from rl_engine.distributed.collectives import (
+    _COLLECTIVES as _SHARED_COLLECTIVES,
+    collective_for_group,
+    deterministic_all_reduce_inplace,
+)
 from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
+from rl_engine.kernels.ops.cuda.matmul.det_gemm import det_gemm_linear
 
 QWEN3_8B_HIDDEN_SIZE = 4096
 QWEN3_8B_INTERMEDIATE_SIZE = 12288
 BACKEND_ID = "rlkernel.ffn.qwen3.deterministic.v1"
 
 _DET_GEMM_SYMBOLS = (
-    "det_gemm_fwd",
-    "det_gemm_fwd_rhs_transposed",
-    "det_gemm_db_transposed",
+    "det_gemm_fwd_weight",
+    "det_gemm_da_weight",
+    "det_gemm_dw",
 )
 _SWIGLU_SYMBOLS = (
     "swiglu_forward",
     "swiglu_backward",
 )
+_PACKED_SWIGLU_SYMBOLS = (
+    "swiglu_packed_forward",
+    "swiglu_packed_backward",
+)
 _REQUIRED_SYMBOLS = _DET_GEMM_SYMBOLS + _SWIGLU_SYMBOLS
 _COLLECTIVE_MIN_CAPACITY_BYTES = 64 * 1024 * 1024
-_COLLECTIVES: dict[tuple[int, int, int, int], Any] = {}
+# Backward-compatible test hook; ownership lives in the shared communication layer.
+_COLLECTIVES = _SHARED_COLLECTIVES
+_PACKED_INFERENCE_OBSERVERS: list[Callable[[], None]] = []
 
 
-def _require_ffn_kernels(*, disable_split_k: bool) -> None:
+def register_packed_inference_observer(callback: Callable[[], None]) -> None:
+    """Arm one execution callback for the graph-captured rollout custom op."""
+
+    if not callable(callback):
+        raise TypeError("packed inference observer must be callable")
+    _PACKED_INFERENCE_OBSERVERS.append(callback)
+
+
+def _notify_packed_inference_observers() -> None:
+    callbacks = tuple(_PACKED_INFERENCE_OBSERVERS)
+    _PACKED_INFERENCE_OBSERVERS.clear()
+    for callback in callbacks:
+        callback()
+
+
+@torch.library.custom_op("rl_kernel::qwen3_ffn_packed_inference", mutates_args=())
+def _qwen3_ffn_packed_inference(
+    rmsnorm_output: Tensor,
+    fused_gate_up_weight: Tensor,
+    down_weight: Tensor,
+) -> Tensor:
+    """Run the graph-safe compute portion of the strict rollout FFN."""
+
+    _notify_packed_inference_observers()
+    input_shape = rmsnorm_output.shape
+    hidden_2d = rmsnorm_output.reshape(-1, input_shape[-1]).contiguous()
+    gate_up = det_gemm_linear(
+        hidden_2d,
+        fused_gate_up_weight,
+        native_op=_C.det_gemm_fwd_weight,
+    )
+    activated = _C.swiglu_packed_forward(gate_up)
+    output = det_gemm_linear(
+        activated,
+        down_weight,
+        native_op=_C.det_gemm_fwd_weight,
+    )
+    return output.reshape(*input_shape[:-1], output.size(-1))
+
+
+@_qwen3_ffn_packed_inference.register_fake
+def _qwen3_ffn_packed_inference_fake(
+    rmsnorm_output: Tensor,
+    fused_gate_up_weight: Tensor,
+    down_weight: Tensor,
+) -> Tensor:
+    del fused_gate_up_weight
+    return rmsnorm_output.new_empty((*rmsnorm_output.shape[:-1], down_weight.shape[0]))
+
+
+def qwen3_ffn_packed_inference(
+    rmsnorm_output: Tensor,
+    fused_gate_up_weight: Tensor,
+    down_weight: Tensor,
+    *,
+    collective_handle: int = 0,
+    tp_world_size: int = 1,
+) -> Tensor:
+    """Inference-only packed FFN entry compatible with torch.compile."""
+
+    output = _qwen3_ffn_packed_inference(
+        rmsnorm_output,
+        fused_gate_up_weight,
+        down_weight,
+    )
+    if tp_world_size <= 1:
+        return output
+    if collective_handle <= 0:
+        raise RuntimeError("packed rollout FFN requires a bound TP collective")
+    return deterministic_all_reduce_inplace(
+        output,
+        collective_handle=collective_handle,
+    )
+
+
+def _require_ffn_kernels(
+    *, disable_split_k: bool, packed_gate_up: bool = False
+) -> None:
     required = _REQUIRED_SYMBOLS if disable_split_k else _SWIGLU_SYMBOLS
+    if packed_gate_up:
+        required += _PACKED_SWIGLU_SYMBOLS
     missing = [name for name in required if not hasattr(_C, name)]
     if not _EXT_AVAILABLE or _C is None or missing:
         suffix = f" Missing symbols: {', '.join(missing)}." if missing else ""
@@ -42,38 +134,26 @@ def _require_ffn_kernels(*, disable_split_k: bool) -> None:
         raise RuntimeError(f"qwen3_ffn requires the {needed}.{suffix}")
 
 
-def _gemm_fwd(a: Tensor, b: Tensor, *, disable_split_k: bool) -> Tensor:
+def _linear_fwd(a: Tensor, weight: Tensor, *, disable_split_k: bool) -> Tensor:
     if disable_split_k:
-        return _C.det_gemm_fwd(a, b)
+        return det_gemm_linear(a, weight, native_op=_C.det_gemm_fwd_weight)
     # cuBLASLt / CUTLASS: may use split-K. Detach so Autograd.Function owns backward.
     with torch.no_grad():
-        return torch.matmul(a, b)
+        return torch.nn.functional.linear(a, weight)
 
 
-def _gemm_fwd_rhs_transposed(
-    a: Tensor,
-    bt: Tensor,
-    *,
-    disable_split_k: bool,
-) -> Tensor:
+def _linear_da(grad_output: Tensor, weight: Tensor, *, disable_split_k: bool) -> Tensor:
     if disable_split_k:
-        return _C.det_gemm_fwd_rhs_transposed(a, bt)
+        return _C.det_gemm_da_weight(grad_output, weight)
     with torch.no_grad():
-        return torch.matmul(a, bt.t())
+        return torch.matmul(grad_output, weight)
 
 
-def _gemm_db_transposed(
-    a: Tensor,
-    grad_output: Tensor,
-    *,
-    disable_split_k: bool,
-) -> Tensor:
+def _linear_dw(a: Tensor, grad_output: Tensor, *, disable_split_k: bool) -> Tensor:
     if disable_split_k:
-        return _C.det_gemm_db_transposed(a, grad_output)
+        return _C.det_gemm_dw(a, grad_output)
     with torch.no_grad():
-        # dW is naturally [out,in]; let the production GEMM create that layout
-        # instead of materializing [in,out] and transposing the result.
-        return torch.matmul(grad_output.t(), a)
+        return torch.matmul(grad_output.t().contiguous(), a)
 
 
 def _require_parallel_group(group: Any, name: str):
@@ -85,7 +165,9 @@ def _require_parallel_group(group: Any, name: str):
     if not dist.is_available():
         raise RuntimeError(f"{name}-parallel FFN requires torch.distributed.")
     if not dist.is_initialized():
-        raise RuntimeError(f"{name}-parallel FFN requires an initialized process group.")
+        raise RuntimeError(
+            f"{name}-parallel FFN requires an initialized process group."
+        )
     if dist.get_world_size(group=group) <= 1:
         raise ValueError(f"{name}_group must contain at least two ranks.")
     return dist
@@ -96,6 +178,7 @@ def _validate_ffn_inputs(
     gate_weight: Tensor,
     up_weight: Tensor,
     down_weight: Tensor,
+    fused_gate_up_weight: Tensor | None,
 ) -> None:
     tensors = {
         "rmsnorm_output": rmsnorm_output,
@@ -103,6 +186,8 @@ def _validate_ffn_inputs(
         "up_weight": up_weight,
         "down_weight": down_weight,
     }
+    if fused_gate_up_weight is not None:
+        tensors["fused_gate_up_weight"] = fused_gate_up_weight
     for name, tensor in tensors.items():
         if not isinstance(tensor, Tensor):
             raise TypeError(f"{name} must be a torch.Tensor, got {type(tensor)!r}.")
@@ -126,6 +211,8 @@ def _validate_ffn_inputs(
         "up_weight": (intermediate_size, hidden_size),
         "down_weight": (hidden_size, intermediate_size),
     }
+    if fused_gate_up_weight is not None:
+        expected_shapes["fused_gate_up_weight"] = (2 * intermediate_size, hidden_size)
     for name, expected in expected_shapes.items():
         actual = tuple(tensors[name].shape)
         if actual != expected:
@@ -135,7 +222,9 @@ def _validate_ffn_inputs(
         if tensor.dtype != torch.bfloat16:
             raise TypeError(f"{name} must have dtype bfloat16, got {tensor.dtype}.")
         if not tensor.is_cuda:
-            raise RuntimeError(f"{name} must be on a CUDA device, got '{tensor.device}'.")
+            raise RuntimeError(
+                f"{name} must be on a CUDA device, got '{tensor.device}'."
+            )
         if tensor.device != rmsnorm_output.device:
             raise RuntimeError(
                 f"all FFN inputs must be on {rmsnorm_output.device}, "
@@ -144,29 +233,11 @@ def _validate_ffn_inputs(
 
 
 def _collective_for_group(group: Any, *, min_size_bytes: int):
-    if group is None:
-        return None
-
-    import torch.distributed as dist
-
-    from rl_engine.distributed import DeterministicCollective
-
-    rank = dist.get_rank(group=group)
-    world_size = dist.get_world_size(group=group)
-    device_index = torch.cuda.current_device()
-    key = (id(group), rank, world_size, device_index)
-    cached = _COLLECTIVES.get(key)
-    if cached is not None and cached.max_size_bytes >= min_size_bytes:
-        return cached
-    if cached is not None:
-        cached.close()
-
-    collective = DeterministicCollective(
+    return collective_for_group(
         group=group,
-        max_size_bytes=max(_COLLECTIVE_MIN_CAPACITY_BYTES, min_size_bytes),
+        min_size_bytes=min_size_bytes,
+        minimum_capacity_bytes=_COLLECTIVE_MIN_CAPACITY_BYTES,
     )
-    _COLLECTIVES[key] = collective
-    return collective
 
 
 def _all_gather_tokens(tensor: Tensor, collective: Any) -> Tensor:
@@ -195,6 +266,7 @@ class _DeterministicFFNFunction(torch.autograd.Function):
         gate_weight: Tensor,
         up_weight: Tensor,
         down_weight: Tensor,
+        fused_gate_up_weight: Tensor | None,
         tp_group: Any,
         cp_group: Any,
         sequence_parallel: bool,
@@ -224,58 +296,81 @@ class _DeterministicFFNFunction(torch.autograd.Function):
         if sequence_parallel:
             rmsnorm_output_2d = _all_gather_tokens(rmsnorm_output_2d, tp_collective)
 
-        # The SM90 TMA kernel consumes physical B^T=[N,K]. Canonical model
-        # weights already have exactly that layout, so no prepared copy is
-        # needed and optimizer updates cannot leave a stale cache behind.
-        gate = _gemm_fwd_rhs_transposed(
-            rmsnorm_output_2d,
-            gate_weight,
-            disable_split_k=disable_split_k,
-        )
-        up = _gemm_fwd_rhs_transposed(
-            rmsnorm_output_2d,
-            up_weight,
-            disable_split_k=disable_split_k,
-        )
-        activated = _C.swiglu_forward(gate, up)
-        output = _gemm_fwd_rhs_transposed(
-            activated,
-            down_weight,
-            disable_split_k=disable_split_k,
-        )
+        packed_gate_up = fused_gate_up_weight is not None and disable_split_k
+        if packed_gate_up:
+            gate_up = _linear_fwd(
+                rmsnorm_output_2d,
+                fused_gate_up_weight,
+                disable_split_k=True,
+            )
+            activated = _C.swiglu_packed_forward(gate_up)
+        else:
+            gate = _linear_fwd(
+                rmsnorm_output_2d,
+                gate_weight,
+                disable_split_k=disable_split_k,
+            )
+            up = _linear_fwd(
+                rmsnorm_output_2d,
+                up_weight,
+                disable_split_k=disable_split_k,
+            )
+            activated = _C.swiglu_forward(gate, up)
+        output = _linear_fwd(activated, down_weight, disable_split_k=disable_split_k)
 
         if sequence_parallel:
             output = _reduce_scatter_tokens(output, tp_collective)
         elif tp_collective is not None:
             output = _all_reduce_inplace(output, tp_collective)
 
-        ctx.save_for_backward(
-            rmsnorm_output_2d,
-            gate,
-            up,
-            activated,
-            gate_weight,
-            up_weight,
-            down_weight,
-        )
+        if packed_gate_up:
+            ctx.save_for_backward(
+                rmsnorm_output_2d,
+                gate_up,
+                activated,
+                gate_weight,
+                up_weight,
+                down_weight,
+            )
+        else:
+            ctx.save_for_backward(
+                rmsnorm_output_2d,
+                gate,
+                up,
+                activated,
+                gate_weight,
+                up_weight,
+                down_weight,
+            )
         ctx.input_shape = input_shape
         ctx.tp_collective = tp_collective
         ctx.cp_collective = cp_collective
         ctx.sequence_parallel = sequence_parallel
         ctx.disable_split_k = disable_split_k
+        ctx.packed_gate_up = packed_gate_up
         return output.reshape(*input_shape[:-1], output.size(-1))
 
     @staticmethod
     def backward(ctx, grad_output: Tensor):
-        (
-            rmsnorm_output,
-            gate,
-            up,
-            activated,
-            gate_weight,
-            up_weight,
-            down_weight,
-        ) = ctx.saved_tensors
+        if ctx.packed_gate_up:
+            (
+                rmsnorm_output,
+                gate_up,
+                activated,
+                gate_weight,
+                up_weight,
+                down_weight,
+            ) = ctx.saved_tensors
+        else:
+            (
+                rmsnorm_output,
+                gate,
+                up,
+                activated,
+                gate_weight,
+                up_weight,
+                down_weight,
+            ) = ctx.saved_tensors
         tp_collective = ctx.tp_collective
         cp_collective = ctx.cp_collective
         disable_split_k = ctx.disable_split_k
@@ -283,56 +378,67 @@ class _DeterministicFFNFunction(torch.autograd.Function):
         if ctx.sequence_parallel:
             grad_output = _all_gather_tokens(grad_output, tp_collective)
 
-        # Down weight gradients must see every CP token so the wgrad K-tree
+        # Down weight gradients must see every CP token so gemm_db's K-tree
         # matches CP=1. Local dW + AllReduce is a different parenthesization
         # whenever T is not a complete mid-split tree of 32-wide leaves.
         if cp_collective is not None:
             activated_full = _all_gather_tokens(activated, cp_collective)
             grad_output_full = _all_gather_tokens(grad_output, cp_collective)
-            grad_down_weight = _gemm_db_transposed(
+            grad_down_weight = _linear_dw(
                 activated_full,
                 grad_output_full,
                 disable_split_k=disable_split_k,
             )
         else:
-            grad_down_weight = _gemm_db_transposed(
+            grad_down_weight = _linear_dw(
                 activated,
                 grad_output,
                 disable_split_k=disable_split_k,
             )
 
         # Down input-gradient shards concatenate across TP; no TP reduction.
-        grad_activated = _gemm_fwd(grad_output, down_weight, disable_split_k=disable_split_k)
-        grad_gate, grad_up = _C.swiglu_backward(grad_activated, gate, up)
+        grad_activated = _linear_da(
+            grad_output,
+            down_weight,
+            disable_split_k=disable_split_k,
+        )
+        if ctx.packed_gate_up:
+            grad_gate, grad_up = _C.swiglu_packed_backward(grad_activated, gate_up)
+        else:
+            grad_gate, grad_up = _C.swiglu_backward(grad_activated, gate, up)
 
         if cp_collective is not None:
             rmsnorm_full = _all_gather_tokens(rmsnorm_output, cp_collective)
             grad_gate_full = _all_gather_tokens(grad_gate, cp_collective)
             grad_up_full = _all_gather_tokens(grad_up, cp_collective)
-            grad_gate_weight = _gemm_db_transposed(
+            grad_gate_weight = _linear_dw(
                 rmsnorm_full,
                 grad_gate_full,
                 disable_split_k=disable_split_k,
             )
-            grad_up_weight = _gemm_db_transposed(
+            grad_up_weight = _linear_dw(
                 rmsnorm_full,
                 grad_up_full,
                 disable_split_k=disable_split_k,
             )
         else:
-            grad_gate_weight = _gemm_db_transposed(
+            grad_gate_weight = _linear_dw(
                 rmsnorm_output,
                 grad_gate,
                 disable_split_k=disable_split_k,
             )
-            grad_up_weight = _gemm_db_transposed(
+            grad_up_weight = _linear_dw(
                 rmsnorm_output,
                 grad_up,
                 disable_split_k=disable_split_k,
             )
 
         # Gate/Up input gradients reduce across TP, then add locally.
-        grad_rmsnorm_from_gate = _gemm_fwd(grad_gate, gate_weight, disable_split_k=disable_split_k)
+        grad_rmsnorm_from_gate = _linear_da(
+            grad_gate,
+            gate_weight,
+            disable_split_k=disable_split_k,
+        )
         if ctx.sequence_parallel:
             grad_rmsnorm_from_gate = _reduce_scatter_tokens(
                 grad_rmsnorm_from_gate,
@@ -344,7 +450,11 @@ class _DeterministicFFNFunction(torch.autograd.Function):
                 tp_collective,
             )
 
-        grad_rmsnorm_from_up = _gemm_fwd(grad_up, up_weight, disable_split_k=disable_split_k)
+        grad_rmsnorm_from_up = _linear_da(
+            grad_up,
+            up_weight,
+            disable_split_k=disable_split_k,
+        )
         if ctx.sequence_parallel:
             grad_rmsnorm_from_up = _reduce_scatter_tokens(
                 grad_rmsnorm_from_up,
@@ -366,6 +476,7 @@ class _DeterministicFFNFunction(torch.autograd.Function):
             None,
             None,
             None,
+            None,
         )
 
 
@@ -375,6 +486,7 @@ def qwen3_ffn(
     up_weight: Tensor,
     down_weight: Tensor,
     *,
+    fused_gate_up_weight: Tensor | None = None,
     tp_group: Any = None,
     cp_group: Any = None,
     sequence_parallel: bool = False,
@@ -391,13 +503,18 @@ def qwen3_ffn(
             ``[I_local, H]``.
         down_weight: Down projection weight in ``[out, in]`` layout, shape
             ``[H, I_local]``.
+        fused_gate_up_weight: Optional existing framework weight in
+            ``[2 * I_local, H]`` layout. Strict CUDA execution consumes this
+            with one GEMM launch while returning gradients through the
+            separate gate/up views, so the framework parameter layout stays
+            unchanged.
         tp_group: Optional tensor-parallel process group. Gate and Up are
             column-parallel; Down is row-parallel. Reductions use the
             deterministic fixed-tree collectives rather than NCCL.
         cp_group: Optional context-parallel process group. Each rank owns
             different token rows and the same local weight shards. Weight
             gradients AllGather tokens along CP and run the full-token
-            ``det_gemm_db_transposed`` so they match CP=1 bitwise.
+            ``det_gemm_dw`` so they match CP=1 bitwise.
         sequence_parallel: Whether ``rmsnorm_output`` and the returned output
             are sharded on the flattened token dimension across ``tp_group``.
             Token gather/scatter use the deterministic AllGather and
@@ -414,13 +531,23 @@ def qwen3_ffn(
     if not isinstance(sequence_parallel, bool):
         raise TypeError("sequence_parallel must be a bool.")
     deterministic = _resolve_deterministic_mode(deterministic, disable_split_k)
-    _validate_ffn_inputs(rmsnorm_output, gate_weight, up_weight, down_weight)
-    _require_ffn_kernels(disable_split_k=deterministic)
+    _validate_ffn_inputs(
+        rmsnorm_output,
+        gate_weight,
+        up_weight,
+        down_weight,
+        fused_gate_up_weight,
+    )
+    _require_ffn_kernels(
+        disable_split_k=deterministic,
+        packed_gate_up=fused_gate_up_weight is not None and deterministic,
+    )
     return _DeterministicFFNFunction.apply(
         rmsnorm_output,
         gate_weight,
         up_weight,
         down_weight,
+        fused_gate_up_weight,
         tp_group,
         cp_group,
         sequence_parallel,
@@ -441,7 +568,9 @@ def _resolve_deterministic_mode(
         and disable_split_k is not None
         and deterministic != disable_split_k
     ):
-        raise ValueError("deterministic and disable_split_k select conflicting FFN backends.")
+        raise ValueError(
+            "deterministic and disable_split_k select conflicting FFN backends."
+        )
     if deterministic is not None:
         return deterministic
     if disable_split_k is not None:
@@ -456,6 +585,61 @@ class Qwen3FFNOp:
     is_batch_invariant = True
     backend_id = BACKEND_ID
 
+    def __init__(self) -> None:
+        # Keep graph-bound IPC resources alive independently of the module-level
+        # lookup cache. CUDA Graphs retain only the small opaque C++ handle.
+        self._packed_inference_collectives: dict[int, Any] = {}
+
+    def prepare_packed_inference(
+        self,
+        fused_gate_up_weight: Tensor,
+        down_weight: Tensor,
+        *,
+        tp_group: Any,
+    ) -> tuple[int, int]:
+        """Create the rollout TP resource before Dynamo captures the model."""
+
+        if tp_group is None:
+            return 0, 1
+        dist = _require_parallel_group(tp_group, "tensor")
+        if dist is None:
+            return 0, 1
+        tp_world_size = int(dist.get_world_size(group=tp_group))
+        if fused_gate_up_weight.size(0) % 2:
+            raise ValueError("fused gate/up weight must contain two equal shards")
+        element_size = fused_gate_up_weight.element_size()
+        min_size_bytes = (
+            max(
+                fused_gate_up_weight.numel() // 2,
+                down_weight.numel(),
+            )
+            * element_size
+        )
+        collective = _collective_for_group(
+            tp_group,
+            min_size_bytes=min_size_bytes,
+        )
+        collective_handle = int(collective._handle)
+        self._packed_inference_collectives[collective_handle] = collective
+        return collective_handle, tp_world_size
+
+    def packed_inference(
+        self,
+        rmsnorm_output: Tensor,
+        fused_gate_up_weight: Tensor,
+        down_weight: Tensor,
+        *,
+        collective_handle: int,
+        tp_world_size: int,
+    ) -> Tensor:
+        return qwen3_ffn_packed_inference(
+            rmsnorm_output,
+            fused_gate_up_weight,
+            down_weight,
+            collective_handle=collective_handle,
+            tp_world_size=tp_world_size,
+        )
+
     def __call__(
         self,
         rmsnorm_output: Tensor,
@@ -463,6 +647,7 @@ class Qwen3FFNOp:
         up_weight: Tensor,
         down_weight: Tensor,
         *,
+        fused_gate_up_weight: Tensor | None = None,
         tp_group: Any = None,
         cp_group: Any = None,
         sequence_parallel: bool = False,
@@ -474,6 +659,7 @@ class Qwen3FFNOp:
             gate_weight,
             up_weight,
             down_weight,
+            fused_gate_up_weight=fused_gate_up_weight,
             tp_group=tp_group,
             cp_group=cp_group,
             sequence_parallel=sequence_parallel,
@@ -488,6 +674,7 @@ class Qwen3FFNOp:
         up_weight: Tensor,
         down_weight: Tensor,
         *,
+        fused_gate_up_weight: Tensor | None = None,
         tp_group: Any = None,
         cp_group: Any = None,
         sequence_parallel: bool = False,
@@ -499,6 +686,7 @@ class Qwen3FFNOp:
             gate_weight,
             up_weight,
             down_weight,
+            fused_gate_up_weight=fused_gate_up_weight,
             tp_group=tp_group,
             cp_group=cp_group,
             sequence_parallel=sequence_parallel,

--- a/rl_engine/kernels/ops/pytorch/loss/linear_logp.py
+++ b/rl_engine/kernels/ops/pytorch/loss/linear_logp.py
@@ -8,6 +8,8 @@ from typing import Any, Optional
 
 import torch
 
+from rl_engine.distributed.collectives import collective_for_group
+
 # Backward token-chunk target: process at most this many ``[chunk, V]`` logit
 # elements per cuBLAS step so peak backward memory stays ~``chunk*V`` instead of
 # ``N*V``.
@@ -176,6 +178,37 @@ def _validate_tp_vocab_partition_cached(
     return int(covered)
 
 
+def _validate_even_tp_vocab_partition_local(
+    *,
+    tp_group: Any,
+    vocab_start_index: int,
+    local_vocab_size: int,
+    global_vocab_size: Optional[int],
+) -> int:
+    """Validate the strict equal-shard contract without a data-plane collective."""
+
+    dist = _require_distributed_initialized()
+    rank = dist.get_rank(group=tp_group)
+    world_size = dist.get_world_size(group=tp_group)
+    expected_global_size = local_vocab_size * world_size
+    expected_start = rank * local_vocab_size
+    if local_vocab_size <= 0:
+        raise ValueError("strict TP linear_logp requires a non-empty vocab shard.")
+    if vocab_start_index != expected_start:
+        raise ValueError(
+            "strict TP linear_logp requires equal rank-ordered vocab shards: "
+            f"rank={rank} expected vocab_start_index={expected_start}, "
+            f"got {vocab_start_index}."
+        )
+    if global_vocab_size is not None and int(global_vocab_size) != expected_global_size:
+        raise ValueError(
+            "strict TP linear_logp global_vocab_size must equal "
+            f"local_vocab_size * world_size={expected_global_size}, "
+            f"got {global_vocab_size}."
+        )
+    return expected_global_size
+
+
 def _validate_global_targets(
     target_1d: torch.Tensor,
     global_vocab_size: int,
@@ -209,6 +242,18 @@ def _validate_global_targets(
             f"got [{t_min}, {t_max}]. Mask or filter padding / ignore-index values "
             "(e.g. -100) before this op."
         )
+
+
+def _assert_global_targets_async(
+    target_1d: torch.Tensor,
+    global_vocab_size: int,
+) -> None:
+    """Range-check targets without synchronizing the CUDA hot path."""
+    torch._assert_async(
+        ((target_1d >= 0) & (target_1d < global_vocab_size)).all(),
+        f"target_ids out of range: expected [0, {global_vocab_size - 1}]. "
+        "Mask or filter padding / ignore-index values (e.g. -100) before this op.",
+    )
 
 
 def _chunked_local_linear_logp_stats(
@@ -276,17 +321,30 @@ def _merge_tp_local_logp(
         return local_target_logit - global_lse, global_lse
 
     local_stats = torch.stack((local_lse, local_target_logit), dim=0).contiguous()
-    gathered = torch.empty(
-        (world_size, *local_stats.shape),
-        device=local_stats.device,
-        dtype=local_stats.dtype,
-    )
-    try:
-        dist.all_gather_into_tensor(gathered, local_stats, group=tp_group)
-    except (AttributeError, RuntimeError):
-        chunks = [torch.empty_like(local_stats) for _ in range(world_size)]
-        dist.all_gather(chunks, local_stats, group=tp_group)
-        gathered = torch.stack(chunks, dim=0)
+    if local_stats.is_cuda:
+        collective = collective_for_group(
+            tp_group,
+            min_size_bytes=local_stats.numel() * local_stats.element_size(),
+            device=local_stats.device,
+        )
+        if collective is None:
+            raise RuntimeError("tensor-parallel linear_logp requires an RL-Kernel collective")
+        gathered = collective.all_gather(
+            local_stats,
+            validate_signature=False,
+        ).reshape(world_size, *local_stats.shape)
+    else:
+        gathered = torch.empty(
+            (world_size, *local_stats.shape),
+            device=local_stats.device,
+            dtype=local_stats.dtype,
+        )
+        try:
+            dist.all_gather_into_tensor(gathered, local_stats, group=tp_group)
+        except (AttributeError, RuntimeError):
+            chunks = [torch.empty_like(local_stats) for _ in range(world_size)]
+            dist.all_gather(chunks, local_stats, group=tp_group)
+            gathered = torch.stack(chunks, dim=0)
 
     # [contract] Explicit rank-ordered reduction trees. ``torch.logsumexp`` and
     # ``Tensor.sum`` own their internal reduction order, which is not part of
@@ -310,6 +368,25 @@ def _merge_tp_local_logp(
     return target_logit - global_lse, global_lse
 
 
+def _deterministic_tp_all_reduce_(tensor: torch.Tensor, tp_group: Any) -> torch.Tensor:
+    if not tensor.is_cuda:
+        dist = _require_distributed_initialized()
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=tp_group)
+        return tensor
+    collective = collective_for_group(
+        tp_group,
+        min_size_bytes=tensor.numel() * tensor.element_size(),
+        device=tensor.device,
+    )
+    if collective is None:
+        raise RuntimeError("tensor-parallel linear_logp requires an RL-Kernel collective")
+    return collective.all_reduce(
+        tensor.contiguous(),
+        out=tensor,
+        validate_signature=False,
+    )
+
+
 def tensor_parallel_linear_logp_backward(
     grad_logp: torch.Tensor,
     hidden_2d: torch.Tensor,
@@ -330,7 +407,6 @@ def tensor_parallel_linear_logp_backward(
     compute_grad_bias: bool = True,
     chunk_elems: int = BWD_CHUNK_ELEMS,
 ):
-    dist = _require_distributed_initialized()
     n, d = hidden_2d.shape
     local_vocab = weight.shape[0]
     dt = weight.dtype
@@ -384,7 +460,7 @@ def tensor_parallel_linear_logp_backward(
 
     grad_hidden = None
     if grad_h is not None:
-        dist.all_reduce(grad_h, op=dist.ReduceOp.SUM, group=tp_group)
+        _deterministic_tp_all_reduce_(grad_h, tp_group)
         grad_hidden = grad_h.to(hidden_dtype).reshape((*tuple(lead_shape), d))
     grad_weight = grad_w.to(weight_dtype) if grad_w is not None else None
     grad_bias = grad_b.to(bias_dtype) if grad_b is not None else None

--- a/rl_engine/kernels/ops/pytorch/norm/rms_norm.py
+++ b/rl_engine/kernels/ops/pytorch/norm/rms_norm.py
@@ -6,6 +6,76 @@ from __future__ import annotations
 import torch
 
 
+@torch.library.custom_op("rl_kernel::strict_rms_norm", mutates_args=())
+def _strict_rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Preserve PyTorch eager RMSNorm arithmetic across graph compilation."""
+
+    return torch.nn.functional.rms_norm(x, (x.shape[-1],), weight, eps)
+
+
+@_strict_rms_norm.register_fake
+def _strict_rms_norm_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    del weight, eps
+    return torch.empty_like(x)
+
+
+@torch.library.custom_op("rl_kernel::strict_add_rms_norm", mutates_args=())
+def _strict_add_rms_norm(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Preserve vLLM's eager residual-add and RMSNorm contract."""
+
+    updated_residual = x + residual
+    normalized = torch.nn.functional.rms_norm(
+        updated_residual,
+        (updated_residual.shape[-1],),
+        weight,
+        eps,
+    )
+    return normalized, updated_residual
+
+
+@_strict_add_rms_norm.register_fake
+def _strict_add_rms_norm_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    del residual, weight, eps
+    return torch.empty_like(x), torch.empty_like(x)
+
+
+def strict_rms_norm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    eps: float,
+) -> torch.Tensor:
+    return _strict_rms_norm(x, weight, eps)
+
+
+def strict_add_rms_norm(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    *,
+    eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return _strict_add_rms_norm(x, residual, weight, eps)
+
+
 class NativeRMSNormOp:
     """
     Pure Pytorch native RMSNorm reference

--- a/rl_engine/runtime_mode.py
+++ b/rl_engine/runtime_mode.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""User-facing RL-Kernel runtime policy."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+
+class RLKernelMode(str, Enum):
+    STRICT = "strict"
+    AUDIT = "audit"
+    AUTO = "auto"
+    OFF = "off"
+
+
+@dataclass(frozen=True)
+class RLKernelModePolicy:
+    mode: RLKernelMode
+    enabled: bool
+    case_id: str
+    provider_mode: str | None
+    fail_on_fallback: bool
+    report_only: bool
+
+
+_POLICIES = {
+    RLKernelMode.STRICT: RLKernelModePolicy(
+        RLKernelMode.STRICT, True, "R/R", "strict", True, False
+    ),
+    RLKernelMode.AUDIT: RLKernelModePolicy(
+        RLKernelMode.AUDIT, True, "R/R", "strict", False, True
+    ),
+    RLKernelMode.AUTO: RLKernelModePolicy(
+        RLKernelMode.AUTO, True, "P/P", "auto", False, False
+    ),
+    RLKernelMode.OFF: RLKernelModePolicy(
+        RLKernelMode.OFF, False, "P/P", None, False, False
+    ),
+}
+
+
+def rl_kernel_mode(value: str | RLKernelMode | None = None) -> RLKernelMode:
+    raw = os.getenv("RL_KERNEL_MODE", "strict") if value is None else value
+    if isinstance(raw, RLKernelMode):
+        return raw
+    normalized = str(raw).strip().lower()
+    try:
+        return RLKernelMode(normalized)
+    except ValueError as exc:
+        choices = ", ".join(mode.value for mode in RLKernelMode)
+        raise RuntimeError(
+            f"RL_KERNEL_MODE must be one of {choices}; got {raw!r}"
+        ) from exc
+
+
+def rl_kernel_mode_policy(
+    value: str | RLKernelMode | None = None,
+) -> RLKernelModePolicy:
+    return _POLICIES[rl_kernel_mode(value)]
+
+
+def strict_contract_enabled() -> bool:
+    configured = os.getenv("RL_KERNEL_MODE")
+    if configured is not None:
+        return rl_kernel_mode(configured) in {RLKernelMode.STRICT, RLKernelMode.AUDIT}
+    legacy = os.getenv("VIME_RL_KERNEL_STRICT", "").strip().lower()
+    return legacy in {"1", "true", "yes", "on"}
+
+
+def route_report_enabled() -> bool:
+    enabled = os.getenv("RL_KERNEL_ROUTE_REPORT", "1").strip().lower()
+    if enabled in {"0", "false", "no", "off"}:
+        return False
+    all_ranks = os.getenv("RL_KERNEL_ROUTE_REPORT_ALL_RANKS", "0").strip().lower()
+    if all_ranks in {"1", "true", "yes", "on"}:
+        return True
+    for name in ("RANK", "LOCAL_RANK"):
+        value = os.getenv(name, "").strip()
+        if value:
+            try:
+                return int(value) == 0
+            except ValueError:
+                continue
+    return True
+
+
+__all__ = [
+    "RLKernelMode",
+    "RLKernelModePolicy",
+    "rl_kernel_mode",
+    "rl_kernel_mode_policy",
+    "route_report_enabled",
+    "strict_contract_enabled",
+]

--- a/tests/distributed/test_deterministic_all_reduce.py
+++ b/tests/distributed/test_deterministic_all_reduce.py
@@ -13,6 +13,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 from rl_engine.distributed import DeterministicCollective
+from rl_engine.distributed.collectives import deterministic_all_reduce_inplace
 
 _MAX_WORLD_SIZE = 8
 _TP_SIZES = (1, 2, 4, 8)
@@ -58,7 +59,9 @@ def _worker(rank: int, port: int) -> None:
         timeout=timedelta(minutes=5),
     )
     try:
-        groups = {tp_size: dist.new_group(ranks=list(range(tp_size))) for tp_size in _TP_SIZES}
+        groups = {
+            tp_size: dist.new_group(ranks=list(range(tp_size))) for tp_size in _TP_SIZES
+        }
         for tp_size, group in groups.items():
             if rank < tp_size:
                 with DeterministicCollective(
@@ -78,14 +81,19 @@ def _worker(rank: int, port: int) -> None:
                             generator=generator,
                         ).to(device=device, dtype=dtype)
                         leaves = list(leaves_tensor.unbind())
-                        input = _fixed_tree_reference(leaves[start : start + leaves_per_rank])
+                        input = _fixed_tree_reference(
+                            leaves[start : start + leaves_per_rank]
+                        )
                         expected = _fixed_tree_reference(leaves)
 
                         output = collective.all_reduce(input)
                         assert torch.equal(output, expected)
 
                         peer_outputs = _all_gather_tensors(output, group, tp_size)
-                        assert all(torch.equal(peer_output, output) for peer_output in peer_outputs)
+                        assert all(
+                            torch.equal(peer_output, output)
+                            for peer_output in peer_outputs
+                        )
 
                         baseline = output.clone()
                         for _ in range(3):
@@ -96,6 +104,46 @@ def _worker(rank: int, port: int) -> None:
                         returned = collective.all_reduce(inplace, out=inplace)
                         assert returned is inplace
                         assert torch.equal(inplace, expected)
+
+                        if tp_size == 2 and dtype is torch.bfloat16:
+                            compiled_input = input.clone()
+                            compiled = torch.compile(
+                                deterministic_all_reduce_inplace,
+                                backend="eager",
+                                fullgraph=True,
+                            )
+                            compiled_output = compiled(
+                                compiled_input,
+                                collective_handle=int(collective._handle),
+                            )
+                            assert compiled_output is compiled_input
+                            assert torch.equal(compiled_output, expected)
+
+                            graph_base = (
+                                torch.arange(257, device=device, dtype=torch.float32)
+                                .div_(64)
+                                .to(torch.bfloat16)
+                            )
+                            graph_input = graph_base + group_rank
+                            graph = torch.cuda.CUDAGraph()
+                            dist.barrier(group=group)
+                            torch.cuda.synchronize(device)
+                            with torch.cuda.graph(graph):
+                                deterministic_all_reduce_inplace(
+                                    graph_input,
+                                    collective_handle=int(collective._handle),
+                                )
+                            for replay in range(3):
+                                graph_input.copy_(graph_base + group_rank + replay)
+                                graph.replay()
+                                torch.cuda.synchronize(device)
+                                expected_graph = _fixed_tree_reference(
+                                    [
+                                        graph_base + peer_rank + replay
+                                        for peer_rank in range(tp_size)
+                                    ]
+                                )
+                                assert torch.equal(graph_input, expected_graph)
             dist.barrier()
     finally:
         dist.destroy_process_group()

--- a/tests/test_det_gemm.py
+++ b/tests/test_det_gemm.py
@@ -13,6 +13,11 @@ import torch
 from rl_engine.kernels.gtest.tolerance import load_contract
 from rl_engine.kernels.ops.base import _C
 from rl_engine.kernels.ops.cuda.matmul import deterministic_gemm
+from rl_engine.kernels.ops.cuda.matmul.det_gemm import (
+    DetGemmOp,
+    det_gemm_backend,
+    det_gemm_backend_id,
+)
 
 try:
     from rl_engine.kernels.ops.triton.matmul import deterministic_gemm_triton
@@ -37,6 +42,80 @@ if _HAS_TRITON:
 
 def _rand(*shape):
     return torch.randn(*shape, device=DEV, dtype=torch.bfloat16)
+
+
+def test_strict_backend_selection_is_explicit(monkeypatch):
+    monkeypatch.setenv("RL_KERNEL_DET_GEMM_BACKEND", "cublaslt")
+    assert det_gemm_backend() == "cublaslt_nosplitk"
+    assert det_gemm_backend_id() == "rlkernel.det_gemm.cublaslt_nosplitk.v1"
+
+    monkeypatch.setenv("RL_KERNEL_DET_GEMM_BACKEND", "unknown")
+    with pytest.raises(RuntimeError, match="RL_KERNEL_DET_GEMM_BACKEND"):
+        det_gemm_backend()
+
+
+def test_aligned_runtime_selects_cublaslt_by_default(monkeypatch):
+    monkeypatch.delenv("RL_KERNEL_DET_GEMM_BACKEND", raising=False)
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    monkeypatch.setenv("CUBLAS_WORKSPACE_CONFIG", ":16:8")
+    monkeypatch.setenv("CUBLASLT_WORKSPACE_SIZE", "1")
+
+    assert det_gemm_backend() == "cublaslt_nosplitk"
+
+
+def test_explicit_sm90_backend_overrides_aligned_default(monkeypatch):
+    monkeypatch.setenv("RL_KERNEL_DET_GEMM_BACKEND", "sm90")
+    monkeypatch.setenv("VLLM_BATCH_INVARIANT", "1")
+    monkeypatch.setenv("CUBLAS_WORKSPACE_CONFIG", ":16:8")
+    monkeypatch.setenv("CUBLASLT_WORKSPACE_SIZE", "1")
+
+    assert det_gemm_backend() == "sm90"
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9,
+    reason="cuBLASLt no-split-K contract is validated on SM90",
+)
+def test_cublaslt_nosplitk_target_shape_is_batch_invariant(monkeypatch):
+    import rl_engine.kernels.ops.cuda.matmul.det_gemm as det_gemm_module
+
+    monkeypatch.setenv("RL_KERNEL_DET_GEMM_BACKEND", "cublaslt_nosplitk")
+    monkeypatch.setenv("CUBLAS_WORKSPACE_CONFIG", ":16:8")
+    monkeypatch.setenv("CUBLASLT_WORKSPACE_SIZE", "1")
+    monkeypatch.setattr(det_gemm_module, "_CUBLASLT_CONFIGURED", False)
+
+    torch.manual_seed(24)
+    rows = _rand(256, 4096)
+    weight = _rand(3072, 4096)
+    op = DetGemmOp()
+    reference = op.linear(rows, weight)[0]
+
+    for row_count in (1, 2, 16, 128):
+        assert torch.equal(op.linear(rows[:row_count], weight)[0], reference)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9,
+    reason="cuBLASLt no-split-K contract is validated on SM90",
+)
+def test_cublaslt_nosplitk_compiles_fullgraph(monkeypatch):
+    import rl_engine.kernels.ops.cuda.matmul.det_gemm as det_gemm_module
+
+    monkeypatch.setenv("RL_KERNEL_DET_GEMM_BACKEND", "cublaslt_nosplitk")
+    monkeypatch.setenv("CUBLAS_WORKSPACE_CONFIG", ":16:8")
+    monkeypatch.setenv("CUBLASLT_WORKSPACE_SIZE", "1")
+    monkeypatch.setattr(det_gemm_module, "_CUBLASLT_CONFIGURED", False)
+
+    op = DetGemmOp()
+    a = _rand(2, 256)
+    weight = _rand(192, 256)
+
+    def linear(value, linear_weight):
+        return op.linear(value, linear_weight)
+
+    expected = linear(a, weight)
+    actual = torch.compile(linear, backend="eager", fullgraph=True)(a, weight)
+    assert torch.equal(actual, expected)
 
 
 # Matches det_gemm_kernel.cu: mid-split K-tree, FP32 leaf width 32, BF16 internal adds.
@@ -144,6 +223,62 @@ def test_forward_batch_invariance(name, gemm):
     assert torch.equal(out1[0], outN[0]), f"{name}: forward batch-invariance broken"
 
 
+def test_native_weight_linear_matches_gemm_bitwise_for_ragged_m():
+    torch.manual_seed(8)
+    weight = _rand(3072, 4096)
+    rows = _rand(129, 4096)
+    op = DetGemmOp()
+    for row_count in (1, 8, 16, 17, 127, 128, 129):
+        actual = op.linear(rows[:row_count], weight)
+        expected = deterministic_gemm(rows[:row_count], weight.t().contiguous())
+        assert torch.equal(
+            actual, expected
+        ), f"native-weight mismatch for M={row_count}"
+
+
+def test_decode_tile_boundary_preserves_batch_invariance():
+    torch.manual_seed(11)
+    weight = _rand(3072, 4096)
+    rows = _rand(17, 4096)
+    op = DetGemmOp()
+
+    decode = op.linear(rows[:16], weight)
+    general = op.linear(rows, weight)
+
+    assert torch.equal(decode, general[:16])
+
+
+def test_native_weight_linear_backward_matches_gemm_bitwise():
+    torch.manual_seed(9)
+    a_native = _rand(128, 256).requires_grad_(True)
+    weight_native = _rand(192, 256).requires_grad_(True)
+    a_reference = a_native.detach().clone().requires_grad_(True)
+    weight_reference = weight_native.detach().clone().requires_grad_(True)
+    grad = _rand(128, 192)
+
+    DetGemmOp().linear(a_native, weight_native).backward(grad)
+    deterministic_gemm(a_reference, weight_reference.t().contiguous()).backward(grad)
+
+    assert torch.equal(a_native.grad, a_reference.grad)
+    assert torch.equal(weight_native.grad, weight_reference.grad)
+
+
+def test_native_weight_linear_compiles_fullgraph_bitwise():
+    torch.manual_seed(10)
+    a = _rand(17, 256)
+    weight = _rand(192, 256)
+    op = DetGemmOp()
+
+    def linear(value, linear_weight):
+        return op.linear(value, linear_weight)
+
+    expected = linear(a, weight)
+    compiled = torch.compile(linear, backend="eager", fullgraph=True)
+    actual = compiled(a, weight)
+
+    assert torch.equal(actual, expected)
+
+
 @pytest.mark.parametrize("name,gemm", _BACKENDS)
 def test_forward_chunked_prefill(name, gemm):
     # Splitting M then concatenating must match the full GEMM bitwise.
@@ -179,7 +314,9 @@ def test_forward_correctness(name, gemm):
         ref = a.float() @ b.float()
     contract = load_contract()
     thresholds = contract["accuracy"]["default"]["reduction"]["bfloat16"]
-    torch.testing.assert_close(out, ref, atol=thresholds["atol"], rtol=thresholds["rtol"])
+    torch.testing.assert_close(
+        out, ref, atol=thresholds["atol"], rtol=thresholds["rtol"]
+    )
 
 
 @pytest.mark.parametrize("name,gemm", _BACKENDS)
@@ -195,7 +332,9 @@ def test_backward_batch_invariance(name, gemm):
     big[0] = row.detach()[0]
     big.requires_grad_(True)
     gemm(big, b).sum().backward()
-    assert torch.equal(g1[0], big.grad[0]), f"{name}: backward dA batch-invariance broken"
+    assert torch.equal(
+        g1[0], big.grad[0]
+    ), f"{name}: backward dA batch-invariance broken"
 
 
 @pytest.mark.parametrize("name,gemm", _BACKENDS)

--- a/tests/test_det_gemm_routing.py
+++ b/tests/test_det_gemm_routing.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+
+import pytest
+
+import rl_engine.kernels.ops.cuda.matmul.det_gemm as det_gemm_module
+from rl_engine.kernels.ops.cuda.matmul.det_gemm import DetGemmOp
+
+
+def test_strict_route_report_is_explicit_and_emitted_once(monkeypatch, capsys):
+    monkeypatch.setenv("RL_KERNEL_MODE", "strict")
+    monkeypatch.setenv("RL_KERNEL_DET_GEMM_BACKEND", "sm90")
+    monkeypatch.setattr(det_gemm_module, "_EXT_AVAILABLE", True)
+    monkeypatch.setattr(
+        det_gemm_module,
+        "_C",
+        SimpleNamespace(det_gemm_fwd=lambda a, b: None),
+    )
+    monkeypatch.setattr(det_gemm_module, "_ROUTE_REPORTED", False)
+
+    DetGemmOp()
+    DetGemmOp()
+
+    routes = [
+        line for line in capsys.readouterr().out.splitlines() if "[route]" in line
+    ]
+    assert routes == [
+        "[RL-Kernel][route] mode=strict module=gemm requested=strict "
+        "actual=rlkernel.det_gemm.sm90.v1 fallback=false"
+    ]
+
+
+def test_missing_extension_fails_instead_of_falling_back(monkeypatch, capsys):
+    monkeypatch.setenv("RL_KERNEL_DET_GEMM_BACKEND", "sm90")
+    monkeypatch.setattr(det_gemm_module, "_EXT_AVAILABLE", False)
+    monkeypatch.setattr(det_gemm_module, "_ROUTE_REPORTED", False)
+
+    with pytest.raises(RuntimeError, match="refusing non-strict fallback"):
+        DetGemmOp()
+    assert "module=gemm" not in capsys.readouterr().out

--- a/tests/test_flashinfer_pr7_attention.py
+++ b/tests/test_flashinfer_pr7_attention.py
@@ -32,7 +32,9 @@ from rl_engine.kernels.ops.cuda.attention.cp_comm import (
     P2PNCCLAttentionCPCommunication,
     sort_attention_cp_partial_states,
 )
-from rl_engine.kernels.ops.cuda.attention.deterministic_attn import DeterministicAttentionCoreResult
+from rl_engine.kernels.ops.cuda.attention.deterministic_attn import (
+    DeterministicAttentionCoreResult,
+)
 from rl_engine.kernels.ops.cuda.attention.flash_attn import (
     StrictFlashAttention4Core,
     StrictFlashAttentionUnavailable,
@@ -1913,6 +1915,7 @@ def test_fa4_core_fixes_reduction_controls_and_exports_fp32_lse(monkeypatch):
 
     core = StrictFlashAttention4Core(_op=fake_fa4, _package_version="4.test")
     monkeypatch.setattr(core, "_validate_inputs", lambda *_args: None)
+    monkeypatch.setattr(core, "_validate_bshd_inputs", lambda *_args: None)
     q = torch.randn(1, 4, 2, 8, dtype=torch.bfloat16)
     k = torch.randn(1, 2, 3, 8, dtype=torch.bfloat16)
     v = torch.randn(1, 2, 3, 8, dtype=torch.bfloat16)
@@ -1947,6 +1950,172 @@ def test_fa4_core_fixes_reduction_controls_and_exports_fp32_lse(monkeypatch):
     assert result.provenance["dropout_p"] == 0.0
     assert result.provenance["native_attention_arithmetic"] is True
     assert result.provenance["production_ready"] is True
+
+
+def test_fa4_core_bshd_entrypoint_preserves_framework_layout(monkeypatch):
+    calls = []
+
+    def fake_fa4(
+        q,
+        k,
+        v,
+        *,
+        softmax_scale=None,
+        causal=False,
+        num_splits=0,
+        pack_gqa=None,
+        deterministic=False,
+        return_lse=False,
+    ):
+        calls.append(
+            {
+                "q_shape": tuple(q.shape),
+                "k_shape": tuple(k.shape),
+                "pack_gqa": pack_gqa,
+                "num_splits": num_splits,
+                "return_lse": return_lse,
+            }
+        )
+        return q.clone(), torch.zeros(
+            q.size(0), q.size(2), q.size(1), dtype=torch.float32, device=q.device
+        )
+
+    core = StrictFlashAttention4Core(_op=fake_fa4, _package_version="4.test")
+    monkeypatch.setattr(core, "_validate_bshd_inputs", lambda *_args: None)
+    q = torch.randn(3, 2, 4, 8, dtype=torch.bfloat16)
+    k = torch.randn(3, 3, 2, 8, dtype=torch.bfloat16)
+    v = torch.randn(3, 3, 2, 8, dtype=torch.bfloat16)
+
+    result = core.forward_bshd_with_lse(
+        q,
+        k,
+        v,
+        causal=False,
+        query_position_ids=torch.tensor([[2, 3]]).repeat(3, 1),
+        key_position_ids=torch.tensor([[0, 1, 2]]).repeat(3, 1),
+    )
+
+    assert calls == [
+        {
+            "q_shape": (3, 2, 4, 8),
+            "k_shape": (3, 3, 2, 8),
+            "pack_gqa": True,
+            "num_splits": 1,
+            "return_lse": True,
+        }
+    ]
+    assert result.out.shape == q.shape
+    assert result.lse.shape == (3, 4, 2)
+    assert result.lse.dtype is torch.float32
+
+
+def test_fa4_core_paged_entrypoint_fixes_reduction_controls(monkeypatch):
+    calls = []
+
+    def fake_fa4(
+        q,
+        k,
+        v,
+        *,
+        softmax_scale=None,
+        causal=False,
+        num_splits=0,
+        pack_gqa=None,
+        deterministic=False,
+        return_lse=False,
+    ):
+        del (
+            k,
+            v,
+            softmax_scale,
+            causal,
+            num_splits,
+            pack_gqa,
+            deterministic,
+            return_lse,
+        )
+        return q, torch.zeros(q.size(0), q.size(2), q.size(1))
+
+    def fake_paged_fa4(
+        q,
+        k,
+        v,
+        *,
+        page_table=None,
+        seqused_k=None,
+        max_seqlen_k=None,
+        softmax_scale=None,
+        causal=False,
+        num_splits=0,
+        pack_gqa=None,
+        deterministic=False,
+        return_lse=False,
+        out=None,
+    ):
+        del k, v
+        calls.append(
+            {
+                "page_table": page_table,
+                "seqused_k": seqused_k,
+                "max_seqlen_k": max_seqlen_k,
+                "softmax_scale": softmax_scale,
+                "causal": causal,
+                "num_splits": num_splits,
+                "pack_gqa": pack_gqa,
+                "deterministic": deterministic,
+                "return_lse": return_lse,
+                "out": out,
+            }
+        )
+        if out is None:
+            out = q.clone()
+        else:
+            out.copy_(q)
+        return out, torch.zeros(q.size(0), q.size(2), q.size(1))
+
+    core = StrictFlashAttention4Core(
+        _op=fake_fa4,
+        _paged_op=fake_paged_fa4,
+        _package_version="4.test",
+    )
+    monkeypatch.setattr(core, "_validate_paged_bshd_inputs", lambda *_args, **_kwargs: None)
+    q = torch.zeros(3, 1, 4, 8, dtype=torch.bfloat16)
+    cache = torch.zeros(6, 4, 2, 8, dtype=torch.bfloat16)
+    pages = torch.tensor([[0, 1], [2, 3], [4, 5]], dtype=torch.int32)
+    lengths = torch.tensor([8, 7, 6], dtype=torch.int32)
+    out = torch.empty_like(q)
+
+    result = core.forward_paged_bshd_with_lse(
+        q,
+        cache,
+        cache,
+        page_table=pages,
+        seqused_k=lengths,
+        max_seqlen_k=8,
+        scale=0.125,
+        out=out,
+    )
+
+    assert calls == [
+        {
+            "page_table": pages,
+            "seqused_k": lengths,
+            "max_seqlen_k": 8,
+            "softmax_scale": 0.125,
+            "causal": False,
+            "num_splits": 1,
+            "pack_gqa": True,
+            "deterministic": True,
+            "return_lse": True,
+            "out": out,
+        }
+    ]
+    assert result.out.data_ptr() == out.data_ptr()
+    assert result.out.shape == q.shape
+    assert result.lse.shape == (3, 4, 1)
+    assert result.provenance["kv_layout"] == "paged_direct"
+    assert result.provenance["output_buffer_reused"] is True
+    assert result.provenance["fallback"] is False
 
 
 def test_strict_paged_default_selects_fa4_production_core(monkeypatch):

--- a/tests/test_framework_runtime_adapters.py
+++ b/tests/test_framework_runtime_adapters.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 
 import ast
 import os
+from collections import namedtuple
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-import rl_engine.integrations.framework_operators as framework_operators
 import torch
+
+import rl_engine.integrations.framework_operators as framework_operators
+from rl_engine.distributed.collectives import DETERMINISTIC_ALL_REDUCE_OP
 from rl_engine.integrations.ablation import (
     IntegrationPlan,
     configure_integration_environment,
@@ -18,15 +23,28 @@ from rl_engine.integrations.ablation import (
 )
 from rl_engine.integrations.framework_operators import (
     MegatronAttentionOperator,
+    MegatronFFNOperator,
     SemanticOperatorHandle,
+    VllmAttentionOperator,
+    VllmFFNOperator,
+    VllmLogpOperator,
     _megatron_zigzag_layout,
     _packed_local_sequence_layout,
     _vllm_kv_cache_views,
 )
-from rl_engine.integrations.megatron_runtime import install_megatron_integration
+from rl_engine.integrations.megatron_runtime import (
+    _patch_strict_attention_projections,
+    _patch_strict_te_rms_norm,
+    install_megatron_integration,
+)
 from rl_engine.integrations.runtime import FrameworkOperatorIntegration
 from rl_engine.integrations.state import clear_active_integration
-from rl_engine.integrations.vllm_runtime import configure_vllm_environment
+from rl_engine.integrations.vllm_runtime import (
+    _configure_strict_ffn_compilation,
+    _patch_qwen3_strict_model,
+    _patch_strict_lm_head_linear,
+    configure_vllm_environment,
+)
 from rl_engine.kernels.attention_contract import (
     STRICT_ATTENTION_FA4_SCHEDULE_ID,
     STRICT_ATTENTION_PRODUCTION_CORE_ID,
@@ -37,12 +55,21 @@ from rl_engine.kernels.attention_contract import (
     ReductionSpec,
     ShardingSpec,
 )
-from rl_engine.kernels.ops.cuda.attention.strict_runtime import StrictCUDAAttentionRuntime
+from rl_engine.kernels.ops.cuda.attention.strict_runtime import (
+    StrictCUDAAttentionRuntime,
+)
+from rl_engine.kernels.ops.cuda.attention.flash_attn import (
+    StrictFlashAttention4Core,
+    StrictFlashAttentionUnavailable,
+)
 
 
 def test_framework_adapters_do_not_construct_registered_kernels_directly():
     source_path = (
-        Path(__file__).parents[1] / "rl_engine" / "integrations" / "framework_operators.py"
+        Path(__file__).parents[1]
+        / "rl_engine"
+        / "integrations"
+        / "framework_operators.py"
     )
     tree = ast.parse(source_path.read_text(encoding="utf-8"))
     forbidden = {
@@ -208,8 +235,12 @@ def test_megatron_packed_attention_runs_each_sequence_in_thd_order(monkeypatch):
         get_tensor_model_parallel_rank=lambda: 0,
         get_context_parallel_group=lambda: "cp-group",
     )
-    monkeypatch.setattr(framework_operators, "_megatron_parallel_state", lambda: parallel_state)
-    monkeypatch.setattr(framework_operators, "_require_nvidia_cuda", lambda tensor, module: None)
+    monkeypatch.setattr(
+        framework_operators, "_megatron_parallel_state", lambda: parallel_state
+    )
+    monkeypatch.setattr(
+        framework_operators, "_require_nvidia_cuda", lambda tensor, module: None
+    )
     packed = SimpleNamespace(
         qkv_format="thd",
         cu_seqlens_q=torch.tensor([0, 8, 16], dtype=torch.int32),
@@ -229,15 +260,635 @@ def test_megatron_packed_attention_runs_each_sequence_in_thd_order(monkeypatch):
     )
 
     assert output.shape == (8, 8)
-    assert len(calls) == 2
+    assert len(calls) == 1
     assert [call["contract"].sharding.global_sequence_length for call in calls] == [
         8,
-        8,
     ]
+    assert calls[0]["contract"].batch_size == 2
     assert [call["query_position_ids"].tolist() for call in calls] == [
-        [[0, 1, 6, 7]],
-        [[0, 1, 6, 7]],
+        [[0, 1, 6, 7], [0, 1, 6, 7]],
     ]
+
+
+def test_megatron_ffn_keeps_strict_gate_up_projections_separate(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    class Operator:
+        def __call__(self, hidden_states, gate, up, down, **kwargs):
+            calls.append(
+                {
+                    "hidden_states": hidden_states,
+                    "gate": gate,
+                    "up": up,
+                    "down": down,
+                    "kwargs": kwargs,
+                }
+            )
+            return hidden_states
+
+    class Handle:
+        provenance = {}
+
+        def get(self, tensor, *, topology):
+            assert tensor.shape == (2, 8)
+            assert topology == {
+                "world_size": 4,
+                "tensor_parallel_size": 2,
+                "context_parallel_size": 2,
+            }
+            return Operator()
+
+    parallel_state = SimpleNamespace(
+        get_context_parallel_world_size=lambda: 2,
+        get_tensor_model_parallel_world_size=lambda: 2,
+        get_context_parallel_group=lambda: "cp-group",
+    )
+    monkeypatch.setattr(
+        framework_operators, "_megatron_parallel_state", lambda: parallel_state
+    )
+    monkeypatch.setattr(
+        framework_operators, "_require_nvidia_cuda", lambda tensor, module: None
+    )
+    fused_gate_up = torch.randn(12, 8)
+    module = SimpleNamespace(
+        config=SimpleNamespace(
+            add_bias_linear=False,
+            gated_linear_unit=True,
+            sequence_parallel=False,
+        ),
+        linear_fc1=SimpleNamespace(weight=fused_gate_up),
+        linear_fc2=SimpleNamespace(weight=torch.randn(8, 6)),
+        tp_group="tp-group",
+    )
+
+    output, bias = MegatronFFNOperator(handle=Handle())(module, torch.randn(2, 8))
+
+    assert output.shape == (2, 8)
+    assert bias is None
+    assert len(calls) == 1
+    assert "fused_gate_up_weight" not in calls[0]["kwargs"]
+    assert calls[0]["kwargs"]["tp_group"] == "tp-group"
+    assert calls[0]["kwargs"]["cp_group"] == "cp-group"
+
+
+def test_megatron_ffn_recovers_transformer_engine_fused_rms_norm(monkeypatch):
+    calls: list[torch.Tensor] = []
+
+    class Operator:
+        def __call__(self, hidden_states, gate, up, down, **kwargs):
+            del gate, up, down, kwargs
+            calls.append(hidden_states)
+            return hidden_states
+
+    class Handle:
+        provenance = {}
+
+        def get(self, tensor, *, topology):
+            del tensor, topology
+            return Operator()
+
+    parallel_state = SimpleNamespace(
+        get_context_parallel_world_size=lambda: 1,
+        get_tensor_model_parallel_world_size=lambda: 1,
+    )
+    monkeypatch.setattr(
+        framework_operators, "_megatron_parallel_state", lambda: parallel_state
+    )
+    monkeypatch.setattr(
+        framework_operators, "_require_nvidia_cuda", lambda tensor, module: None
+    )
+    norm_weight = torch.tensor([1.5, 0.5])
+    linear_fc1 = SimpleNamespace(
+        weight=torch.randn(4, 2),
+        layer_norm_weight=norm_weight,
+        layer_norm_bias=None,
+        normalization="RMSNorm",
+        zero_centered_gamma=False,
+        eps=1e-6,
+    )
+    module = SimpleNamespace(
+        config=SimpleNamespace(
+            add_bias_linear=False,
+            gated_linear_unit=True,
+            sequence_parallel=False,
+        ),
+        linear_fc1=linear_fc1,
+        linear_fc2=SimpleNamespace(weight=torch.randn(2, 2)),
+        tp_group=None,
+    )
+    hidden_states = torch.tensor([[1.0, 2.0]])
+
+    output, _ = MegatronFFNOperator(handle=Handle())(module, hidden_states)
+
+    expected = torch.nn.functional.rms_norm(
+        hidden_states,
+        (2,),
+        norm_weight,
+        1e-6,
+    )
+    assert torch.equal(output, expected)
+    assert torch.equal(calls[0], expected)
+
+
+def test_vllm_ffn_uses_existing_packed_gate_up_weight(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    class Operator:
+        def __call__(self, hidden_states, gate, up, down, **kwargs):
+            calls.append(
+                {
+                    "hidden_states": hidden_states,
+                    "gate": gate,
+                    "up": up,
+                    "down": down,
+                    "kwargs": kwargs,
+                }
+            )
+            return hidden_states
+
+    class Handle:
+        provenance = {}
+
+        def get(self, tensor, *, topology):
+            assert topology == {
+                "world_size": 2,
+                "tensor_parallel_size": 2,
+                "context_parallel_size": 1,
+            }
+            return Operator()
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        framework_operators, "_require_nvidia_cuda", lambda tensor, module: None
+    )
+    monkeypatch.setattr(
+        framework_operators,
+        "_vllm_tp_coordinates",
+        lambda: (2, 0, "tp-group"),
+    )
+    fused_gate_up = torch.randn(12, 8)
+    module = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(weight=fused_gate_up),
+        down_proj=SimpleNamespace(weight=torch.randn(8, 6)),
+    )
+
+    output = VllmFFNOperator(handle=Handle())(module, torch.randn(2, 8))
+
+    assert output.shape == (2, 8)
+    assert len(calls) == 1
+    assert calls[0]["kwargs"]["fused_gate_up_weight"] is fused_gate_up
+    assert calls[0]["kwargs"]["tp_group"] == "tp-group"
+
+
+def test_vllm_ffn_compiled_path_uses_prebound_collective(monkeypatch):
+    calls: list[dict[str, object]] = []
+    coordinate_calls = 0
+
+    def tp_coordinates():
+        nonlocal coordinate_calls
+        coordinate_calls += 1
+        return 2, 0, "tp-group"
+
+    class Operator:
+        def prepare_packed_inference(self, fused, down, *, tp_group):
+            calls.append(
+                {
+                    "phase": "prepare",
+                    "fused": fused,
+                    "down": down,
+                    "tp_group": tp_group,
+                }
+            )
+            return 1234, 2
+
+        def packed_inference(
+            self,
+            hidden_states,
+            fused,
+            down,
+            *,
+            collective_handle,
+            tp_world_size,
+        ):
+            calls.append(
+                {
+                    "phase": "execute",
+                    "fused": fused,
+                    "down": down,
+                    "collective_handle": collective_handle,
+                    "tp_world_size": tp_world_size,
+                }
+            )
+            return hidden_states
+
+    operator = Operator()
+
+    class Handle:
+        provenance = {}
+
+        def get(self, tensor, *, topology):
+            assert topology == {
+                "world_size": 2,
+                "tensor_parallel_size": 2,
+                "context_parallel_size": 1,
+            }
+            return operator
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(torch._dynamo, "is_compiling", lambda: True)
+    monkeypatch.setattr(
+        framework_operators, "_require_nvidia_cuda", lambda tensor, module: None
+    )
+    monkeypatch.setattr(
+        framework_operators,
+        "_vllm_tp_coordinates",
+        tp_coordinates,
+    )
+    fused_gate_up = torch.randn(12, 8)
+    down = torch.randn(8, 6)
+    module = SimpleNamespace(
+        gate_up_proj=SimpleNamespace(weight=fused_gate_up),
+        down_proj=SimpleNamespace(weight=down),
+    )
+    adapter = VllmFFNOperator(handle=Handle())
+
+    adapter.bind_packed_inference(module)
+    assert adapter.provenance["execution"] == {
+        "framework_layout": "vllm_tensor_parallel",
+        "tp_world_size": 2,
+        "runtime_platform": "cuda",
+        "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
+        "gemm_backend": "rlkernel.det_gemm.sm90.v1",
+        "gate_up_projection": "packed_single_launch",
+        "triton_used": False,
+    }
+    output = adapter(module, torch.randn(2, 8))
+
+    assert output.shape == (2, 8)
+    assert coordinate_calls == 1
+    assert calls == [
+        {
+            "phase": "prepare",
+            "fused": fused_gate_up,
+            "down": down,
+            "tp_group": "tp-group",
+        },
+        {
+            "phase": "execute",
+            "fused": fused_gate_up,
+            "down": down,
+            "collective_handle": 1234,
+            "tp_world_size": 2,
+        },
+    ]
+
+
+def test_vllm_strict_tp_ffn_preserves_full_graph_for_device_sequenced_collective():
+    class CudaGraphMode(Enum):
+        NONE = 0
+        PIECEWISE = 1
+        FULL = 2
+        FULL_AND_PIECEWISE = 3
+        FULL_DECODE_ONLY = 4
+
+    compilation = SimpleNamespace(
+        splitting_ops=["vllm::unified_attention"],
+        cudagraph_mode=CudaGraphMode.FULL_AND_PIECEWISE,
+    )
+    config = SimpleNamespace(compilation_config=compilation)
+
+    _configure_strict_ffn_compilation(config)
+    _configure_strict_ffn_compilation(config)
+
+    assert compilation.cudagraph_mode is CudaGraphMode.FULL_AND_PIECEWISE
+    assert compilation.splitting_ops == ["vllm::unified_attention"]
+
+
+def test_vllm_attention_builds_paged_rows_from_device_metadata():
+    operator = VllmAttentionOperator()
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([4, 4], dtype=torch.int32),
+        block_table=torch.tensor([[0], [1]], dtype=torch.int32),
+        max_seq_len=4,
+    )
+    query = torch.zeros(2, 2, 4, dtype=torch.bfloat16)
+
+    groups, summary = operator._materialization_groups(
+        metadata,
+        query=query,
+        block_table=metadata.block_table,
+        block_size=4,
+        num_actual=2,
+    )
+
+    assert len(groups) == 1
+    assert groups[0]["pages"].tolist() == [[0], [1]]
+    assert groups[0]["query_indices"].tolist() == [0, 1]
+    assert groups[0]["seqused_k"].tolist() == [4, 4]
+    assert summary == {
+        "row_count": 2,
+        "query_position_range": "device_dynamic",
+        "kv_token_range": "device_dynamic",
+        "launch_group_count": 1,
+        "metadata_source": "vllm_gpu",
+        "metadata_reused_across_layers": False,
+    }
+
+
+def test_vllm_attention_binds_after_worker_device_selection(monkeypatch):
+    calls = []
+    empty_calls = []
+
+    class Handle:
+        provenance = {}
+
+        def get(self, tensor, *, topology):
+            calls.append((tensor.device, topology))
+            return object()
+
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 3)
+    monkeypatch.setattr(
+        framework_operators,
+        "_vllm_tp_coordinates",
+        lambda: (2, 1, "tp-group"),
+    )
+    def fake_empty(*args, **kwargs):
+        empty_calls.append((args, kwargs))
+        return torch.zeros(1)
+
+    monkeypatch.setattr(torch, "empty", fake_empty)
+    operator = VllmAttentionOperator(handle=Handle())
+
+    assert calls == []
+    operator.bind_inference()
+    operator.bind_inference()
+
+    assert len(calls) == 1
+    assert empty_calls[0][1]["device"] == torch.device("cuda", 3)
+    assert calls[0][1] == {
+        "world_size": 2,
+        "tensor_parallel_size": 2,
+        "context_parallel_size": 1,
+    }
+
+
+def test_vllm_attention_collapses_mixed_prefixes_into_one_paged_launch():
+    operator = VllmAttentionOperator()
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([5, 3], dtype=torch.int32),
+        block_table=torch.tensor([[2, 3], [7, -1]], dtype=torch.int32),
+        max_seq_len=5,
+    )
+    query = torch.zeros(3, 2, 4, dtype=torch.bfloat16)
+
+    groups, summary = operator._materialization_groups(
+        metadata,
+        query=query,
+        block_table=metadata.block_table,
+        block_size=4,
+        num_actual=3,
+    )
+
+    assert len(groups) == 1
+    assert groups[0]["query_indices"].tolist() == [0, 1, 2]
+    assert groups[0]["seqused_k"].tolist() == [4, 5, 3]
+    assert groups[0]["pages"].tolist() == [[2, 3], [2, 3], [7, -1]]
+    assert summary["kv_token_range"] == "device_dynamic"
+    assert summary["launch_group_count"] == 1
+
+
+def test_vllm_attention_reuses_device_metadata_once_per_model_forward():
+    operator = VllmAttentionOperator()
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 2, 3], dtype=torch.int32),
+        seq_lens=torch.tensor([5, 3], dtype=torch.int32),
+        block_table=torch.tensor([[2, 3], [7, -1]], dtype=torch.int32),
+        max_seq_len=5,
+    )
+    query = torch.zeros(3, 2, 4, dtype=torch.bfloat16)
+    first_layer = object()
+    second_layer = object()
+
+    first, first_summary = operator._materialization_groups(
+        metadata,
+        query=query,
+        block_table=metadata.block_table,
+        block_size=4,
+        num_actual=3,
+        cache_owner=first_layer,
+    )
+    second, second_summary = operator._materialization_groups(
+        metadata,
+        query=query,
+        block_table=metadata.block_table,
+        block_size=4,
+        num_actual=3,
+        cache_owner=second_layer,
+    )
+
+    assert second[0]["pages"].data_ptr() == first[0]["pages"].data_ptr()
+    assert second[0]["seqused_k"].data_ptr() == first[0]["seqused_k"].data_ptr()
+    assert first_summary["metadata_reused_across_layers"] is False
+    assert second_summary["metadata_reused_across_layers"] is True
+
+    next_forward, next_summary = operator._materialization_groups(
+        metadata,
+        query=query,
+        block_table=metadata.block_table,
+        block_size=4,
+        num_actual=3,
+        cache_owner=first_layer,
+    )
+    assert next_forward[0]["pages"].data_ptr() != first[0]["pages"].data_ptr()
+    assert next_summary["metadata_reused_across_layers"] is False
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_vllm_attention_device_metadata_replays_in_cuda_graph():
+    operator = VllmAttentionOperator()
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor(
+            [0, 2, 3], device="cuda", dtype=torch.int32
+        ),
+        seq_lens=torch.tensor([5, 3], device="cuda", dtype=torch.int32),
+        block_table=torch.tensor(
+            [[2, 3], [7, 8]], device="cuda", dtype=torch.int32
+        ),
+        max_seq_len=8,
+    )
+    query = torch.zeros(3, 2, 4, device="cuda", dtype=torch.bfloat16)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        operator._materialization_groups(
+            metadata,
+            query=query,
+            block_table=metadata.block_table,
+            block_size=4,
+            num_actual=3,
+        )
+    torch.cuda.current_stream().wait_stream(stream)
+
+    graph = torch.cuda.CUDAGraph()
+    first_layer = object()
+    second_layer = object()
+    with torch.cuda.graph(graph):
+        groups, _summary = operator._materialization_groups(
+            metadata,
+            query=query,
+            block_table=metadata.block_table,
+            block_size=4,
+            num_actual=3,
+            cache_owner=first_layer,
+        )
+        reused_groups, reused_summary = operator._materialization_groups(
+            metadata,
+            query=query,
+            block_table=metadata.block_table,
+            block_size=4,
+            num_actual=3,
+            cache_owner=second_layer,
+        )
+    pages = groups[0]["pages"]
+    seqused_k = groups[0]["seqused_k"]
+    assert reused_groups[0]["pages"].data_ptr() == pages.data_ptr()
+    assert reused_summary["metadata_reused_across_layers"] is True
+
+    metadata.query_start_loc.copy_(
+        torch.tensor([0, 1, 3], device="cuda", dtype=torch.int32)
+    )
+    metadata.seq_lens.copy_(
+        torch.tensor([4, 6], device="cuda", dtype=torch.int32)
+    )
+    metadata.block_table.copy_(
+        torch.tensor([[10, 11], [20, 21]], device="cuda", dtype=torch.int32)
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert seqused_k.tolist() == [4, 5, 6]
+    assert pages.tolist() == [[10, 11], [20, 21], [20, 21]]
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_vllm_attention_cuda_graph_masks_capacity_padding_rows():
+    operator = VllmAttentionOperator()
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 8], device="cuda", dtype=torch.int32),
+        seq_lens=torch.tensor([8], device="cuda", dtype=torch.int32),
+        block_table=torch.tensor([[3, 4]], device="cuda", dtype=torch.int32),
+        max_seq_len=8,
+    )
+    query = torch.zeros(8, 2, 4, device="cuda", dtype=torch.bfloat16)
+
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        operator._materialization_groups(
+            metadata,
+            query=query,
+            block_table=metadata.block_table,
+            block_size=4,
+            num_actual=8,
+        )
+    torch.cuda.current_stream().wait_stream(stream)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        groups, _summary = operator._materialization_groups(
+            metadata,
+            query=query,
+            block_table=metadata.block_table,
+            block_size=4,
+            num_actual=8,
+            cache_owner=object(),
+        )
+
+    metadata.query_start_loc.copy_(
+        torch.tensor([0, 5], device="cuda", dtype=torch.int32)
+    )
+    metadata.seq_lens.copy_(torch.tensor([5], device="cuda", dtype=torch.int32))
+    metadata.block_table.copy_(
+        torch.tensor([[10, 11]], device="cuda", dtype=torch.int32)
+    )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert groups[0]["seqused_k"].tolist() == [1, 2, 3, 4, 5, 1, 1, 1]
+    assert groups[0]["pages"].tolist() == [[10, 11]] * 8
+
+
+def test_vllm_attention_writes_contiguous_rows_directly_to_output(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    class Runtime:
+        def forward_paged_with_lse(self, q, k, v, **kwargs):
+            del k, v
+            out = kwargs["out"]
+            assert out is not None
+            out.fill_(3)
+            calls.append({"q": q, "out": out, "kwargs": kwargs})
+            return SimpleNamespace(
+                out=out,
+                provenance={
+                    "actual_backend": "rlkernel.cuda.attention.fa4_ag_rs.v1",
+                    "fallback": False,
+                },
+            )
+
+    class Operator:
+        def bind_cuda_runtime(self):
+            return Runtime()
+
+    class Handle:
+        provenance = {}
+
+        def get(self, tensor, *, topology):
+            del tensor
+            assert topology["tensor_parallel_size"] == 2
+            return Operator()
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    monkeypatch.setattr(
+        framework_operators, "_require_nvidia_cuda", lambda tensor, module: None
+    )
+    monkeypatch.setattr(
+        framework_operators,
+        "_vllm_tp_coordinates",
+        lambda: (2, 0, "tp-group"),
+    )
+    adapter = VllmAttentionOperator(handle=Handle())
+    metadata = SimpleNamespace(
+        query_start_loc=torch.tensor([0, 1, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([4, 4], dtype=torch.int32),
+        block_table=torch.tensor([[0], [1]], dtype=torch.int32),
+        num_actual_tokens=2,
+        max_seq_len=4,
+    )
+    query = torch.zeros(2, 2, 4, dtype=torch.bfloat16)
+    kv_cache = torch.zeros(2, 2, 4, 1, 4, dtype=torch.bfloat16)
+    output = torch.full((2, 8), -1, dtype=torch.bfloat16)
+
+    result = adapter(
+        SimpleNamespace(head_size=4, num_heads=2, scale=0.5),
+        None,
+        query,
+        query,
+        query,
+        kv_cache,
+        metadata,
+        output=output,
+    )
+
+    assert result.data_ptr() == output.data_ptr()
+    assert torch.equal(result, torch.full_like(result, 3))
+    assert len(calls) == 1
+    assert calls[0]["q"].data_ptr() == query.data_ptr()
+    assert calls[0]["out"].data_ptr() == output.data_ptr()
+    assert adapter.provenance["execution"]["direct_output_buffer"] is True
 
 
 def test_vllm_current_flash_attention_kv_cache_layout_is_materialized():
@@ -251,16 +902,359 @@ def test_vllm_current_flash_attention_kv_cache_layout_is_materialized():
     assert torch.equal(value, cache.transpose(1, 2)[..., 5:])
 
 
-def _cp1_contract(tokens: int) -> AttentionContract:
+def test_megatron_strict_attention_projections_install_without_debug_environment(
+    monkeypatch,
+):
+    monkeypatch.delenv("RL_KERNEL_MODEL_DEBUG_DIR", raising=False)
+
+    class ColumnLinear:
+        def __init__(self):
+            self.allreduce_dgrad = True
+
+        def _forward_impl(self, input, weight, *args, **kwargs):
+            del args, kwargs
+            return input.new_full((*input.shape[:-1], weight.shape[0]), -1)
+
+    class RowLinear:
+        def _forward_impl(self, input, weight, *args, **kwargs):
+            del args, kwargs
+            return input.new_full((*input.shape[:-1], weight.shape[0]), -1)
+
+    class SelfAttention:
+        def __init__(self):
+            self.linear_qkv = ColumnLinear()
+            self.linear_proj = RowLinear()
+
+    _patch_strict_attention_projections(
+        self_attention_cls=SelfAttention,
+        column_linear_cls=ColumnLinear,
+        row_linear_cls=RowLinear,
+        det_gemm=lambda lhs, rhs: lhs @ rhs,
+    )
+    attention = SelfAttention()
+    value = torch.tensor([[1.0, 2.0]])
+    weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+
+    qkv = attention.linear_qkv._forward_impl(value, weight, bias=None)
+    projection = attention.linear_proj._forward_impl(value, weight, bias=None)
+    native = ColumnLinear()._forward_impl(value, weight, bias=None)
+
+    assert torch.equal(qkv, torch.tensor([[1.0, 2.0, 3.0]]))
+    assert torch.equal(projection, qkv)
+    assert torch.equal(native, torch.full((1, 3), -1.0))
+    assert attention.linear_qkv.allreduce_dgrad is False
+
+
+def test_megatron_strict_attention_projections_preserve_te_fused_norm_and_tp_mapping():
+    events: list[str] = []
+
+    class LocalLinear:
+        def _forward_impl(self, input, weight, *args, **kwargs):
+            del weight, args, kwargs
+            return input
+
+    class TELinear:
+        def __init__(self, weight):
+            self.weight = weight
+
+        def __call__(self, value):
+            return self.forward(value)
+
+    class TEQKV(TELinear):
+        def __init__(self, weight, norm_weight):
+            super().__init__(weight)
+            self.layer_norm_weight = norm_weight
+            self.layer_norm_bias = None
+            self.normalization = "RMSNorm"
+            self.zero_centered_gamma = False
+            self.eps = 1e-6
+
+        def forward(self, value):
+            return value.new_full((*value.shape[:-1], self.weight.shape[0]), -1), None
+
+    class TERow(TELinear):
+        def forward(self, value):
+            return value.new_full((*value.shape[:-1], self.weight.shape[0]), -1), None
+
+    qkv_weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+    norm_weight = torch.tensor([1.5, 0.5])
+    projection_weight = torch.eye(3)
+
+    class SelfAttention:
+        def __init__(self):
+            self.linear_qkv = TEQKV(qkv_weight, norm_weight)
+            self.linear_proj = TERow(projection_weight)
+
+    def copy_to_tp(value):
+        events.append("copy")
+        return value
+
+    def reduce_from_tp(value):
+        events.append("reduce")
+        return value
+
+    _patch_strict_attention_projections(
+        self_attention_cls=SelfAttention,
+        column_linear_cls=LocalLinear,
+        row_linear_cls=LocalLinear,
+        det_gemm=lambda lhs, rhs: lhs @ rhs,
+        copy_to_tp=copy_to_tp,
+        reduce_from_tp=reduce_from_tp,
+    )
+    attention = SelfAttention()
+    value = torch.tensor([[1.0, 2.0]])
+
+    qkv, qkv_bias = attention.linear_qkv(value)
+    projection, projection_bias = attention.linear_proj(qkv)
+
+    normalized = torch.nn.functional.rms_norm(value, (2,), norm_weight, 1e-6)
+    assert torch.equal(qkv, normalized @ qkv_weight.t())
+    assert torch.equal(projection, qkv)
+    assert qkv_bias is None
+    assert projection_bias is None
+    assert events == ["copy", "reduce"]
+
+
+def test_strict_te_rms_norm_uses_pytorch_arithmetic():
+    class RMSNorm:
+        def __init__(self):
+            self.weight = torch.tensor([1.5, 0.5])
+            self.eps = 1e-6
+            self.zero_centered_gamma = False
+
+        def forward(self, value):
+            return value.new_full(value.shape, -1)
+
+    _patch_strict_te_rms_norm(RMSNorm)
+    module = RMSNorm()
+    value = torch.tensor([[1.0, 2.0]])
+
+    result = module.forward(value)
+
+    expected = torch.nn.functional.rms_norm(value, (2,), module.weight, module.eps)
+    assert torch.equal(result, expected)
+
+
+def test_vllm_qwen3_strict_model_installs_without_debug_environment(monkeypatch):
+    monkeypatch.delenv("RL_KERNEL_MODEL_DEBUG_DIR", raising=False)
+
+    class RMSNorm:
+        def __init__(self):
+            self.variance_size_override = None
+            self.has_weight = True
+            self.hidden_size = 2
+            self.weight = torch.tensor([1.5, 0.5])
+            self.variance_epsilon = 1e-6
+            self._forward_method = self.forward_native
+
+        def forward_cuda(self, x, residual=None):
+            del residual
+            return x.new_full(x.shape, -1)
+
+        def forward_native(self, x, residual=None):
+            del residual
+            return x.new_full(x.shape, -2)
+
+    class RotaryEmbedding:
+        def __init__(self):
+            self._forward_method = self.forward_native
+
+        def forward_cuda(self, x):
+            return x + 1
+
+        def forward_native(self, x):
+            return x - 1
+
+    class LinearLayer:
+        def __init__(self):
+            self.weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+
+    class LinearMethod:
+        def apply(self, layer, x, bias=None):
+            del bias
+            return x.new_full((*x.shape[:-1], layer.weight.shape[0]), -1)
+
+    class Attention:
+        def __init__(self):
+            self.qkv_proj = LinearLayer()
+            self.o_proj = LinearLayer()
+
+    _patch_qwen3_strict_model(
+        rms_norm_cls=RMSNorm,
+        rotary_cls=RotaryEmbedding,
+        linear_method_cls=LinearMethod,
+        attention_cls=Attention,
+        det_gemm=lambda lhs, rhs: lhs @ rhs,
+    )
+    attention = Attention()
+    method = LinearMethod()
+    value = torch.tensor([[1.0, 2.0]])
+    norm = RMSNorm()
+    rotary = RotaryEmbedding()
+
+    assert torch.equal(
+        method.apply(attention.qkv_proj, value),
+        torch.tensor([[1.0, 2.0, 3.0]]),
+    )
+    assert torch.equal(
+        method.apply(LinearLayer(), value),
+        torch.full((1, 3), -1.0),
+    )
+    assert torch.equal(
+        norm.forward_cuda(value),
+        torch.nn.functional.rms_norm(value, (2,), norm.weight, 1e-6),
+    )
+    assert norm._forward_method == norm.forward_cuda
+    assert rotary._forward_method == rotary.forward_cuda
+    assert torch.equal(rotary._forward_method(value), value + 1)
+
+    norm.variance_size_override = 1
+    assert torch.equal(norm._forward_method(value), torch.full_like(value, -2))
+    norm.variance_size_override = None
+    norm.has_weight = False
+    assert torch.equal(norm._forward_method(value), torch.full_like(value, -2))
+
+
+def test_vllm_strict_lm_head_patch_routes_only_marked_projection():
+    class LinearMethod:
+        def apply(self, layer, x, bias=None):
+            del bias
+            return x.new_full((*x.shape[:-1], layer.weight.size(0)), -1)
+
+    class Layer:
+        def __init__(self, *, marked):
+            self.weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+            if marked:
+                setattr(self, "__rl_kernel_strict_attention_projection__", "lm_head")
+
+    class DetGemm:
+        @staticmethod
+        def linear(x, weight):
+            return x @ weight.t()
+
+    _patch_strict_lm_head_linear(
+        linear_method_cls=LinearMethod,
+        det_gemm=DetGemm(),
+    )
+    method = LinearMethod()
+    value = torch.tensor([[1.0, 2.0]])
+    assert torch.equal(
+        method.apply(Layer(marked=True), value),
+        torch.tensor([[1.0, 2.0, 3.0]]),
+    )
+    assert torch.equal(
+        method.apply(Layer(marked=False), value),
+        torch.full((1, 3), -1.0),
+    )
+
+
+def test_vllm_logp_replaces_every_duplicate_sampled_token_column():
+    logprobs_type = namedtuple(
+        "LogprobsTensors",
+        ("logprob_token_ids", "logprobs", "selected_token_ranks"),
+    )
+
+    @dataclass(frozen=True)
+    class SamplerResult:
+        sampled_token_ids: torch.Tensor
+        logprobs_tensors: object
+
+    operator = VllmLogpOperator(lambda *_args, **_kwargs: None)
+    result = SamplerResult(
+        sampled_token_ids=torch.tensor([[7], [8]]),
+        logprobs_tensors=logprobs_type(
+            logprob_token_ids=torch.tensor([[7, 7], [8, 9]]),
+            logprobs=torch.tensor([[-0.1, -0.1], [-0.2, -0.3]]),
+            selected_token_ranks=torch.tensor([1, 2]),
+        ),
+    )
+
+    updated = operator._replace_sampled_value(
+        result,
+        token_ids=torch.tensor([7, 8]),
+        selected=torch.tensor([-1.25, -2.5]),
+        provenance={},
+    )
+
+    assert torch.equal(
+        updated.logprobs_tensors.logprobs,
+        torch.tensor([[-1.25, -1.25], [-2.5, -0.3]]),
+    )
+    assert operator.provenance["native_reference_compared"] is False
+    assert operator.provenance["strict_selected_logp"]["shape"] == [2]
+    assert "native_vs_rlkernel_selected_diff" not in operator.provenance
+
+
+def test_vllm_strict_logp_preserves_raw_local_logits_before_native_sampling(monkeypatch):
+    from rl_engine.integrations.linear_logp import publish_rollout_linear_logp_context
+
+    logprobs_type = namedtuple(
+        "LogprobsTensors",
+        ("logprob_token_ids", "logprobs", "selected_token_ranks"),
+    )
+
+    @dataclass(frozen=True)
+    class SamplerResult:
+        sampled_token_ids: torch.Tensor
+        logprobs_tensors: object
+
+    captured = {}
+
+    class LinearLogp:
+        backend_id = "rlkernel.linear_logp.bitwise.v1"
+        provenance = {"actual_backend": backend_id}
+
+        @staticmethod
+        def from_local_logits(local_logits, target_ids, **kwargs):
+            captured["local_logits"] = local_logits.clone()
+            captured["target_ids"] = target_ids.clone()
+            captured["kwargs"] = kwargs
+            return torch.tensor([-7.0])
+
+    def native(_sampler, logits, _sampling_metadata, **_kwargs):
+        logits.fill_(99)
+        return SamplerResult(
+            sampled_token_ids=torch.tensor([[4]]),
+            logprobs_tensors=logprobs_type(
+                logprob_token_ids=torch.tensor([[4]]),
+                logprobs=torch.tensor([[-1.0]]),
+                selected_token_ranks=torch.tensor([0]),
+            ),
+        )
+
+    monkeypatch.setattr(framework_operators, "_require_nvidia_cuda", lambda *args: None)
+    publish_rollout_linear_logp_context(
+        torch.zeros(1, 2, dtype=torch.bfloat16),
+        torch.zeros(3, 2, dtype=torch.bfloat16),
+        None,
+        tp_group=object(),
+        vocab_start_index=3,
+        global_vocab_size=6,
+        real_vocab_size=5,
+    )
+    operator = VllmLogpOperator(native, strict_linear_logp=True)
+    operator._linear_logp = LinearLogp()
+    logits = torch.tensor([[0.0, 1.0, 2.0, 3.0, 4.0]], dtype=torch.bfloat16)
+    result = operator(object(), logits, object())
+
+    assert torch.equal(logits, torch.full_like(logits, 99))
+    assert torch.equal(
+        captured["local_logits"],
+        torch.tensor([[3.0, 4.0, float("-inf")]], dtype=torch.bfloat16),
+    )
+    assert torch.equal(result.logprobs_tensors.logprobs, torch.tensor([[-7.0]]))
+
+
+def _cp1_contract(tokens: int, *, batch_size: int = 1) -> AttentionContract:
     return AttentionContract(
         role=AttentionRole.TRAIN,
         mode=AttentionMode.PREFILL,
         dtype=AttentionDType.BF16,
-        batch_size=1,
+        batch_size=batch_size,
         query_sequence_length=tokens,
         head_dim=4,
         causal=True,
-        causal_offsets=(0,),
+        causal_offsets=(0,) * batch_size,
         sharding=ShardingSpec(
             tp_rank=0,
             tp_world_size=1,
@@ -282,8 +1276,8 @@ def _cp1_contract(tokens: int) -> AttentionContract:
     )
 
 
-def test_strict_cuda_runtime_pins_training_to_single_query_prefixes(monkeypatch):
-    calls: list[tuple[int, int, bool]] = []
+def test_strict_cuda_runtime_batches_training_sequence_in_one_causal_launch(monkeypatch):
+    calls: list[tuple[int, int, int, bool]] = []
 
     class Core:
         core_id = STRICT_ATTENTION_PRODUCTION_CORE_ID
@@ -291,7 +1285,7 @@ def test_strict_cuda_runtime_pins_training_to_single_query_prefixes(monkeypatch)
 
         def forward_bshd_with_lse(self, q, k, v, *, causal, **kwargs):
             del v, kwargs
-            calls.append((q.size(1), k.size(1), causal))
+            calls.append((q.size(0), q.size(1), k.size(1), causal))
             return SimpleNamespace(
                 out=q.clone(),
                 lse=torch.zeros((q.size(0), q.size(2), q.size(1)), dtype=torch.float32),
@@ -302,15 +1296,15 @@ def test_strict_cuda_runtime_pins_training_to_single_query_prefixes(monkeypatch)
         StrictCUDAAttentionRuntime, "_require_nvidia_cuda", lambda self, tensor: None
     )
     runtime = StrictCUDAAttentionRuntime(core=Core(), communication=object())
-    q = torch.zeros(1, 2, 4, 4, dtype=torch.bfloat16)
-    k = torch.zeros(1, 1, 4, 4, dtype=torch.bfloat16)
-    positions = torch.arange(4).unsqueeze(0)
+    q = torch.zeros(3, 2, 4, 4, dtype=torch.bfloat16)
+    k = torch.zeros(3, 1, 4, 4, dtype=torch.bfloat16)
+    positions = torch.arange(4).repeat(3, 1)
 
     result = runtime.forward_with_lse(
         q,
         k,
         k,
-        contract=_cp1_contract(4),
+        contract=_cp1_contract(4, batch_size=3),
         causal=True,
         scale=0.5,
         cp_world_size=1,
@@ -318,8 +1312,146 @@ def test_strict_cuda_runtime_pins_training_to_single_query_prefixes(monkeypatch)
         key_position_ids=positions,
     )
 
-    assert calls == [(1, 1, False), (1, 2, False), (1, 3, False), (1, 4, False)]
-    assert result.provenance["query_schedule"] == "single_query_causal_prefix"
+    assert calls == [(3, 4, 4, True)]
+    assert result.provenance["query_schedule"] == (
+        "full_sequence_causal_single_launch"
+    )
+    assert result.provenance["backward_schedule"] == (
+        "fa4_deterministic_full_sequence"
+    )
+    assert result.provenance["core_row_count"] == 12
+    assert result.provenance["core_launch_count"] == 1
+    assert result.provenance["core_query_length"] == 4
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_fa4_full_sequence_preserves_prefix_bitwise_and_deterministic_backward():
+    if torch.cuda.get_device_capability()[0] < 9:
+        pytest.skip("FA4 strict schedule requires SM90")
+    try:
+        core = StrictFlashAttention4Core()
+    except StrictFlashAttentionUnavailable as exc:
+        pytest.skip(str(exc))
+
+    torch.manual_seed(20260826)
+    batch, tokens, q_heads, kv_heads, head_dim = 1, 16, 16, 4, 128
+    base = (
+        torch.randn(
+            batch,
+            tokens,
+            q_heads,
+            head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        ),
+        torch.randn(
+            batch,
+            tokens,
+            kv_heads,
+            head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        ),
+        torch.randn(
+            batch,
+            tokens,
+            kv_heads,
+            head_dim,
+            device="cuda",
+            dtype=torch.bfloat16,
+        ),
+    )
+    positions = torch.arange(tokens, device="cuda", dtype=torch.int64).repeat(
+        batch, 1
+    )
+    grad_output = torch.randn_like(base[0])
+
+    prefix_outputs = []
+    prefix_lses = []
+    prefix_inputs = tuple(value.detach().clone().requires_grad_(True) for value in base)
+    for query_index in range(tokens):
+        prefix = core.forward_bshd_with_lse(
+            prefix_inputs[0][:, query_index : query_index + 1],
+            prefix_inputs[1][:, : query_index + 1],
+            prefix_inputs[2][:, : query_index + 1],
+            causal=False,
+            scale=head_dim**-0.5,
+            query_position_ids=positions[:, query_index : query_index + 1],
+            key_position_ids=positions[:, : query_index + 1],
+            output_dtype=torch.bfloat16,
+        )
+        prefix_outputs.append(prefix.out)
+        prefix_lses.append(prefix.lse)
+    prefix_out = torch.cat(prefix_outputs, dim=1)
+    prefix_lse = torch.cat(prefix_lses, dim=2)
+    prefix_grads = torch.autograd.grad(
+        prefix_out, prefix_inputs, grad_output
+    )
+
+    full_runs = []
+    for _ in range(2):
+        full_inputs = tuple(value.detach().clone().requires_grad_(True) for value in base)
+        full = core.forward_bshd_with_lse(
+            *full_inputs,
+            causal=True,
+            scale=head_dim**-0.5,
+            query_position_ids=positions,
+            key_position_ids=positions,
+            output_dtype=torch.bfloat16,
+        )
+        full_grads = torch.autograd.grad(full.out, full_inputs, grad_output)
+        full_runs.append((full.out.detach(), full.lse.detach(), *full_grads))
+
+    assert torch.equal(prefix_out, full_runs[0][0])
+    assert torch.equal(prefix_lse, full_runs[0][1])
+    assert torch.equal(prefix_grads[0], full_runs[0][2])
+    assert all(
+        torch.equal(first, second)
+        for first, second in zip(full_runs[0], full_runs[1], strict=True)
+    )
+
+
+def test_strict_cuda_runtime_routes_paged_kv_without_dense_materialization(monkeypatch):
+    calls = []
+
+    class Core:
+        core_id = STRICT_ATTENTION_PRODUCTION_CORE_ID
+        strict_schedule = STRICT_ATTENTION_FA4_SCHEDULE_ID
+
+        def forward_paged_bshd_with_lse(self, q, k, v, **kwargs):
+            calls.append((q.shape, k.shape, v.shape, kwargs))
+            return SimpleNamespace(
+                out=q.clone(),
+                lse=torch.zeros((q.size(0), q.size(2), q.size(1))),
+                provenance={"attention_backend": "fake.cuda.fa4.paged"},
+            )
+
+    monkeypatch.setattr(
+        StrictCUDAAttentionRuntime, "_require_nvidia_cuda", lambda self, tensor: None
+    )
+    runtime = StrictCUDAAttentionRuntime(core=Core(), communication=object())
+    q = torch.zeros(3, 2, 1, 4, dtype=torch.bfloat16)
+    cache = torch.zeros(4, 4, 1, 4, dtype=torch.bfloat16)
+    pages = torch.tensor([[0], [1], [2]], dtype=torch.int32)
+    lengths = torch.tensor([4, 3, 2], dtype=torch.int32)
+
+    result = runtime.forward_paged_with_lse(
+        q,
+        cache,
+        cache,
+        page_table=pages,
+        seqused_k=lengths,
+        max_seqlen_k=4,
+        scale=0.5,
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] == torch.Size([3, 1, 2, 4])
+    assert calls[0][3]["page_table"] is pages
+    assert result.out.shape == q.shape
+    assert result.provenance["query_schedule"] == "paged_single_query_batch"
+    assert result.provenance["core_launch_count"] == 1
+    assert result.provenance["fallback"] is False
 
 
 class _ReadbackOperator:
@@ -375,3 +1507,82 @@ def test_strict_readback_accepts_cuda_without_triton():
     integration.execute("attention", lambda value: value, "x")
 
     integration.assert_strict_ready()
+
+
+def test_compiled_custom_op_execution_is_valid_route_evidence():
+    plan = IntegrationPlan.from_case_ids(ffn="R/R")
+    operator = _ReadbackOperator(
+        {
+            "runtime_platform": "cuda",
+            "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
+            "triton_used": False,
+        }
+    )
+    integration = FrameworkOperatorIntegration(
+        framework="vllm",
+        target="rollout",
+        plan=plan,
+        rl_kernel_operators={"ffn": operator},
+    )
+    integration.record_installed_hook("ffn", "test.compiled_ffn")
+
+    integration.record_execution(
+        "ffn",
+        operator,
+        execution_mode="compiled_cuda_graph",
+    )
+
+    readback = integration.readback()["operators"]["ffn"]
+    assert readback["call_count"] == 1
+    assert readback["execution_mode"] == "compiled_cuda_graph"
+    integration.assert_strict_ready()
+
+
+def test_route_report_is_emitted_once(capsys, monkeypatch):
+    monkeypatch.setenv("RANK", "0")
+    plan = IntegrationPlan.from_case_ids(attention="R/R")
+    integration = FrameworkOperatorIntegration(
+        framework="megatron",
+        target="training",
+        plan=plan,
+        rl_kernel_operators={
+            "attention": _ReadbackOperator(
+                {
+                    "runtime_platform": "cuda",
+                    "actual_backend": "rlkernel.cuda.fa4",
+                    "fallback": False,
+                }
+            )
+        },
+    )
+
+    integration.execute("attention", lambda value: value, "first")
+    integration.execute("attention", lambda value: value, "second")
+
+    lines = [line for line in capsys.readouterr().out.splitlines() if "[route]" in line]
+    assert lines == [
+        "[RL-Kernel][route] framework=megatron target=training module=attention "
+        "requested=rl_kernel actual=rlkernel.cuda.fa4 fallback=false"
+    ]
+
+
+def test_strict_route_fails_when_provenance_reports_fallback(monkeypatch):
+    monkeypatch.setenv("RL_KERNEL_ROUTE_REPORT", "0")
+    plan = IntegrationPlan.from_case_ids(ffn="R/R")
+    integration = FrameworkOperatorIntegration(
+        framework="vllm",
+        target="rollout",
+        plan=plan,
+        rl_kernel_operators={
+            "ffn": _ReadbackOperator(
+                {
+                    "runtime_platform": "cuda",
+                    "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
+                    "fallback": True,
+                }
+            )
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="strict RL-Kernel route reported fallback"):
+        integration.execute("ffn", lambda value: value, "x")

--- a/tests/test_framework_runtime_adapters.py
+++ b/tests/test_framework_runtime_adapters.py
@@ -519,6 +519,7 @@ def test_vllm_ffn_compiled_path_uses_prebound_collective(monkeypatch):
         "runtime_platform": "cuda",
         "actual_backend": "rlkernel.cuda.det_gemm_swiglu",
         "gemm_backend": "rlkernel.det_gemm.sm90.v1",
+        "fallback": False,
         "gate_up_projection": "packed_single_launch",
         "triton_used": False,
     }
@@ -1540,6 +1541,7 @@ def test_compiled_custom_op_execution_is_valid_route_evidence():
 
 def test_route_report_is_emitted_once(capsys, monkeypatch):
     monkeypatch.setenv("RANK", "0")
+    monkeypatch.setenv("RL_KERNEL_MODE", "strict")
     plan = IntegrationPlan.from_case_ids(attention="R/R")
     integration = FrameworkOperatorIntegration(
         framework="megatron",
@@ -1549,6 +1551,8 @@ def test_route_report_is_emitted_once(capsys, monkeypatch):
             "attention": _ReadbackOperator(
                 {
                     "runtime_platform": "cuda",
+                    "interface": "megatron.attention.forward",
+                    "operator": "rlkernel.cuda.fa4",
                     "actual_backend": "rlkernel.cuda.fa4",
                     "fallback": False,
                 }
@@ -1561,13 +1565,16 @@ def test_route_report_is_emitted_once(capsys, monkeypatch):
 
     lines = [line for line in capsys.readouterr().out.splitlines() if "[route]" in line]
     assert lines == [
-        "[RL-Kernel][route] framework=megatron target=training module=attention "
+        "[RL-Kernel][route] mode=strict framework=megatron target=training "
+        "module=attention interface=megatron.attention.forward "
+        "operator=rlkernel.cuda.fa4 "
         "requested=rl_kernel actual=rlkernel.cuda.fa4 fallback=false"
     ]
 
 
 def test_strict_route_fails_when_provenance_reports_fallback(monkeypatch):
     monkeypatch.setenv("RL_KERNEL_ROUTE_REPORT", "0")
+    monkeypatch.setenv("RL_KERNEL_MODE", "strict")
     plan = IntegrationPlan.from_case_ids(ffn="R/R")
     integration = FrameworkOperatorIntegration(
         framework="vllm",
@@ -1586,3 +1593,31 @@ def test_strict_route_fails_when_provenance_reports_fallback(monkeypatch):
 
     with pytest.raises(RuntimeError, match="strict RL-Kernel route reported fallback"):
         integration.execute("ffn", lambda value: value, "x")
+
+
+def test_audit_route_records_fallback_without_hiding_it(monkeypatch):
+    monkeypatch.setenv("RL_KERNEL_ROUTE_REPORT", "0")
+    monkeypatch.setenv("RL_KERNEL_MODE", "audit")
+    plan = IntegrationPlan.from_case_ids(ffn="R/R")
+    integration = FrameworkOperatorIntegration(
+        framework="vllm",
+        target="rollout",
+        plan=plan,
+        rl_kernel_operators={
+            "ffn": _ReadbackOperator(
+                {
+                    "runtime_platform": "cuda",
+                    "actual_backend": "vllm.native.silu_and_mul",
+                    "fallback": True,
+                }
+            )
+        },
+    )
+
+    assert integration.execute("ffn", lambda value: value, "x") == "x"
+    assert integration.readback()["fallbacks"] == [
+        {
+            "module": "ffn",
+            "reason": "operator provenance selected vllm.native.silu_and_mul",
+        }
+    ]

--- a/tests/test_linear_logp.py
+++ b/tests/test_linear_logp.py
@@ -126,6 +126,133 @@ def _tp_linear_logp_gloo_worker(rank, world_size, init_method, result_queue):
             torch.distributed.destroy_process_group()
 
 
+def _tp_linear_logp_rl_collective_worker(rank, world_size, init_method, result_queue):
+    collective_module = None
+    try:
+        import torch.distributed as dist
+
+        from rl_engine.distributed import collectives as collective_module
+        from rl_engine.kernels.ops.pytorch.loss.linear_logp import (
+            _deterministic_tp_all_reduce_,
+            _merge_tp_local_logp,
+        )
+        from rl_engine.kernels.ops.base import _C
+        from rl_engine.kernels.ops.cuda.loss.linear_logp import (
+            sm90_deterministic_linear_logp_tp,
+            sm90_deterministic_logp_from_local_logits_tp,
+        )
+
+        torch.cuda.set_device(rank)
+        dist.init_process_group(
+            backend="nccl",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        device = torch.device("cuda", rank)
+        peer_lse = torch.tensor(
+            [[1.25, -2.0, 3.0], [0.5, -1.0, 2.5]],
+            device=device,
+            dtype=torch.float32,
+        )
+        peer_target = torch.tensor(
+            [[5.0, 0.0, 7.0], [0.0, 6.0, 0.0]],
+            device=device,
+            dtype=torch.float32,
+        )
+        local_lse = peer_lse[rank].contiguous()
+        local_target = peer_target[rank].contiguous()
+
+        # The first call performs the one-time CUDA IPC handle exchange.
+        _merge_tp_local_logp(local_lse, local_target, tp_group=dist.group.WORLD)
+
+        forbidden_names = (
+            "all_gather",
+            "all_gather_into_tensor",
+            "all_gather_object",
+            "all_reduce",
+        )
+        saved = {name: getattr(dist, name) for name in forbidden_names}
+
+        def forbidden(*args, **kwargs):
+            del args, kwargs
+            raise AssertionError("steady-state CUDA linear_logp used torch.distributed data plane")
+
+        for name in forbidden_names:
+            setattr(dist, name, forbidden)
+        try:
+            logp, lse = _merge_tp_local_logp(
+                local_lse,
+                local_target,
+                tp_group=dist.group.WORLD,
+            )
+            reduce_input = (
+                torch.tensor([1.0, -2.0], device=device)
+                if rank == 0
+                else torch.tensor([3.0, 4.0], device=device)
+            )
+            reduced = _deterministic_tp_all_reduce_(reduce_input, dist.group.WORLD)
+            hidden = (
+                torch.arange(3 * 32, device=device, dtype=torch.float32)
+                .reshape(3, 32)
+                .div_(128)
+                .to(torch.bfloat16)
+            )
+            weight = (
+                torch.arange(64 * 32, device=device, dtype=torch.float32)
+                .reshape(64, 32)
+                .add_(rank * 64 * 32)
+                .div_(4096)
+                .to(torch.bfloat16)
+            )
+            target = torch.tensor([0, 64, 127], device=device)
+            recomputed, _ = sm90_deterministic_linear_logp_tp(
+                hidden,
+                weight,
+                target,
+                vocab_start_index=rank * 64,
+                global_vocab_size=128,
+                real_vocab_size=128,
+                tp_group=dist.group.WORLD,
+            )
+            local_logits = _C.det_gemm_fwd_weight(hidden, weight)
+            reused, _ = sm90_deterministic_logp_from_local_logits_tp(
+                local_logits,
+                target,
+                vocab_start_index=rank * 64,
+                global_vocab_size=128,
+                real_vocab_size=128,
+                tp_group=dist.group.WORLD,
+            )
+        finally:
+            for name, function in saved.items():
+                setattr(dist, name, function)
+
+        global_max = torch.maximum(peer_lse[0], peer_lse[1])
+        expected_lse = global_max + torch.log(
+            torch.exp(peer_lse[0] - global_max) + torch.exp(peer_lse[1] - global_max)
+        )
+        expected_logp = peer_target[0] + peer_target[1] - expected_lse
+        assert torch.equal(lse, expected_lse)
+        assert torch.equal(logp, expected_logp)
+        assert torch.equal(reduced, torch.tensor([4.0, 2.0], device=device))
+        assert torch.equal(reused, recomputed)
+        result_queue.put({"ok": True, "rank": rank})
+    except Exception:  # pragma: no cover - forwarded to parent process
+        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        raise
+    finally:
+        if collective_module is not None:
+            try:
+                for collective in list(collective_module._COLLECTIVES.values()):
+                    collective.close()
+                collective_module._COLLECTIVES.clear()
+            except Exception:
+                pass
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
 # SM90 forward needs bf16 and a hidden dim that is a multiple of the kernel's K
 # slice (32); N / V are deliberately left unaligned to the 64-wide tiles.
 _SM90_N = 96
@@ -477,6 +604,47 @@ def test_native_tensor_parallel_matches_full_reference_cpu_gloo_4_ranks():
         assert result["hidden_grad"] < 1e-5
         assert result["weight_grad"] < 1e-5
         assert result["bias_grad"] < 1e-5
+
+
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="RL-Kernel TP linear_logp collective test requires two CUDA devices.",
+)
+def test_tp_linear_logp_uses_rl_collectives_without_torch_distributed_steady_state():
+    ctx = mp.get_context("spawn")
+    world_size = 2
+    with tempfile.TemporaryDirectory() as tmpdir:
+        init_method = (Path(tmpdir) / "nccl_init").as_uri()
+        result_queue = ctx.Queue()
+        processes = [
+            ctx.Process(
+                target=_tp_linear_logp_rl_collective_worker,
+                args=(rank, world_size, init_method, result_queue),
+            )
+            for rank in range(world_size)
+        ]
+        for process in processes:
+            process.start()
+
+        results = []
+        try:
+            for _ in processes:
+                results.append(result_queue.get(timeout=90))
+        except queue.Empty:
+            for process in processes:
+                if process.is_alive():
+                    process.terminate()
+            pytest.fail("timed out waiting for RL-Kernel TP linear_logp workers")
+        finally:
+            for process in processes:
+                process.join(timeout=10)
+                if process.is_alive():
+                    process.terminate()
+
+    for result in sorted(results, key=lambda item: item["rank"]):
+        assert result["ok"], result.get("traceback")
+    for process in processes:
+        assert process.exitcode == 0
 
 
 @requires_triton_cuda
@@ -1256,6 +1424,165 @@ def test_sm90_backward_prefers_fused_extension_when_available(monkeypatch):
     assert grad_hidden is None
     assert torch.equal(grad_weight, torch.ones_like(weight))
     assert torch.equal(grad_bias, torch.ones_like(bias))
+
+
+def test_strict_tp_hot_path_avoids_validation_collectives_and_weight_transpose(
+    monkeypatch,
+):
+    from rl_engine.kernels.ops.cuda.loss import linear_logp as cuda_linear_logp
+
+    calls = {}
+
+    class FakeC:
+        @staticmethod
+        def det_gemm_fwd_weight(hidden, weight):
+            calls["gemm_weight"] = weight
+            return hidden.new_zeros((hidden.size(0), weight.size(0)))
+
+        @staticmethod
+        def linear_logp_local_bf16_forward(logits, target, vocab_start):
+            del vocab_start
+            return (
+                torch.zeros_like(target, dtype=torch.float32),
+                torch.zeros_like(target, dtype=torch.float32),
+            )
+
+        @staticmethod
+        def linear_logp_logits_bf16_to_dlogits(*args):
+            del args
+
+    hidden = torch.randn(2, 8, dtype=torch.bfloat16)
+    weight = torch.randn(4, 8, dtype=torch.bfloat16)
+    target = torch.tensor([1, 5], dtype=torch.long)
+
+    monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_VALIDATE_TP_TARGETS", raising=False)
+    monkeypatch.delenv("VIME_RL_KERNEL_VALIDATE_TP_TARGETS", raising=False)
+    monkeypatch.setattr(cuda_linear_logp, "_EXT_AVAILABLE", True)
+    monkeypatch.setattr(cuda_linear_logp, "_C", FakeC)
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "_validate_tp_vocab_partition_cached",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("strict TP must not call synchronized partition validation")
+        ),
+    )
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "_validate_even_tp_vocab_partition_local",
+        lambda **kwargs: kwargs["global_vocab_size"],
+    )
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "_require_distributed_initialized",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("default strict TP validation must not issue all_reduce")
+        ),
+    )
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "_merge_tp_local_logp",
+        lambda local_lse, local_target, **kwargs: (
+            local_target - local_lse,
+            local_lse,
+        ),
+    )
+
+    logp, lse, *_ = cuda_linear_logp._strict_tp_run(
+        hidden,
+        weight,
+        None,
+        target,
+        vocab_start=0,
+        global_vocab=8,
+        real_vocab=8,
+        temperature=None,
+        tp_group=object(),
+    )
+
+    assert logp.shape == target.shape
+    assert lse.shape == target.shape
+    assert calls["gemm_weight"].data_ptr() == weight.data_ptr()
+
+
+def test_strict_tp_synchronized_validation_is_opt_in(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss import linear_logp as cuda_linear_logp
+
+    calls = {"target_validation": 0, "all_reduce": 0}
+
+    class FakeC:
+        @staticmethod
+        def det_gemm_fwd_weight(hidden, weight):
+            return hidden.new_zeros((hidden.size(0), weight.size(0)))
+
+        @staticmethod
+        def linear_logp_local_bf16_forward(logits, target, vocab_start):
+            del logits, vocab_start
+            return (
+                torch.zeros_like(target, dtype=torch.float32),
+                torch.zeros_like(target, dtype=torch.float32),
+            )
+
+        @staticmethod
+        def linear_logp_logits_bf16_to_dlogits(*args):
+            del args
+
+    class FakeDist:
+        class ReduceOp:
+            SUM = object()
+
+        @staticmethod
+        def all_reduce(tensor, **kwargs):
+            del tensor, kwargs
+            calls["all_reduce"] += 1
+
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_VALIDATE_TP_TARGETS", "1")
+    monkeypatch.setattr(cuda_linear_logp, "_EXT_AVAILABLE", True)
+    monkeypatch.setattr(cuda_linear_logp, "_C", FakeC)
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "_validate_tp_vocab_partition_cached",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("strict TP must not call synchronized partition validation")
+        ),
+    )
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "_validate_even_tp_vocab_partition_local",
+        lambda **kwargs: kwargs["global_vocab_size"],
+    )
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "_validate_global_targets",
+        lambda *args, **kwargs: calls.__setitem__(
+            "target_validation", calls["target_validation"] + 1
+        ),
+    )
+    monkeypatch.setattr(cuda_linear_logp, "_require_distributed_initialized", FakeDist)
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "_merge_tp_local_logp",
+        lambda local_lse, local_target, **kwargs: (
+            local_target - local_lse,
+            local_lse,
+        ),
+    )
+
+    hidden = torch.randn(2, 8, dtype=torch.bfloat16)
+    weight = torch.randn(4, 8, dtype=torch.bfloat16)
+    target = torch.tensor([1, 2], dtype=torch.long)
+    cuda_linear_logp._strict_tp_run(
+        hidden,
+        weight,
+        None,
+        target,
+        vocab_start=0,
+        global_vocab=8,
+        real_vocab=8,
+        temperature=None,
+        tp_group=object(),
+    )
+
+    assert calls == {"target_validation": 1, "all_reduce": 1}
 
 
 def test_registry_dispatch_matches_native():

--- a/tests/test_qwen_ffn.py
+++ b/tests/test_qwen_ffn.py
@@ -24,15 +24,19 @@ from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
 from rl_engine.kernels.ops.pytorch.ffn.ffn import (
     QWEN3_8B_HIDDEN_SIZE,
     QWEN3_8B_INTERMEDIATE_SIZE,
+    Qwen3FFNOp,
     qwen3_ffn,
+    qwen3_ffn_packed_inference,
 )
 
 _REQUIRED_SYMBOLS = (
-    "det_gemm_fwd",
-    "det_gemm_fwd_rhs_transposed",
-    "det_gemm_db_transposed",
+    "det_gemm_fwd_weight",
+    "det_gemm_da_weight",
+    "det_gemm_dw",
     "swiglu_forward",
     "swiglu_backward",
+    "swiglu_packed_forward",
+    "swiglu_packed_backward",
 )
 _HIDDEN = 64
 _INTERMEDIATE = 512
@@ -42,20 +46,29 @@ _TOKEN_BOUNDARY_COUNTS = (8, 31, 32, 33, 64, 96, 128)
 _WORLD2_CONFIGS = (
     ("tp2_sp", 2, 1, True, _TOPOLOGY_TOKENS),
     ("cp2", 1, 2, False, _TOPOLOGY_TOKENS),
-    *((f"cp2_T{token_count}", 1, 2, False, token_count) for token_count in _CP_TOKEN_COUNTS),
+    *(
+        (f"cp2_T{token_count}", 1, 2, False, token_count)
+        for token_count in _CP_TOKEN_COUNTS
+    ),
 )
 _WORLD4_CONFIGS = (
     ("tp4", 4, 1, False, _TOPOLOGY_TOKENS),
     ("cp4", 1, 4, False, _TOPOLOGY_TOKENS),
     ("tp2_cp2", 2, 2, False, _TOPOLOGY_TOKENS),
     ("tp2_cp2_sp", 2, 2, True, _TOPOLOGY_TOKENS),
-    *((f"cp4_T{token_count}", 1, 4, False, token_count) for token_count in _CP_TOKEN_COUNTS),
+    *(
+        (f"cp4_T{token_count}", 1, 4, False, token_count)
+        for token_count in _CP_TOKEN_COUNTS
+    ),
 )
 _WORLD8_WORLD_GROUP_CONFIGS = (
     ("tp8", 8, 1, False, _TOPOLOGY_TOKENS),
     ("tp8_sp", 8, 1, True, _TOPOLOGY_TOKENS),
     ("cp8", 1, 8, False, _TOPOLOGY_TOKENS),
-    *((f"cp8_T{token_count}", 1, 8, False, token_count) for token_count in _CP_TOKEN_COUNTS),
+    *(
+        (f"cp8_T{token_count}", 1, 8, False, token_count)
+        for token_count in _CP_TOKEN_COUNTS
+    ),
 )
 _WORLD8_TP2_CP4_CONFIGS = (("tp2_cp4", 2, 4, False, _TOPOLOGY_TOKENS),)
 _WORLD8_TP4_CP2_CONFIGS = (
@@ -70,7 +83,9 @@ def _has_sm90_ffn_devices(count: int) -> bool:
         and torch.distributed.is_available()
         and torch.distributed.is_nccl_available()
         and torch.cuda.device_count() >= count
-        and all(torch.cuda.get_device_capability(index)[0] == 9 for index in range(count))
+        and all(
+            torch.cuda.get_device_capability(index)[0] == 9 for index in range(count)
+        )
         and all(hasattr(_C, name) for name in _REQUIRED_SYMBOLS)
     )
 
@@ -94,17 +109,17 @@ class _TorchKernelStub:
     def __init__(self) -> None:
         self.calls: list[str] = []
 
-    def det_gemm_fwd(self, a, b):
-        self.calls.append("det_gemm_fwd")
-        return a @ b
+    def det_gemm_fwd_weight(self, a, weight):
+        self.calls.append("det_gemm_fwd_weight")
+        return a @ weight.t()
 
-    def det_gemm_fwd_rhs_transposed(self, a, bt):
-        self.calls.append("det_gemm_fwd_rhs_transposed")
-        return a @ bt.t()
+    def det_gemm_da_weight(self, grad_output, weight):
+        self.calls.append("det_gemm_da_weight")
+        return grad_output @ weight
 
-    def det_gemm_db_transposed(self, a, grad_output):
-        self.calls.append("det_gemm_db_transposed")
-        return grad_output.t() @ a
+    def det_gemm_dw(self, a, grad_output):
+        self.calls.append("det_gemm_dw")
+        return grad_output.t().contiguous() @ a
 
     def swiglu_forward(self, gate, up):
         self.calls.append("swiglu_forward")
@@ -112,6 +127,19 @@ class _TorchKernelStub:
 
     def swiglu_backward(self, grad_output, gate, up):
         self.calls.append("swiglu_backward")
+        sigmoid = torch.sigmoid(gate)
+        grad_gate = grad_output * up * sigmoid * (1.0 + gate * (1.0 - sigmoid))
+        grad_up = grad_output * gate * sigmoid
+        return grad_gate, grad_up
+
+    def swiglu_packed_forward(self, gate_up):
+        self.calls.append("swiglu_packed_forward")
+        gate, up = gate_up.chunk(2, dim=-1)
+        return gate * torch.sigmoid(gate) * up
+
+    def swiglu_packed_backward(self, grad_output, gate_up):
+        self.calls.append("swiglu_packed_backward")
+        gate, up = gate_up.chunk(2, dim=-1)
         sigmoid = torch.sigmoid(gate)
         grad_gate = grad_output * up * sigmoid * (1.0 + gate * (1.0 - sigmoid))
         grad_up = grad_output * gate * sigmoid
@@ -160,9 +188,13 @@ def _shard_ranges(
     return token_start, token_end, feat_start, feat_end
 
 
-def _spawn_nccl_workers(worker, world_size: int, worker_args=(), *, timeout: int = 180) -> None:
+def _spawn_nccl_workers(
+    worker, world_size: int, worker_args=(), *, timeout: int = 180
+) -> None:
     if not _has_sm90_ffn_devices(world_size):
-        pytest.skip(f"requires {world_size} SM90 GPUs, NCCL, and the GEMM/SwiGLU extension")
+        pytest.skip(
+            f"requires {world_size} SM90 GPUs, NCCL, and the GEMM/SwiGLU extension"
+        )
 
     ctx = mp.get_context("spawn")
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -343,7 +375,9 @@ def _distributed_ffn_backward_nccl_worker(
         ), "FFN input gradient changed with the local token batch size"
         result_queue.put({"ok": True, "rank": rank})
     except Exception:  # pragma: no cover - forwarded to the parent process.
-        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        result_queue.put(
+            {"ok": False, "rank": rank, "traceback": traceback.format_exc()}
+        )
         raise
     finally:
         _close_ffn_collectives()
@@ -351,7 +385,9 @@ def _distributed_ffn_backward_nccl_worker(
             torch.distributed.destroy_process_group()
 
 
-def _tp1_vs_tpn_train_infer_worker(rank, world_size, init_method, result_queue, expect_match):
+def _tp1_vs_tpn_train_infer_worker(
+    rank, world_size, init_method, result_queue, expect_match
+):
     try:
         import torch.distributed as dist
 
@@ -364,7 +400,9 @@ def _tp1_vs_tpn_train_infer_worker(rank, world_size, init_method, result_queue, 
         )
         device = torch.device("cuda", rank)
         token_count, hidden_size, intermediate_size = 16, 64, 256
-        hidden = _randn((token_count, hidden_size), seed=50, device=device, dtype=torch.bfloat16)
+        hidden = _randn(
+            (token_count, hidden_size), seed=50, device=device, dtype=torch.bfloat16
+        )
         gate_weight = _randn(
             (intermediate_size, hidden_size),
             seed=51,
@@ -396,7 +434,9 @@ def _tp1_vs_tpn_train_infer_worker(rank, world_size, init_method, result_queue, 
         ]
         train_tp1 = qwen3_ffn(*tp1_inputs)
         train_tp1.backward(grad_output)
-        assert torch.equal(infer_tp1, train_tp1.detach()), "TP=1 train/infer forward mismatch"
+        assert torch.equal(
+            infer_tp1, train_tp1.detach()
+        ), "TP=1 train/infer forward mismatch"
 
         local_i = intermediate_size // world_size
         feat_start = rank * local_i
@@ -425,9 +465,15 @@ def _tp1_vs_tpn_train_infer_worker(rank, world_size, init_method, result_queue, 
             assert train_match, f"TP=1 vs TP={world_size} train forward mismatch"
             assert hidden_match, f"TP=1 vs TP={world_size} hidden grad mismatch"
         else:
-            assert not infer_match, f"TP=1 vs TP={world_size} infer forward unexpectedly matched"
-            assert not train_match, f"TP=1 vs TP={world_size} train forward unexpectedly matched"
-            assert not hidden_match, f"TP=1 vs TP={world_size} hidden grad unexpectedly matched"
+            assert (
+                not infer_match
+            ), f"TP=1 vs TP={world_size} infer forward unexpectedly matched"
+            assert (
+                not train_match
+            ), f"TP=1 vs TP={world_size} train forward unexpectedly matched"
+            assert (
+                not hidden_match
+            ), f"TP=1 vs TP={world_size} hidden grad unexpectedly matched"
 
         assert torch.equal(
             tp1_inputs[1].grad[feat_start:feat_end], tpn_inputs[1].grad
@@ -441,7 +487,9 @@ def _tp1_vs_tpn_train_infer_worker(rank, world_size, init_method, result_queue, 
 
         result_queue.put({"ok": True, "rank": rank})
     except Exception:  # pragma: no cover - forwarded to the parent process.
-        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        result_queue.put(
+            {"ok": False, "rank": rank, "traceback": traceback.format_exc()}
+        )
         raise
     finally:
         _close_ffn_collectives()
@@ -450,10 +498,16 @@ def _tp1_vs_tpn_train_infer_worker(rank, world_size, init_method, result_queue, 
 
 
 def _make_topology_inputs(token_count, device):
-    hidden = _randn((token_count, _HIDDEN), seed=60, device=device, dtype=torch.bfloat16)
-    gate = _randn((_INTERMEDIATE, _HIDDEN), seed=61, device=device, dtype=torch.bfloat16)
+    hidden = _randn(
+        (token_count, _HIDDEN), seed=60, device=device, dtype=torch.bfloat16
+    )
+    gate = _randn(
+        (_INTERMEDIATE, _HIDDEN), seed=61, device=device, dtype=torch.bfloat16
+    )
     up = _randn((_INTERMEDIATE, _HIDDEN), seed=62, device=device, dtype=torch.bfloat16)
-    down = _randn((_HIDDEN, _INTERMEDIATE), seed=63, device=device, dtype=torch.bfloat16)
+    down = _randn(
+        (_HIDDEN, _INTERMEDIATE), seed=63, device=device, dtype=torch.bfloat16
+    )
     grad = _randn((token_count, _HIDDEN), seed=64, device=device, dtype=torch.bfloat16)
     return hidden, gate, up, down, grad
 
@@ -461,7 +515,10 @@ def _make_topology_inputs(token_count, device):
 def _canonical(hidden, gate, up, down, grad):
     with torch.no_grad():
         infer = qwen3_ffn(hidden, gate, up, down)
-    inputs = [value.detach().clone().requires_grad_(True) for value in (hidden, gate, up, down)]
+    inputs = [
+        value.detach().clone().requires_grad_(True)
+        for value in (hidden, gate, up, down)
+    ]
     train = qwen3_ffn(*inputs)
     train.backward(grad)
     return infer, train, inputs
@@ -584,7 +641,9 @@ def _topology_worker(rank, world_size, init_method, result_queue, configs):
             if token_count not in canonical:
                 tensors = _make_topology_inputs(token_count, device)
                 canonical[token_count] = (*tensors, *_canonical(*tensors))
-            hidden, gate, up, down, grad, infer_ref, train_ref, ref_inputs = canonical[token_count]
+            hidden, gate, up, down, grad, infer_ref, train_ref, ref_inputs = canonical[
+                token_count
+            ]
             _run_topology_config(
                 rank,
                 dist,
@@ -604,7 +663,9 @@ def _topology_worker(rank, world_size, init_method, result_queue, configs):
             )
         result_queue.put({"ok": True, "rank": rank})
     except Exception:  # pragma: no cover - forwarded to the parent process.
-        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        result_queue.put(
+            {"ok": False, "rank": rank, "traceback": traceback.format_exc()}
+        )
         raise
     finally:
         _close_ffn_collectives()
@@ -612,11 +673,21 @@ def _topology_worker(rank, world_size, init_method, result_queue, configs):
             torch.distributed.destroy_process_group()
 
 
-def _ffn_tensors(token_count, device, seed, *, hidden=_HIDDEN, intermediate=_INTERMEDIATE):
-    rmsnorm = _randn((token_count, hidden), seed=seed, device=device, dtype=torch.bfloat16)
-    gate = _randn((intermediate, hidden), seed=seed + 1, device=device, dtype=torch.bfloat16)
-    up = _randn((intermediate, hidden), seed=seed + 2, device=device, dtype=torch.bfloat16)
-    down = _randn((hidden, intermediate), seed=seed + 3, device=device, dtype=torch.bfloat16)
+def _ffn_tensors(
+    token_count, device, seed, *, hidden=_HIDDEN, intermediate=_INTERMEDIATE
+):
+    rmsnorm = _randn(
+        (token_count, hidden), seed=seed, device=device, dtype=torch.bfloat16
+    )
+    gate = _randn(
+        (intermediate, hidden), seed=seed + 1, device=device, dtype=torch.bfloat16
+    )
+    up = _randn(
+        (intermediate, hidden), seed=seed + 2, device=device, dtype=torch.bfloat16
+    )
+    down = _randn(
+        (hidden, intermediate), seed=seed + 3, device=device, dtype=torch.bfloat16
+    )
     return rmsnorm, gate, up, down
 
 
@@ -676,7 +747,9 @@ def _cache_worker(rank, world_size, init_method, result_queue):
         _close_ffn_collectives()
         result_queue.put({"ok": True, "rank": rank})
     except Exception:  # pragma: no cover - forwarded to the parent process.
-        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        result_queue.put(
+            {"ok": False, "rank": rank, "traceback": traceback.format_exc()}
+        )
         raise
     finally:
         _close_ffn_collectives()
@@ -723,7 +796,9 @@ def _uneven_sp_worker(rank, world_size, init_method, result_queue):
                 raise
             result_queue.put({"ok": True, "rank": rank})
     except Exception:  # pragma: no cover - forwarded to the parent process.
-        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        result_queue.put(
+            {"ok": False, "rank": rank, "traceback": traceback.format_exc()}
+        )
         raise
     finally:
         _close_ffn_collectives()
@@ -732,7 +807,9 @@ def _uneven_sp_worker(rank, world_size, init_method, result_queue):
 
 
 def _qwen3_8b_weights(device):
-    hidden = _randn((8, QWEN3_8B_HIDDEN_SIZE), seed=90, device=device, dtype=torch.bfloat16)
+    hidden = _randn(
+        (8, QWEN3_8B_HIDDEN_SIZE), seed=90, device=device, dtype=torch.bfloat16
+    )
     gate = _randn(
         (QWEN3_8B_INTERMEDIATE_SIZE, QWEN3_8B_HIDDEN_SIZE),
         seed=91,
@@ -751,7 +828,9 @@ def _qwen3_8b_weights(device):
         device=device,
         dtype=torch.bfloat16,
     )
-    grad = _randn((8, QWEN3_8B_HIDDEN_SIZE), seed=94, device=device, dtype=torch.bfloat16)
+    grad = _randn(
+        (8, QWEN3_8B_HIDDEN_SIZE), seed=94, device=device, dtype=torch.bfloat16
+    )
     return hidden, gate, up, down, grad
 
 
@@ -771,7 +850,8 @@ def _qwen3_8b_tp2_worker(rank, world_size, init_method, result_queue):
         with torch.no_grad():
             infer_tp1 = qwen3_ffn(hidden, gate, up, down)
         tp1_inputs = [
-            value.detach().clone().requires_grad_(True) for value in (hidden, gate, up, down)
+            value.detach().clone().requires_grad_(True)
+            for value in (hidden, gate, up, down)
         ]
         train_tp1 = qwen3_ffn(*tp1_inputs)
         train_tp1.backward(grad)
@@ -796,15 +876,78 @@ def _qwen3_8b_tp2_worker(rank, world_size, init_method, result_queue):
         assert torch.equal(tp1_inputs[0].grad, tp2_inputs[0].grad)
         assert torch.equal(tp1_inputs[1].grad[feat_start:feat_end], tp2_inputs[1].grad)
         assert torch.equal(tp1_inputs[2].grad[feat_start:feat_end], tp2_inputs[2].grad)
-        assert torch.equal(tp1_inputs[3].grad[:, feat_start:feat_end], tp2_inputs[3].grad)
+        assert torch.equal(
+            tp1_inputs[3].grad[:, feat_start:feat_end], tp2_inputs[3].grad
+        )
         result_queue.put({"ok": True, "rank": rank})
     except Exception:  # pragma: no cover - forwarded to the parent process.
-        result_queue.put({"ok": False, "rank": rank, "traceback": traceback.format_exc()})
+        result_queue.put(
+            {"ok": False, "rank": rank, "traceback": traceback.format_exc()}
+        )
         raise
     finally:
         _close_ffn_collectives()
         if torch.distributed.is_available() and torch.distributed.is_initialized():
             torch.distributed.destroy_process_group()
+
+
+def _compiled_packed_tp2_worker(rank, world_size, init_method, result_queue):
+    try:
+        import torch.distributed as dist
+
+        torch.cuda.set_device(rank)
+        dist.init_process_group(
+            backend="nccl",
+            init_method=init_method,
+            rank=rank,
+            world_size=world_size,
+        )
+        device = torch.device("cuda", rank)
+        hidden = _randn((17, 64), seed=141, device=device, dtype=torch.bfloat16)
+        fused = _randn((256, 64), seed=142 + rank, device=device, dtype=torch.bfloat16)
+        down = _randn((64, 128), seed=144 + rank, device=device, dtype=torch.bfloat16)
+        gate, up = fused.chunk(2, dim=0)
+        operator = Qwen3FFNOp()
+
+        with torch.no_grad():
+            expected = operator(
+                hidden,
+                gate,
+                up,
+                down,
+                fused_gate_up_weight=fused,
+                tp_group=dist.group.WORLD,
+                deterministic=True,
+            )
+            collective_handle, tp_world_size = operator.prepare_packed_inference(
+                fused,
+                down,
+                tp_group=dist.group.WORLD,
+            )
+            compiled = torch.compile(qwen3_ffn_packed_inference, fullgraph=True)
+            actual = compiled(
+                hidden,
+                fused,
+                down,
+                collective_handle=collective_handle,
+                tp_world_size=tp_world_size,
+            )
+
+        assert torch.equal(actual, expected)
+        result_queue.put({"ok": True, "rank": rank})
+    except Exception:  # pragma: no cover - forwarded to the parent process.
+        result_queue.put(
+            {"ok": False, "rank": rank, "traceback": traceback.format_exc()}
+        )
+        raise
+    finally:
+        _close_ffn_collectives()
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+def test_qwen_ffn_compiled_packed_tp2_matches_eager_strict():
+    _spawn_nccl_workers(_compiled_packed_tp2_worker, 2)
 
 
 def test_qwen_ffn_qwen3_8b_dimensions_are_pinned():
@@ -841,16 +984,57 @@ def test_qwen_ffn_backward_matches_autograd_reference(monkeypatch):
     torch.testing.assert_close(actual, expected.detach())
     for actual_input, reference in zip(actual_inputs, ref_inputs, strict=True):
         torch.testing.assert_close(actual_input.grad, reference.grad)
-    for weight in actual_inputs[1:]:
-        assert weight.grad is not None
-        assert weight.grad.is_contiguous()
-        assert weight.grad.stride() == weight.stride()
 
-    assert stub.calls.count("det_gemm_fwd") == 3
-    assert stub.calls.count("det_gemm_fwd_rhs_transposed") == 3
-    assert stub.calls.count("det_gemm_db_transposed") == 3
+    assert stub.calls.count("det_gemm_fwd_weight") == 3
+    assert stub.calls.count("det_gemm_da_weight") == 3
+    assert stub.calls.count("det_gemm_dw") == 3
     assert stub.calls.count("swiglu_forward") == 1
     assert stub.calls.count("swiglu_backward") == 1
+
+
+def test_qwen_ffn_packed_gate_up_matches_separate_backward(monkeypatch):
+    stub = _TorchKernelStub()
+    monkeypatch.setattr(ffn_module, "_C", stub)
+    monkeypatch.setattr(ffn_module, "_EXT_AVAILABLE", True)
+    monkeypatch.setattr(ffn_module, "_validate_ffn_inputs", lambda *args: None)
+
+    hidden = _randn((2, 3, 8), seed=10)
+    fused = torch.cat(
+        (_randn((12, 8), seed=11), _randn((12, 8), seed=12)),
+        dim=0,
+    )
+    down = _randn((8, 12), seed=13)
+    grad_output = _randn(hidden.shape, seed=14)
+
+    ref_hidden = hidden.detach().clone().requires_grad_(True)
+    ref_fused = fused.detach().clone().requires_grad_(True)
+    ref_gate, ref_up = ref_fused.chunk(2, dim=0)
+    ref_down = down.detach().clone().requires_grad_(True)
+    expected, _, _, _ = _reference(ref_hidden, ref_gate, ref_up, ref_down)
+    expected.backward(grad_output)
+
+    actual_hidden = hidden.detach().clone().requires_grad_(True)
+    actual_fused = fused.detach().clone().requires_grad_(True)
+    actual_gate, actual_up = actual_fused.chunk(2, dim=0)
+    actual_down = down.detach().clone().requires_grad_(True)
+    actual = qwen3_ffn(
+        actual_hidden,
+        actual_gate,
+        actual_up,
+        actual_down,
+        fused_gate_up_weight=actual_fused,
+    )
+    actual.backward(grad_output)
+
+    torch.testing.assert_close(actual, expected.detach())
+    torch.testing.assert_close(actual_hidden.grad, ref_hidden.grad)
+    torch.testing.assert_close(actual_fused.grad, ref_fused.grad)
+    torch.testing.assert_close(actual_down.grad, ref_down.grad)
+    assert stub.calls.count("det_gemm_fwd_weight") == 2
+    assert stub.calls.count("swiglu_packed_forward") == 1
+    assert stub.calls.count("swiglu_packed_backward") == 1
+    assert stub.calls.count("swiglu_forward") == 0
+    assert stub.calls.count("swiglu_backward") == 0
 
 
 def test_qwen_ffn_disable_split_k_false_uses_torch_matmul(monkeypatch):
@@ -883,9 +1067,9 @@ def test_qwen_ffn_disable_split_k_false_uses_torch_matmul(monkeypatch):
     for actual_input, reference in zip(actual_inputs, ref_inputs, strict=True):
         torch.testing.assert_close(actual_input.grad, reference.grad)
 
-    assert stub.calls.count("det_gemm_fwd") == 0
-    assert stub.calls.count("det_gemm_fwd_rhs_transposed") == 0
-    assert stub.calls.count("det_gemm_db_transposed") == 0
+    assert stub.calls.count("det_gemm_fwd_weight") == 0
+    assert stub.calls.count("det_gemm_da_weight") == 0
+    assert stub.calls.count("det_gemm_dw") == 0
     assert stub.calls.count("swiglu_forward") == 1
     assert stub.calls.count("swiglu_backward") == 1
 
@@ -893,7 +1077,9 @@ def test_qwen_ffn_disable_split_k_false_uses_torch_matmul(monkeypatch):
 def test_qwen_ffn_deterministic_false_uses_production_gemm(monkeypatch):
     modes = []
     monkeypatch.setattr(ffn_module, "_validate_ffn_inputs", lambda *args: None)
-    monkeypatch.setattr(ffn_module, "_require_ffn_kernels", lambda **kwargs: modes.append(kwargs))
+    monkeypatch.setattr(
+        ffn_module, "_require_ffn_kernels", lambda **kwargs: modes.append(kwargs)
+    )
     monkeypatch.setattr(
         ffn_module._DeterministicFFNFunction,
         "apply",
@@ -902,7 +1088,7 @@ def test_qwen_ffn_deterministic_false_uses_production_gemm(monkeypatch):
 
     tensors = [torch.empty(1)] * 4
     assert qwen3_ffn(*tensors, deterministic=False) is False
-    assert modes == [{"disable_split_k": False}]
+    assert modes == [{"disable_split_k": False, "packed_gate_up": False}]
 
 
 def test_qwen_ffn_rejects_conflicting_backend_switches():
@@ -1016,13 +1202,79 @@ def test_qwen_ffn_cuda_train_and_infer_forward_are_bitwise_identical():
 
 
 @requires_cuda_ffn
+def test_qwen_ffn_packed_gate_up_is_bitwise_identical():
+    hidden = _randn((17, 64), seed=40, device="cuda", dtype=torch.bfloat16)
+    fused = torch.cat(
+        (
+            _randn((128, 64), seed=41, device="cuda", dtype=torch.bfloat16),
+            _randn((128, 64), seed=42, device="cuda", dtype=torch.bfloat16),
+        ),
+        dim=0,
+    )
+    down = _randn((64, 128), seed=43, device="cuda", dtype=torch.bfloat16)
+    grad = _randn(hidden.shape, seed=44, device="cuda", dtype=torch.bfloat16)
+
+    separate_hidden = hidden.detach().clone().requires_grad_(True)
+    separate_gate = fused[:128].detach().clone().requires_grad_(True)
+    separate_up = fused[128:].detach().clone().requires_grad_(True)
+    separate_down = down.detach().clone().requires_grad_(True)
+    separate = qwen3_ffn(
+        separate_hidden,
+        separate_gate,
+        separate_up,
+        separate_down,
+    )
+    separate.backward(grad)
+
+    packed_hidden = hidden.detach().clone().requires_grad_(True)
+    packed_fused = fused.detach().clone().requires_grad_(True)
+    packed_gate, packed_up = packed_fused.chunk(2, dim=0)
+    packed_down = down.detach().clone().requires_grad_(True)
+    packed = qwen3_ffn(
+        packed_hidden,
+        packed_gate,
+        packed_up,
+        packed_down,
+        fused_gate_up_weight=packed_fused,
+    )
+    packed.backward(grad)
+
+    assert torch.equal(packed, separate)
+    assert torch.equal(packed_hidden.grad, separate_hidden.grad)
+    assert torch.equal(
+        packed_fused.grad,
+        torch.cat((separate_gate.grad, separate_up.grad), dim=0),
+    )
+    assert torch.equal(packed_down.grad, separate_down.grad)
+
+
+@requires_cuda_ffn
+def test_qwen_ffn_packed_inference_compiles_fullgraph_bitwise():
+    hidden = _randn((17, 64), seed=45, device="cuda", dtype=torch.bfloat16)
+    fused = _randn((256, 64), seed=46, device="cuda", dtype=torch.bfloat16)
+    down = _randn((64, 128), seed=47, device="cuda", dtype=torch.bfloat16)
+
+    expected = qwen3_ffn_packed_inference(hidden, fused, down)
+    compiled = torch.compile(
+        qwen3_ffn_packed_inference,
+        backend="eager",
+        fullgraph=True,
+    )
+    actual = compiled(hidden, fused, down)
+
+    assert torch.equal(actual, expected)
+
+
+@requires_cuda_ffn
 @pytest.mark.parametrize("token_count", _TOKEN_BOUNDARY_COUNTS)
 def test_qwen_ffn_output_and_hidden_grad_are_batch_invariant(token_count):
     device = torch.device("cuda", 0)
     gate = _randn((256, _HIDDEN), seed=70, device=device, dtype=torch.bfloat16)
     up = _randn((256, _HIDDEN), seed=71, device=device, dtype=torch.bfloat16)
     down = _randn((_HIDDEN, 256), seed=72, device=device, dtype=torch.bfloat16)
-    hidden = _randn((token_count, _HIDDEN), seed=73, device=device, dtype=torch.bfloat16)
+    hidden = _randn(
+        (token_count, _HIDDEN), seed=73, device=device, dtype=torch.bfloat16
+    )
     grad = _randn((token_count, _HIDDEN), seed=74, device=device, dtype=torch.bfloat16)
 
     full_hidden = hidden.detach().clone().requires_grad_(True)
@@ -1063,12 +1315,16 @@ def test_qwen_ffn_qwen3_8b_shapes_run_and_are_batch_invariant():
 def test_qwen_ffn_sequence_parallel_requires_tensor_parallel_group():
     device = torch.device("cuda", 0)
     hidden, gate, up, down = _ffn_tensors(8, device, seed=120, intermediate=128)
-    with pytest.raises(ValueError, match="sequence_parallel requires a tensor-parallel group"):
+    with pytest.raises(
+        ValueError, match="sequence_parallel requires a tensor-parallel group"
+    ):
         qwen3_ffn(hidden, gate, up, down, sequence_parallel=True)
 
 
 def test_qwen_ffn_tp_correctness_and_batch_invariance():
-    _spawn_nccl_workers(_distributed_ffn_backward_nccl_worker, 2, (1, False), timeout=90)
+    _spawn_nccl_workers(
+        _distributed_ffn_backward_nccl_worker, 2, (1, False), timeout=90
+    )
 
 
 def test_qwen_ffn_tp_sp_correctness_and_batch_invariance():
@@ -1076,7 +1332,9 @@ def test_qwen_ffn_tp_sp_correctness_and_batch_invariance():
 
 
 def test_qwen_ffn_tp_cp_correctness_and_batch_invariance():
-    _spawn_nccl_workers(_distributed_ffn_backward_nccl_worker, 4, (2, False), timeout=90)
+    _spawn_nccl_workers(
+        _distributed_ffn_backward_nccl_worker, 4, (2, False), timeout=90
+    )
 
 
 def test_qwen_ffn_tp_cp_sp_correctness_and_batch_invariance():
@@ -1100,7 +1358,9 @@ def test_qwen_ffn_world4_tp_cp_sp_match_tp1_cp1_bitwise():
 
 
 def test_qwen_ffn_world8_tp8_and_cp8_match_tp1_cp1_bitwise():
-    _spawn_nccl_workers(_topology_worker, 8, (_WORLD8_WORLD_GROUP_CONFIGS,), timeout=120)
+    _spawn_nccl_workers(
+        _topology_worker, 8, (_WORLD8_WORLD_GROUP_CONFIGS,), timeout=120
+    )
 
 
 def test_qwen_ffn_world8_tp2_cp4_match_tp1_cp1_bitwise():

--- a/tests/test_rms_norm.py
+++ b/tests/test_rms_norm.py
@@ -6,7 +6,11 @@ import torch
 import torch.nn.functional as F
 
 from rl_engine.kernels.ops.cuda.norm.rmsnorm import RMSNormCudaOp, rmsnorm_cuda
-from rl_engine.kernels.ops.pytorch.norm.rms_norm import NativeRMSNormOp
+from rl_engine.kernels.ops.pytorch.norm.rms_norm import (
+    NativeRMSNormOp,
+    strict_add_rms_norm,
+    strict_rms_norm,
+)
 from rl_engine.kernels.ops.triton.rmsnorm_triton import rmsnorm_triton
 
 try:
@@ -16,13 +20,34 @@ try:
         hasattr(_C, name)
         for name in ("rmsnorm_forward", "rmsnorm_backward_dx", "rmsnorm_backward_dw")
     )
-except ImportError:  # pragma: no cover - import can fail when the extension is not built.
+except (
+    ImportError
+):  # pragma: no cover - import can fail when the extension is not built.
     _HAS_CUDA_RMSNORM = False
 
 # Qwen3-8B normalized dims this op must cover.
 _HIDDEN = 4096  # input / post-attention norm
 _HEAD_DIM = 128  # QK-Norm (per-head RMSNorm on Q and K)
 _EPS = 1e-6
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_strict_rms_norm_is_bitwise_under_inductor():
+    x = torch.randn((17, 128), device="cuda", dtype=torch.bfloat16)
+    residual = torch.randn_like(x)
+    weight = torch.randn((128,), device="cuda", dtype=torch.bfloat16)
+
+    expected = strict_rms_norm(x, weight, eps=_EPS)
+    expected_fused = strict_add_rms_norm(x, residual, weight, eps=_EPS)
+    compiled_norm = torch.compile(strict_rms_norm, fullgraph=True)
+    compiled_fused = torch.compile(strict_add_rms_norm, fullgraph=True)
+
+    actual = compiled_norm(x, weight, eps=_EPS)
+    actual_fused = compiled_fused(x, residual, weight, eps=_EPS)
+
+    assert torch.equal(actual, expected)
+    assert torch.equal(actual_fused[0], expected_fused[0])
+    assert torch.equal(actual_fused[1], expected_fused[1])
 
 
 # Shared helpers
@@ -73,8 +98,12 @@ def _build_padded_layout(x_real, dy_real, total_rows, real_positions):
     assert len(real_positions) == real_rows
     assert total_rows >= real_rows
 
-    x_pad = torch.randn((total_rows, hidden), device=device, dtype=torch.float32).to(dtype)
-    dy_pad = torch.randn((total_rows, hidden), device=device, dtype=torch.float32).to(dtype)
+    x_pad = torch.randn((total_rows, hidden), device=device, dtype=torch.float32).to(
+        dtype
+    )
+    dy_pad = torch.randn((total_rows, hidden), device=device, dtype=torch.float32).to(
+        dtype
+    )
     mask = torch.zeros((total_rows,), device=device, dtype=torch.bool)
 
     for src_t, dst_t in enumerate(real_positions):
@@ -98,7 +127,9 @@ requires_cuda_rmsnorm = pytest.mark.skipif(
     reason="CUDA RMSNorm extension is not available",
 )
 
-requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is required"
+)
 
 
 # 1. Primary correctness check vs PyTorch's own F.rms_norm. This is a *truly*
@@ -250,8 +281,12 @@ def test_registry_dispatches_rms_norm():
 @requires_cuda
 @pytest.mark.parametrize("impl", ["triton", "cuda"])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
-@pytest.mark.parametrize("rows, hidden", [(1, 128), (8, 768), (32, 2048), (128, _HIDDEN)])
-def test_cuda_triton_rms_norm_matches_native_forward_and_backward(impl, dtype, rows, hidden):
+@pytest.mark.parametrize(
+    "rows, hidden", [(1, 128), (8, 768), (32, 2048), (128, _HIDDEN)]
+)
+def test_cuda_triton_rms_norm_matches_native_forward_and_backward(
+    impl, dtype, rows, hidden
+):
     if impl == "cuda" and not _HAS_CUDA_RMSNORM:
         pytest.skip("CUDA RMSNorm extension is not available")
 
@@ -278,8 +313,12 @@ def test_cuda_triton_rms_norm_matches_native_forward_and_backward(impl, dtype, r
 
     atol, rtol = _dtype_tolerance(dtype)
     dw_scale = max(1.0, rows**0.5 / 4.0)
-    torch.testing.assert_close(y_gpu.detach().cpu().float(), y_ref.detach(), atol=atol, rtol=rtol)
-    torch.testing.assert_close(x_gpu.grad.detach().cpu().float(), x_ref.grad, atol=atol, rtol=rtol)
+    torch.testing.assert_close(
+        y_gpu.detach().cpu().float(), y_ref.detach(), atol=atol, rtol=rtol
+    )
+    torch.testing.assert_close(
+        x_gpu.grad.detach().cpu().float(), x_ref.grad, atol=atol, rtol=rtol
+    )
     torch.testing.assert_close(
         w_gpu.grad.detach().cpu().float(),
         w_ref.grad,
@@ -332,7 +371,9 @@ def test_triton_rms_norm_long_context_dw_reduction():
     y_gpu.backward(dy_gpu)
 
     assert w_gpu.grad.dtype == w_gpu.dtype
-    torch.testing.assert_close(y_gpu.detach().cpu().float(), y_ref.detach(), atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(
+        y_gpu.detach().cpu().float(), y_ref.detach(), atol=2e-2, rtol=2e-2
+    )
     torch.testing.assert_close(
         w_gpu.grad.detach().cpu().float(),
         w_ref.grad,

--- a/tests/test_runtime_mode.py
+++ b/tests/test_runtime_mode.py
@@ -1,0 +1,31 @@
+import pytest
+
+from rl_engine.runtime_mode import (
+    RLKernelMode,
+    rl_kernel_mode,
+    rl_kernel_mode_policy,
+)
+
+
+@pytest.mark.parametrize(
+    ("mode", "enabled", "case_id", "provider_mode", "fail_on_fallback"),
+    (
+        ("strict", True, "R/R", "strict", True),
+        ("audit", True, "R/R", "strict", False),
+        ("auto", True, "P/P", "auto", False),
+        ("off", False, "P/P", None, False),
+    ),
+)
+def test_mode_policy(mode, enabled, case_id, provider_mode, fail_on_fallback):
+    policy = rl_kernel_mode_policy(mode)
+
+    assert policy.mode is RLKernelMode(mode)
+    assert policy.enabled is enabled
+    assert policy.case_id == case_id
+    assert policy.provider_mode == provider_mode
+    assert policy.fail_on_fallback is fail_on_fallback
+
+
+def test_mode_rejects_unknown_value():
+    with pytest.raises(RuntimeError, match="RL_KERNEL_MODE must be one of"):
+        rl_kernel_mode("unexpected")

--- a/tests/test_vime_logprob_provider.py
+++ b/tests/test_vime_logprob_provider.py
@@ -13,6 +13,11 @@ import torch
 from rl_engine.integrations.vime.logp import SelectedLogprobProviderUnavailable, provider
 
 
+@pytest.fixture(autouse=True)
+def _select_rlkernel_training_logp(monkeypatch):
+    monkeypatch.setenv("RL_KERNEL_LOGP_CASE", "R/R")
+
+
 def _request(*, cp_rank: int = 0, with_entropy: bool = False, keep_mask=None):
     logits = torch.tensor(
         [[0.25, -0.5, 1.0, 0.1, -0.3, 0.6, -0.7, 0.4] for _ in range(3)],
@@ -91,3 +96,10 @@ def test_provider_rejects_local_vocab_metadata_that_cannot_describe_tp_ownership
 
     with pytest.raises(SelectedLogprobProviderUnavailable, match="cover padded_vocab_size"):
         provider(request)
+
+
+def test_provider_production_training_case_requests_vime_native_fallback(monkeypatch):
+    monkeypatch.setenv("RL_KERNEL_LOGP_CASE", "P/R")
+
+    with pytest.raises(SelectedLogprobProviderUnavailable, match="Vime's native"):
+        provider(_request())

--- a/tests/test_vime_logprob_provider.py
+++ b/tests/test_vime_logprob_provider.py
@@ -10,7 +10,16 @@ from types import SimpleNamespace
 import pytest
 import torch
 
-from rl_engine.integrations.vime.logp import SelectedLogprobProviderUnavailable, provider
+from rl_engine.integrations.vime.linear_logp import (
+    SelectedLogprobProviderUnavailable,
+    provider,
+)
+
+
+def test_legacy_provider_path_is_an_alias():
+    from rl_engine.integrations.vime.logp import provider as legacy_provider
+
+    assert legacy_provider is provider
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_vime_qwen3_example.py
+++ b/tests/test_vime_qwen3_example.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -15,6 +17,9 @@ from examples.vime_qwen3_8b_tp2_cp2.run import (
 
 ROOT = Path(__file__).parents[1]
 CONFIG = ROOT / "examples" / "vime_qwen3_8b_tp2_cp2" / "qwen3_8b_tp2_cp2.json"
+PYTHON_ENTRYPOINT = (
+    ROOT / "examples" / "vime_qwen3_8b_tp2_cp2" / "aligned_python_entrypoint.sh"
+)
 
 
 def test_qwen3_example_config_is_strict_and_explicit():
@@ -23,6 +28,14 @@ def test_qwen3_example_config_is_strict_and_explicit():
     assert config["training"]["tensor_model_parallel_size"] == 2
     assert config["training"]["context_parallel_size"] == 2
     assert config["selected_logprob_provider"]["mode"] == "strict"
+    assert (
+        config["selected_logprob_provider"]["path"]
+        == "rl_engine.integrations.vime.linear_logp.provider"
+    )
+    assert (
+        config["selected_logprob_provider"]["backend_id"]
+        == "rlkernel.linear_logp.bitwise.v1"
+    )
 
 
 def test_qwen3_example_report_does_not_claim_unread_back_attention_or_ffn(tmp_path):
@@ -34,7 +47,7 @@ def test_qwen3_example_report_does_not_claim_unread_back_attention_or_ffn(tmp_pa
         command=["bash", "run.sh"],
         status="passed",
         returncode=0,
-        log_text="Selected-logprob provider active: backend_id=pytorch-vocab-parallel-logp-ws2",
+        log_text="Selected-logprob provider active: backend_id=rlkernel.linear_logp.bitwise.v1",
         log_path=tmp_path / "run.log",
     )
     assert report["status"] == "passed"
@@ -117,7 +130,7 @@ def test_qwen3_example_accepts_only_exact_zero_runtime_evidence(tmp_path):
         command=["bash", "run.sh"],
         status="passed",
         returncode=0,
-        log_text="Selected-logprob provider active: backend_id=pytorch-vocab-parallel-logp-ws2",
+        log_text="Selected-logprob provider active: backend_id=rlkernel.linear_logp.bitwise.v1",
         log_path=None,
         runtime_evidence=evidence,
     )
@@ -138,3 +151,53 @@ def test_qwen3_example_rejects_non_rlkernel_provider(bad_path):
     config["selected_logprob_provider"]["path"] = bad_path
     with pytest.raises(ValueError, match="RL-Kernel Vime provider"):
         validate_config(config)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="the Vime launcher is a Bash entrypoint")
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    (
+        ("off", ["train.py", "--keep", "value"]),
+        (
+            "strict",
+            [
+                "train.py",
+                "--custom-megatron-init-path",
+                "old.init",
+                "--selected-logprob-provider",
+                "rl_engine.integrations.vime.linear_logp.provider",
+                "--selected-logprob-provider-mode",
+                "strict",
+                "--keep",
+                "value",
+            ],
+        ),
+    ),
+)
+def test_python_entrypoint_controls_provider_injection(mode, expected):
+    env = {
+        **os.environ,
+        "RL_KERNEL_REAL_PYTHON": "/bin/echo",
+        "RL_KERNEL_MODE": mode,
+        "RL_KERNEL_ALIGNED": "0",
+    }
+    result = subprocess.run(
+        [
+            str(PYTHON_ENTRYPOINT),
+            "train.py",
+            "--custom-megatron-init-path",
+            "old.init",
+            "--selected-logprob-provider",
+            "old.provider",
+            "--selected-logprob-provider-mode",
+            "strict",
+            "--keep",
+            "value",
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.stdout.split() == expected

--- a/tests/test_vime_validation_artifacts.py
+++ b/tests/test_vime_validation_artifacts.py
@@ -75,3 +75,45 @@ def test_vime_artifacts_reject_triton_even_when_values_match(tmp_path):
 
     assert report["passed"] is False
     assert "vllm/rollout attention used Triton" in report["readbacks"]["errors"]
+
+
+def test_vime_artifacts_accept_successful_zero_threshold_runtime_assertion(tmp_path):
+    readbacks = tmp_path / "readbacks"
+    train_data = tmp_path / "train-data"
+    readbacks.mkdir()
+    train_data.mkdir()
+    _write_readback(readbacks, "megatron", "training")
+    _write_readback(readbacks, "vllm", "rollout")
+    rollout = [torch.tensor([-1.25]), torch.tensor([-2.5, -3.0])]
+    torch.save({"rollout_data": {"rollout_log_probs": rollout}}, train_data / "0.pt")
+
+    report = validate_artifacts(
+        readbacks,
+        train_data,
+        runtime_ci_zero_threshold_passed=True,
+    )
+
+    assert report["passed"] is True
+    assert report["train_rollout_logp"]["comparison_mode"] == "runtime_ci_zero_threshold"
+    assert report["train_rollout_logp"]["runtime_asserted_sample_count"] == 2
+    assert report["train_rollout_logp"]["element_count"] == 3
+
+
+def test_vime_artifacts_reject_missing_training_values_without_runtime_assertion(tmp_path):
+    readbacks = tmp_path / "readbacks"
+    train_data = tmp_path / "train-data"
+    readbacks.mkdir()
+    train_data.mkdir()
+    _write_readback(readbacks, "megatron", "training")
+    _write_readback(readbacks, "vllm", "rollout")
+    torch.save(
+        {"rollout_data": {"rollout_log_probs": [torch.tensor([-1.25])]}},
+        train_data / "0.pt",
+    )
+
+    report = validate_artifacts(readbacks, train_data)
+
+    assert report["passed"] is False
+    assert "no successful zero-threshold runtime CI assertion" in " ".join(
+        report["train_rollout_logp"]["errors"]
+    )


### PR DESCRIPTION
## Summary

This publishes the complete RL-Kernel side of the Qwen3-8B TP=2, CP=2 strict
train/rollout consistency work on top of the current `test` branch.

- restores the strict Megatron and vLLM Attention, FFN, collective, and
  `linear_logp` runtime routes used by the 8xH100 validation;
- keeps every strict Attention, GEMM, FFN, and logprob route fail-closed;
- defaults the aligned Hopper runtime to deterministic cuBLASLt no-split-K
  GEMM while retaining the explicit SM90 backend;
- adds `RL_KERNEL_MODE=strict|audit|auto|off` as the user-facing integration
  contract;
- reports `interface`, `operator`, `actual`, and `fallback` once per module on
  rank 0 by default;
- exposes the canonical provider as
  `rl_engine.integrations.vime.linear_logp.provider`, while keeping the old
  provider path compatible;
- keeps all framework changes in RL-Kernel-owned adapters. No Vime, Megatron,
  or vLLM native source is modified.

The branch was rebuilt from `origin/test` before publication, so the earlier
local WIP snapshot is not present in the PR history.

## 8xH100 evidence

Qwen3-8B, TP=2, CP=2, strict aligned R/R:

```text
mismatch_count=0
max_abs_diff=0
torch_equal=true
steady rollout=1.0173s
steady actor=0.8536s
steady step=22.8104s
```

Artifact directory on the validation host:

```text
/home/ellm/ljj/vime-debug-main/outputs/rlkernel/fair-rr-aligned-cublaslt-20260826T152921Z
```

## Tests

```text
66 passed, 44 skipped
```

The skipped cases require CUDA. `bash -n` and `git diff --check` also pass.
