### PR TITLE
Feat/strict embedding backward

### DIFF
--- a/docs/operators/embedding.md
+++ b/docs/operators/embedding.md
@@ -33,7 +33,8 @@ The op exposes the WS1 dual-path contract:
 | --- | --- | --- | --- |
 | PyTorch fallback | `NativeEmbeddingOp` | None | fp32 ground-truth reference; CPU and any GPU. |
 | CUDA SM90 (H200/Hopper) | `SM90EmbeddingOp` | `_C.embedding_sm90_forward` | Single-card batch-invariant forward backend; deterministic duplicate-id backward in the wrapper. |
-| ROCm / Triton | N/A | N/A | Falls back to the PyTorch native reference. |
+| Triton | `TritonEmbeddingOp` | `_embedding_fwd`, `_embedding_bwd` | CUDA gather with deterministic, atomic-free sorted-segment backward. |
+| ROCm | N/A | N/A | Falls back to the PyTorch native reference. |
 
 ## Tensor Contract
 
@@ -86,27 +87,39 @@ nondeterminism for repeated token ids at the cost of throughput.
 ## Tests
 
 ```bash
-python -m pytest tests/test_embedding.py -v
+python -m pytest \
+  tests/test_embedding.py \
+  tests/test_triton_embedding.py \
+  tests/test_canonical_embedding.py -v
 ```
 
 Covers: correctness vs direct indexing (bitwise), dtype paths, non-int64 id tolerance,
 Axis-A batch invariance (slice + padding), input purity, gradient flow to `weight`
 (including sparse-grad: unused rows stay zero), registry dispatch, and a GPU-only smoke
 test at the real Qwen3-8B dims (`vocab=151936, hidden=4096`, boundary ids `0` and
-`vocab-1`) that skips when CUDA or GPU memory is unavailable.
+`vocab-1`) that skips when CUDA or GPU memory is unavailable. Additional tests cover the
+Triton sorted-segment backward and canonical logical-row ordering.
 
 ## Implementation Files
 
 - `rl_engine/kernels/ops/pytorch/linear/embedding.py`
+- `rl_engine/kernels/ops/triton/linear/embedding.py`
 - `rl_engine/kernels/ops/cuda/linear/embedding.py`
+- `rl_engine/kernels/ops/canonical_embedding.py`
 - `csrc/cuda/embedding_lm_head_sm90.cu`
 - `rl_engine/kernels/registry.py`
 - `tests/test_embedding.py`
+- `tests/test_triton_embedding.py`
+- `tests/test_canonical_embedding.py`
 
 ## Known Limitations
 
-- The CUDA SM90 path is single-card coverage; TP/vocab-parallel and Triton embedding
-  backends are outside this PR.
-- Token ids must be in `[0, vocab)`. The SM90 host path validates the range before the
-  kernel launch and raises instead of masking invalid ids.
+- The CUDA SM90 and Triton paths are single-card coverage, not TP/vocab-parallel
+  integration paths.
+- Token ids must be in `[0, vocab)`. The Triton fast path reports invalid ids
+  asynchronously; use its explicit validator when the error must be raised at the call
+  boundary.
 - The deterministic SM90 backward is a reference path, not a tuned training kernel.
+- The standalone operator has no logical-row metadata, so its deterministic guarantee is
+  limited to a fixed flattened order. Cross-layout and cross-chunk invariance requires the
+  canonical Qwen training wrapper and its logical keys.

--- a/rl_engine/alignment/qwen3_dense.py
+++ b/rl_engine/alignment/qwen3_dense.py
@@ -21,6 +21,7 @@ import torch
 from rl_engine.kernels.gtest.gradient_adapters import resolve_profile_candidate
 from rl_engine.kernels.gtest.operator_specs import OP_SPECS, _load_object
 from rl_engine.kernels.ops.canonical_backward import active_session
+from rl_engine.kernels.ops.canonical_embedding import canonical_embedding
 from rl_engine.kernels.ops.canonical_linear import canonical_linear_fp32
 from rl_engine.kernels.ops.canonical_lm_head import (
     canonical_cuda_lm_head_fp32,
@@ -793,7 +794,7 @@ class Qwen3DenseBIModel:
             q_parts: list[torch.Tensor] = []
             k_parts: list[torch.Tensor] = []
             v_parts: list[torch.Tensor] = []
-            for hidden, (start, end) in zip(hidden_parts, chunks):
+            for hidden, (start, end) in zip(hidden_parts, chunks, strict=True):
                 self._current_logical_keys = logical_keys[:, start:end]
                 normed = self._rms(
                     hidden.to(dtype=self.execution_dtype),
@@ -845,7 +846,7 @@ class Qwen3DenseBIModel:
             self._record(f"{prefix}.attn", attn_public)
 
             next_hidden_parts: list[torch.Tensor] = []
-            for hidden, (start, end) in zip(hidden_parts, chunks):
+            for hidden, (start, end) in zip(hidden_parts, chunks, strict=True):
                 self._current_logical_keys = logical_keys[:, start:end]
                 attn = attn_all[:, :, start:end, :]
                 attn_merged = (
@@ -905,7 +906,7 @@ class Qwen3DenseBIModel:
         hidden_outputs: list[torch.Tensor] = []
         lm_head_op = self.profile_ops.get("lm_head")
         lm_family = self.profile_ops.provenance["lm_head"]["actual_backend"]
-        for hidden, (start, end) in zip(hidden_parts, chunks):
+        for hidden, (start, end) in zip(hidden_parts, chunks, strict=True):
             keys = logical_keys[:, start:end]
             self._current_logical_keys = keys
             final_hidden = self._rms(
@@ -1006,7 +1007,19 @@ class Qwen3DenseBIModel:
 
     def _embed(self, input_ids: torch.Tensor) -> torch.Tensor:
         op = self.profile_ops.get("embedding")
-        out = op.forward(input_ids, self.weights["embed_tokens.weight"])
+        weight = self.weights["embed_tokens.weight"]
+        keys = getattr(self, "_current_logical_keys", None)
+        if torch.is_grad_enabled() and active_session() is not None and keys is not None:
+            family = self.profile_ops.provenance["embedding"]["actual_backend"]
+            out = canonical_embedding(
+                input_ids,
+                weight,
+                keys,
+                forward_op=op.forward,
+                family=family,
+            )
+        else:
+            out = op.forward(input_ids, weight)
         self.profile_ops.observe("embedding", out)
         return self._record("embedding", out)
 

--- a/rl_engine/integrations/framework_operators.py
+++ b/rl_engine/integrations/framework_operators.py
@@ -16,8 +16,12 @@ from threading import Lock
 from typing import Any, Mapping, cast
 
 import torch
+
 from rl_engine.alignment.cross_config.operators import OperatorBridge, OperatorOverride
-from rl_engine.integrations.linear_logp import LinearLogpWrapper, take_rollout_linear_logp_context
+from rl_engine.integrations.linear_logp import (
+    LinearLogpWrapper,
+    take_rollout_linear_logp_context,
+)
 from rl_engine.kernels.attention_contract import (
     STRICT_ATTENTION_FA4_SCHEDULE_ID,
     STRICT_ATTENTION_PRODUCTION_CORE_ID,
@@ -28,13 +32,22 @@ from rl_engine.kernels.attention_contract import (
 )
 from rl_engine.kernels.attention_contract import ReductionSpec as AttentionReductionSpec
 from rl_engine.kernels.attention_contract import ShardingSpec as AttentionShardingSpec
-from rl_engine.kernels.attention_contract import SplitKVSpec
-from rl_engine.kernels.logprob_contract import LogprobContract, LogprobDType, LogprobRole, MaskSpec
+from rl_engine.kernels.attention_contract import (
+    SplitKVSpec,
+)
+from rl_engine.kernels.logprob_contract import (
+    LogprobContract,
+    LogprobDType,
+    LogprobRole,
+    MaskSpec,
+)
 from rl_engine.kernels.logprob_contract import ReductionSpec as LogprobReductionSpec
 from rl_engine.kernels.logprob_contract import ShardingSpec as LogprobShardingSpec
 from rl_engine.kernels.ops.pytorch.attention.ablation import AttentionAblationConfig
 from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import BACKEND_ID as LOGP_BACKEND_ID
-from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import DEFAULT_NUM_VOCAB_TILES
+from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import (
+    DEFAULT_NUM_VOCAB_TILES,
+)
 from rl_engine.kernels.registry import kernel_registry
 from rl_engine.kernels.semantic_registry import OperatorRequirements
 
@@ -1087,7 +1100,10 @@ class VllmLogpOperator:
         native_selected = values[
             torch.arange(values.size(0), device=values.device), columns
         ].clone()
-        values[torch.arange(values.size(0), device=values.device), columns] = selected
+        # vLLM prepends the sampled token and then appends top-k tokens. When
+        # the sample is also in top-k, its API conversion keeps the last
+        # duplicate, so every matching column must carry the strict value.
+        values = torch.where(matches, selected.unsqueeze(1), values)
         self._last_provenance = {
             **dict(provenance),
             "sampled_token_ids": _tensor_debug_stats(token_ids),

--- a/rl_engine/integrations/megatron_runtime.py
+++ b/rl_engine/integrations/megatron_runtime.py
@@ -9,6 +9,8 @@ import importlib
 from collections.abc import Iterable
 from typing import Any
 
+import torch
+
 from rl_engine.integrations.ablation import Implementation, IntegrationPlan
 from rl_engine.integrations.framework_operators import (
     MegatronAttentionOperator,
@@ -21,6 +23,8 @@ from rl_engine.integrations.state import get_active_integration, set_active_inte
 from rl_engine.integrations.vime.logp import _provider_impl
 
 _PATCH_MARKER = "__rl_kernel_original_forward__"
+_STRICT_ATTENTION_PATCH_MARKER = "__rl_kernel_original_strict_attention_init__"
+_STRICT_ATTENTION_PROJECTION_MARKER = "__rl_kernel_strict_attention_projection__"
 
 
 def _optional_class(path: str) -> type[Any] | None:
@@ -72,6 +76,81 @@ def _patch_forward(
     cls.forward = wrapped
 
 
+def _patch_strict_attention_projections(
+    *,
+    self_attention_cls: type[Any] | None = None,
+    column_linear_cls: type[Any] | None = None,
+    row_linear_cls: type[Any] | None = None,
+    det_gemm: Any | None = None,
+) -> None:
+    """Use the shared deterministic GEMM for Megatron Attention projections."""
+
+    if self_attention_cls is None or column_linear_cls is None or row_linear_cls is None:
+        from megatron.core.tensor_parallel.layers import (
+            ColumnParallelLinear,
+            RowParallelLinear,
+        )
+        from megatron.core.transformer.attention import SelfAttention
+
+        self_attention_cls = SelfAttention
+        column_linear_cls = ColumnParallelLinear
+        row_linear_cls = RowParallelLinear
+    if hasattr(self_attention_cls, _STRICT_ATTENTION_PATCH_MARKER):
+        return
+    if det_gemm is None:
+        from rl_engine.kernels.ops.cuda.matmul.det_gemm import DetGemmOp
+
+        det_gemm = DetGemmOp()
+
+    attention_init = self_attention_cls.__init__
+    column_forward_impl = column_linear_cls._forward_impl
+    row_forward_impl = row_linear_cls._forward_impl
+
+    def deterministic_projection(
+        input_value: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        input_2d = input_value.reshape(-1, input_value.shape[-1])
+        output_2d = det_gemm(input_2d, weight.t().contiguous())
+        output = output_2d.reshape(*input_value.shape[:-1], weight.shape[0])
+        return output if bias is None else output + bias
+
+    def attention_init_wrapped(instance: Any, *args: Any, **kwargs: Any) -> None:
+        attention_init(instance, *args, **kwargs)
+        setattr(instance.linear_qkv, _STRICT_ATTENTION_PROJECTION_MARKER, "qkv")
+        setattr(instance.linear_proj, _STRICT_ATTENTION_PROJECTION_MARKER, "o_proj")
+        # copy_to_tensor_model_parallel_region already owns this TP dgrad reduction.
+        instance.linear_qkv.allreduce_dgrad = False
+
+    def column_forward_impl_wrapped(
+        instance: Any,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if hasattr(instance, _STRICT_ATTENTION_PROJECTION_MARKER):
+            return deterministic_projection(input, weight, kwargs.get("bias"))
+        return column_forward_impl(instance, input, weight, *args, **kwargs)
+
+    def row_forward_impl_wrapped(
+        instance: Any,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if hasattr(instance, _STRICT_ATTENTION_PROJECTION_MARKER):
+            return deterministic_projection(input, weight, kwargs.get("bias"))
+        return row_forward_impl(instance, input, weight, *args, **kwargs)
+
+    setattr(self_attention_cls, _STRICT_ATTENTION_PATCH_MARKER, attention_init)
+    self_attention_cls.__init__ = attention_init_wrapped
+    column_linear_cls._forward_impl = column_forward_impl_wrapped
+    row_linear_cls._forward_impl = row_forward_impl_wrapped
+
+
 def install_megatron_integration(
     plan: IntegrationPlan,
     *,
@@ -112,6 +191,8 @@ def install_megatron_integration(
         raise RuntimeError("R/R Megatron FFN selected but no supported class was found")
 
     set_active_integration("megatron", integration)
+    if plan.implementation_for("attention", "training") is Implementation.RL_KERNEL:
+        _patch_strict_attention_projections()
     for cls in resolved_attention:
         _patch_forward(cls, integration=integration, module="attention")
     if resolved_attention:

--- a/rl_engine/integrations/vllm_runtime.py
+++ b/rl_engine/integrations/vllm_runtime.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
+import importlib
 import os
+import sys
 from typing import Any
 
 import torch
+
 from rl_engine.integrations.ablation import (
     Implementation,
     IntegrationPlan,
@@ -28,6 +31,8 @@ from rl_engine.integrations.state import get_active_integration, set_active_inte
 from rl_engine.integrations.vllm import VllmIntegration
 
 _PATCH_MARKER = "__rl_kernel_original_forward__"
+_STRICT_MODEL_PATCH_MARKER = "__rl_kernel_original_strict_model_init__"
+_STRICT_PROJECTION_MARKER = "__rl_kernel_strict_attention_projection__"
 _RLK_ATTENTION_BACKEND: type[Any] | None = None
 _RLK_ATTENTION_IMPL: type[Any] | None = None
 
@@ -237,6 +242,96 @@ def _patch_qwen_ffn(integration: VllmIntegration) -> None:
     integration.record_installed_hook("ffn", "vllm.model_executor.models.qwen2.Qwen2MLP.forward")
 
 
+def _install_flash_attn_ops_compatibility() -> None:
+    """Supply the legacy rotary import tree when an FA4-only package is installed."""
+
+    try:
+        importlib.import_module("flash_attn.ops.triton.rotary")
+        return
+    except (ImportError, OSError, RuntimeError):
+        pass
+
+    from vllm.vllm_flash_attn import ops as bundled_ops
+    from vllm.vllm_flash_attn.ops import triton as bundled_triton
+    from vllm.vllm_flash_attn.ops.triton import rotary as bundled_rotary
+
+    sys.modules.setdefault("flash_attn.ops", bundled_ops)
+    sys.modules.setdefault("flash_attn.ops.triton", bundled_triton)
+    sys.modules.setdefault("flash_attn.ops.triton.rotary", bundled_rotary)
+
+
+def _patch_qwen3_strict_model(
+    *,
+    rms_norm_cls: type[Any] | None = None,
+    linear_method_cls: type[Any] | None = None,
+    attention_cls: type[Any] | None = None,
+    det_gemm: Any | None = None,
+) -> None:
+    """Align vLLM's RMSNorm and Attention projections with Megatron."""
+
+    if rms_norm_cls is None or linear_method_cls is None or attention_cls is None:
+        from vllm.model_executor.layers.layernorm import RMSNorm
+        from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+        from vllm.model_executor.models.qwen3 import Qwen3Attention
+
+        rms_norm_cls = RMSNorm
+        linear_method_cls = UnquantizedLinearMethod
+        attention_cls = Qwen3Attention
+    if hasattr(attention_cls, _STRICT_MODEL_PATCH_MARKER):
+        return
+    if det_gemm is None:
+        from rl_engine.kernels.ops.cuda.matmul.det_gemm import DetGemmOp
+
+        det_gemm = DetGemmOp()
+
+    attention_init = attention_cls.__init__
+    unquantized_apply = linear_method_cls.apply
+
+    def deterministic_linear_apply(
+        method: Any,
+        layer: Any,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if not hasattr(layer, _STRICT_PROJECTION_MARKER):
+            return unquantized_apply(method, layer, x, bias)
+        x_2d = x.reshape(-1, x.shape[-1])
+        output_2d = det_gemm(x_2d, layer.weight.t().contiguous())
+        output = output_2d.reshape(*x.shape[:-1], layer.weight.shape[0])
+        return output if bias is None else output + bias
+
+    def strict_rms_norm_forward_cuda(
+        instance: Any,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if instance.variance_size_override is not None:
+            return instance.forward_native(x, residual)
+        if residual is not None:
+            residual = x + residual
+            x = residual
+        weight = instance.weight.data if instance.has_weight else None
+        normalized = torch.nn.functional.rms_norm(
+            x,
+            (instance.hidden_size,),
+            weight,
+            instance.variance_epsilon,
+        )
+        if residual is None:
+            return normalized
+        return normalized, residual
+
+    def attention_init_wrapped(instance: Any, *args: Any, **kwargs: Any) -> None:
+        attention_init(instance, *args, **kwargs)
+        setattr(instance.qkv_proj, _STRICT_PROJECTION_MARKER, "qkv")
+        setattr(instance.o_proj, _STRICT_PROJECTION_MARKER, "o_proj")
+
+    setattr(attention_cls, _STRICT_MODEL_PATCH_MARKER, attention_init)
+    rms_norm_cls.forward_cuda = strict_rms_norm_forward_cuda
+    linear_method_cls.apply = deterministic_linear_apply
+    attention_cls.__init__ = attention_init_wrapped
+
+
 def _patch_sampler(integration: VllmIntegration, *, strict_linear_logp: bool) -> None:
     from vllm.v1.sample.sampler import Sampler
 
@@ -308,8 +403,14 @@ def _patch_worker_sampler(integration: VllmIntegration, *, strict_linear_logp: b
 def _register_attention_backend(integration: VllmIntegration) -> None:
     global _RLK_ATTENTION_BACKEND, _RLK_ATTENTION_IMPL
 
-    from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend, FlashAttentionImpl
-    from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+    from vllm.v1.attention.backends.flash_attn import (
+        FlashAttentionBackend,
+        FlashAttentionImpl,
+    )
+    from vllm.v1.attention.backends.registry import (
+        AttentionBackendEnum,
+        register_backend,
+    )
 
     operator = VllmAttentionOperator()
     integration.install_operator("attention", operator)
@@ -361,6 +462,11 @@ def install_vllm_integration(plan: IntegrationPlan) -> VllmIntegration:
     integration = VllmIntegration(plan, rl_kernel_operators={})
     set_active_integration("vllm", integration)
     strict_linear_logp = plan.implementation_for("logp", "rollout") is Implementation.RL_KERNEL
+    strict_attention = plan.implementation_for("attention", "rollout") is Implementation.RL_KERNEL
+    if strict_attention or strict_linear_logp:
+        _install_flash_attn_ops_compatibility()
+    if strict_attention:
+        _patch_qwen3_strict_model()
     if strict_linear_logp:
         _patch_qwen_lm_head_padding()
         _patch_qwen_compute_logits(integration)

--- a/rl_engine/kernels/ops/canonical_embedding.py
+++ b/rl_engine/kernels/ops/canonical_embedding.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Logical-row canonical embedding parameter gradient."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import torch
+
+from rl_engine.kernels.ops.backward_runtime import record_backward
+from rl_engine.kernels.ops.canonical_backward import active_session
+
+
+def _canonical_embedding_family(family: str) -> str:
+    requested = str(family)
+    normalized = "cuda" if requested.startswith("cuda") else requested
+    if normalized not in {"cuda", "pytorch", "triton"}:
+        raise RuntimeError(
+            f"unsupported canonical embedding backend family: {requested!r}"
+        )
+    return normalized
+
+
+def _reduce_embedding_grad_weight(
+    ids: torch.Tensor,
+    grad_rows: torch.Tensor,
+    *,
+    weight_shape: tuple[int, int],
+    weight_dtype: torch.dtype,
+    family: str,
+) -> torch.Tensor:
+    if family == "triton":
+        from rl_engine.kernels.ops.triton.linear.embedding import _embedding_grad_weight
+
+        return _embedding_grad_weight(
+            ids.reshape(-1).to(dtype=torch.long),
+            grad_rows,
+            weight_shape=weight_shape,
+            weight_dtype=weight_dtype,
+        )
+
+    if family not in {"cuda", "pytorch"}:
+        raise RuntimeError(f"unsupported canonical embedding backend family: {family!r}")
+
+    from rl_engine.kernels.ops.cuda.linear.embedding import (
+        _deterministic_embedding_grad_weight,
+    )
+
+    return _deterministic_embedding_grad_weight(
+        ids.reshape(-1).to(dtype=torch.long),
+        grad_rows.float(),
+        weight_shape=weight_shape,
+        weight_dtype=weight_dtype,
+    )
+
+
+class _CanonicalEmbeddingFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        token_ids: torch.Tensor,
+        weight: torch.Tensor,
+        logical_keys: torch.Tensor,
+        parameter_id: str,
+        forward_op: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+        family: str,
+    ) -> torch.Tensor:
+        session = active_session()
+        if session is None:
+            raise RuntimeError(
+                "canonical embedding requires an active backward session"
+            )
+        if weight.ndim != 2:
+            raise ValueError("canonical embedding weight must be [vocab, hidden]")
+        if logical_keys.ndim < 2 or logical_keys.shape[-1] not in (2, 3):
+            raise ValueError(
+                "canonical embedding logical keys must end in width 2 or 3"
+            )
+        if logical_keys.device != token_ids.device:
+            raise ValueError("canonical embedding token ids and logical keys must share a device")
+
+        ids = token_ids.reshape(-1).to(dtype=torch.long).contiguous()
+        keys = logical_keys.reshape(-1, logical_keys.shape[-1])
+        if keys.shape[0] != ids.numel():
+            raise ValueError("logical key count does not match embedding token count")
+        normalized_family = _canonical_embedding_family(family)
+
+        ctx.save_for_backward(ids)
+        ctx.session = session
+        ctx.parameter_id = str(parameter_id)
+        ctx.slot = (
+            session.register(ctx.parameter_id, keys) if weight.requires_grad else None
+        )
+        ctx.weight_shape = (int(weight.shape[0]), int(weight.shape[1]))
+        ctx.weight_dtype = weight.dtype
+        ctx.family = normalized_family
+        with torch.no_grad():
+            return forward_op(token_ids, weight)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        (ids,) = ctx.saved_tensors
+        grad_weight = None
+        if ctx.needs_input_grad[1]:
+            if ctx.slot is None:
+                raise RuntimeError("canonical embedding gradient was not registered")
+            hidden = ctx.weight_shape[1]
+            grad_rows = grad_output.reshape(-1, hidden).contiguous()
+
+            def reducer(
+                ordered_ids: torch.Tensor, ordered_grads: torch.Tensor
+            ) -> torch.Tensor:
+                return _reduce_embedding_grad_weight(
+                    ordered_ids,
+                    ordered_grads,
+                    weight_shape=ctx.weight_shape,
+                    weight_dtype=ctx.weight_dtype,
+                    family=ctx.family,
+                )
+
+            grad_weight = ctx.session.submit_linear(
+                ctx.parameter_id,
+                ctx.slot,
+                ids.unsqueeze(1),
+                grad_rows,
+                reducer,
+            )
+            record_backward(
+                "embedding",
+                kernel_id=(
+                    "rl_engine.kernels.ops.triton.linear.embedding._embedding_bwd"
+                    if ctx.family == "triton"
+                    else (
+                        "rl_engine.kernels.ops.cuda.linear.embedding."
+                        "_deterministic_embedding_grad_weight"
+                    )
+                ),
+                impl=f"{ctx.family}_embedding_canonical_rowfold",
+                family=ctx.family,
+            )
+        return None, grad_weight, None, None, None, None
+
+
+def canonical_embedding(
+    token_ids: torch.Tensor,
+    weight: torch.Tensor,
+    logical_keys: torch.Tensor,
+    *,
+    forward_op: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+    family: str,
+    parameter_id: str = "embed_tokens.weight",
+) -> torch.Tensor:
+    return _CanonicalEmbeddingFunction.apply(
+        token_ids,
+        weight,
+        logical_keys,
+        parameter_id,
+        forward_op,
+        family,
+    )
+
+
+__all__ = ["canonical_embedding"]

--- a/rl_engine/kernels/ops/cuda/attention/flash_attn.py
+++ b/rl_engine/kernels/ops/cuda/attention/flash_attn.py
@@ -24,6 +24,8 @@ from rl_engine.kernels.ops.cuda.attention.deterministic_attn import (
 from rl_engine.utils.logger import logger
 
 _FA4_API_SOURCE = "flash_attn.cute.interface"
+_FA4_COMPAT_API_SOURCE = "vllm.vllm_flash_attn.cute.interface"
+_FA4_API_SOURCES = (_FA4_API_SOURCE, _FA4_COMPAT_API_SOURCE)
 _FA4_REQUIRED_PARAMETERS = frozenset(
     {"softmax_scale", "causal", "num_splits", "pack_gqa", "deterministic", "return_lse"}
 )
@@ -33,19 +35,28 @@ class StrictFlashAttentionUnavailable(RuntimeError):
     """Raised when the exact FlashAttention production contract is unavailable."""
 
 
-def _load_fa4_cute_op() -> tuple[Callable[..., Any], str]:
-    try:
-        module = importlib.import_module(_FA4_API_SOURCE)
-        op = getattr(module, "flash_attn_func")
-    except (AttributeError, ImportError, OSError, RuntimeError) as exc:
-        raise StrictFlashAttentionUnavailable(
-            "strict CUDA Attention requires flash_attn.cute.interface.flash_attn_func"
-        ) from exc
-    try:
-        package_version = importlib.metadata.version("flash-attn")
-    except importlib.metadata.PackageNotFoundError:
-        package_version = "unknown"
-    return op, package_version
+def _load_fa4_cute_op() -> tuple[Callable[..., Any], str, str]:
+    errors: list[str] = []
+    for api_source in _FA4_API_SOURCES:
+        try:
+            module = importlib.import_module(api_source)
+            op = getattr(module, "flash_attn_func")
+        except (AttributeError, ImportError, OSError, RuntimeError) as exc:
+            errors.append(f"{api_source}: {exc}")
+            continue
+
+        package_name = "vllm" if api_source == _FA4_COMPAT_API_SOURCE else "flash-attn"
+        try:
+            package_version = importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError:
+            package_version = "unknown"
+        return op, package_version, api_source
+
+    raise StrictFlashAttentionUnavailable(
+        "strict CUDA Attention requires a FlashAttention CuTe API; tried "
+        + ", ".join(_FA4_API_SOURCES)
+        + (f" ({'; '.join(errors)})" if errors else "")
+    )
 
 
 class StrictFlashAttention4Core:
@@ -78,13 +89,15 @@ class StrictFlashAttention4Core:
         if requested.mode is not SplitKVMode.DISABLED:
             raise ValueError("strict FA4 Attention requires Split-KV to be disabled")
         if _op is None:
-            op, package_version = _load_fa4_cute_op()
+            op, package_version, api_source = _load_fa4_cute_op()
         else:
             op = _op
             package_version = "test-double" if _package_version is None else _package_version
+            api_source = _FA4_API_SOURCE
         self._validate_api(op)
         self.split_kv = requested
         self.package_version = package_version
+        self.api_source = api_source
         self._op = op
 
     @staticmethod
@@ -138,14 +151,57 @@ class StrictFlashAttention4Core:
         q_fa = q.transpose(1, 2).contiguous()
         k_fa = k.transpose(1, 2).contiguous()
         v_fa = v.transpose(1, 2).contiguous()
-        result = self._op(
+        result = self.forward_bshd_with_lse(
             q_fa,
             k_fa,
             v_fa,
+            causal=causal,
+            scale=scale,
+            key_padding_mask=key_padding_mask,
+            query_position_ids=query_position_ids,
+            key_position_ids=key_position_ids,
+            output_dtype=resolved_dtype,
+        )
+        return DeterministicAttentionCoreResult(
+            out=result.out.transpose(1, 2).contiguous(),
+            lse=result.lse,
+            provenance=result.provenance,
+        )
+
+    def forward_bshd_with_lse(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        causal: bool = True,
+        scale: float | None = None,
+        key_padding_mask: torch.Tensor | None = None,
+        query_position_ids: torch.Tensor | None = None,
+        key_position_ids: torch.Tensor | None = None,
+        output_dtype: torch.dtype | None = None,
+    ) -> DeterministicAttentionCoreResult:
+        """Run strict FA4 on tensors already laid out as [B, S, H, D]."""
+        self._validate_bshd_inputs(q, k, v, key_padding_mask)
+        RLKernelDeterministicAttentionCore._validate_positions(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            causal=causal,
+            query_position_ids=query_position_ids,
+            key_position_ids=key_position_ids,
+        )
+        resolved_dtype = q.dtype if output_dtype is None else output_dtype
+        if resolved_dtype != q.dtype:
+            raise ValueError("strict Attention output_dtype must match the Q/K/V input dtype")
+
+        result = self._op(
+            q,
+            k,
+            v,
             softmax_scale=scale,
             causal=causal,
             num_splits=self.num_splits,
-            pack_gqa=q.size(1) > k.size(1),
+            pack_gqa=q.size(2) > k.size(2),
             deterministic=self.deterministic_backward,
             return_lse=True,
         )
@@ -156,9 +212,9 @@ class StrictFlashAttention4Core:
         out_fa, lse = result
         if not isinstance(out_fa, torch.Tensor) or not isinstance(lse, torch.Tensor):
             raise StrictFlashAttentionUnavailable("FlashAttention CuTe returned non-tensor output")
-        expected_out_shape = q_fa.shape
-        expected_lse_shape = (q.size(0), q.size(1), q.size(2))
-        if tuple(out_fa.shape) != tuple(expected_out_shape):
+        expected_out_shape = q.shape
+        expected_lse_shape = (q.size(0), q.size(2), q.size(1))
+        if tuple(out_fa.shape) != expected_out_shape:
             raise StrictFlashAttentionUnavailable(
                 f"FlashAttention output must have shape {tuple(expected_out_shape)}"
             )
@@ -175,9 +231,8 @@ class StrictFlashAttention4Core:
                 "FlashAttention attention-domain LSE must be FP32"
             )
 
-        out = out_fa.transpose(1, 2).contiguous()
         return DeterministicAttentionCoreResult(
-            out=out,
+            out=out_fa,
             lse=lse.contiguous(),
             provenance={
                 "strict_core_id": self.core_id,
@@ -188,7 +243,7 @@ class StrictFlashAttention4Core:
                 "num_splits": self.num_splits,
                 "deterministic_backward": self.deterministic_backward,
                 "dropout_p": 0.0,
-                "split_kv": self.split_kv.resolve(k.size(2), backend=self.backend_id).to_dict(),
+                "split_kv": self.split_kv.resolve(k.size(1), backend=self.backend_id).to_dict(),
                 "merge_order": self.merge_order,
                 "accum_dtype": self.accum_dtype,
                 "downcast_at": self.downcast_at,
@@ -199,6 +254,36 @@ class StrictFlashAttention4Core:
                 "reference_only": self.reference_only,
             },
         )
+
+    @staticmethod
+    def _validate_bshd_inputs(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        key_padding_mask: torch.Tensor | None,
+    ) -> None:
+        if key_padding_mask is not None:
+            raise ValueError(
+                "strict FA4 core does not accept padding masks; materialize each logical row"
+            )
+        if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+            raise ValueError("q/k/v must be 4-D [B, S, H, D]")
+        if q.size(0) != 1:
+            raise ValueError("strict FA4 core executes one logical batch row at a time")
+        if k.size(0) != 1 or v.size(0) != 1:
+            raise ValueError("q/k/v batch sizes must match")
+        if k.shape != v.shape or q.size(3) != k.size(3):
+            raise ValueError("k/v shapes and q/k/v head dimensions must match")
+        if q.size(2) % k.size(2) != 0:
+            raise ValueError("Q heads must be divisible by KV heads for GQA")
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("strict FA4 core supports FP16/BF16 only")
+        if k.dtype != q.dtype or v.dtype != q.dtype:
+            raise ValueError("q/k/v must share one dtype")
+        if not (q.is_cuda and k.is_cuda and v.is_cuda):
+            raise ValueError("strict FA4 core requires CUDA tensors")
+        if not (q.device == k.device == v.device):
+            raise ValueError("q/k/v must be on one CUDA device")
 
     @staticmethod
     def _validate_inputs(
@@ -273,7 +358,10 @@ class FlashAttentionOp:
             k: (batch, seqlen, nheads_k, headdim)
             v: (batch, seqlen, nheads_k, headdim)
         """
-        assert q.dtype in [torch.float16, torch.bfloat16], "FlashAttention requires FP16 or BF16"
+        assert q.dtype in [
+            torch.float16,
+            torch.bfloat16,
+        ], "FlashAttention requires FP16 or BF16"
         assert q.is_cuda and k.is_cuda and v.is_cuda, "Inputs must be on CUDA device"
 
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()

--- a/rl_engine/kernels/ops/triton/linear/embedding.py
+++ b/rl_engine/kernels/ops/triton/linear/embedding.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
 
-"""Deterministic Triton embedding with an atomic-free backward."""
+"""Deterministic Triton embedding with an atomic-free sorted-segment backward."""
 
 from __future__ import annotations
 
@@ -11,54 +11,210 @@ import triton.language as tl
 
 from rl_engine.kernels.ops.backward_runtime import record_backward
 
+_SUPPORTED_WEIGHT_DTYPES = {torch.float32, torch.float16, torch.bfloat16}
+_BACKWARD_BLOCK_H = 128
+
+
+def _validate_embedding_inputs(token_ids: torch.Tensor, weight: torch.Tensor) -> None:
+    if weight.dim() != 2:
+        raise ValueError(
+            f"embedding weight must be [vocab, hidden], got {tuple(weight.shape)}"
+        )
+    if weight.size(0) <= 0 or weight.size(1) <= 0:
+        raise ValueError(
+            "embedding weight must have positive vocab and hidden dimensions"
+        )
+    if weight.dtype not in _SUPPORTED_WEIGHT_DTYPES:
+        raise TypeError("embedding weight must use fp16, bf16, or fp32")
+    if (
+        token_ids.is_floating_point()
+        or token_ids.is_complex()
+        or token_ids.dtype == torch.bool
+    ):
+        raise TypeError("embedding token_ids must use an integer dtype")
+    if token_ids.device != weight.device:
+        raise RuntimeError("embedding token_ids and weight must be on the same device")
+
+
+def _assert_valid_token_ids_async(ids: torch.Tensor, vocab_size: int) -> None:
+    if ids.numel() == 0:
+        return
+    valid = ((ids >= 0) & (ids < vocab_size)).all()
+    torch._assert_async(valid, f"embedding token_ids must be in [0, {vocab_size})")
+
+
+def _validate_token_ids_sync(token_ids: torch.Tensor, vocab_size: int) -> None:
+    if vocab_size <= 0:
+        raise ValueError("embedding vocab_size must be positive")
+    if (
+        token_ids.is_floating_point()
+        or token_ids.is_complex()
+        or token_ids.dtype == torch.bool
+    ):
+        raise TypeError("embedding token_ids must use an integer dtype")
+    ids = token_ids.reshape(-1).to(dtype=torch.int64)
+    if ids.numel() and bool(((ids < 0) | (ids >= vocab_size)).any().item()):
+        raise ValueError(f"embedding token_ids must be in [0, {vocab_size})")
+
+
+def _stable_sort_token_rows(
+    ids: torch.Tensor, grad_rows: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    order = torch.argsort(ids, stable=True)
+    return ids.index_select(0, order), grad_rows.index_select(0, order).contiguous()
+
+
+def _embedding_backward_grid(n_tokens: int, hidden: int) -> tuple[int, int]:
+    return n_tokens, (hidden + _BACKWARD_BLOCK_H - 1) // _BACKWARD_BLOCK_H
+
+
+def _validate_embedding_backward_inputs(
+    ids: torch.Tensor,
+    grad_rows: torch.Tensor,
+    *,
+    weight_shape: tuple[int, int],
+    weight_dtype: torch.dtype,
+) -> None:
+    if len(weight_shape) != 2 or weight_shape[0] <= 0 or weight_shape[1] <= 0:
+        raise ValueError("embedding weight_shape must contain positive vocab and hidden sizes")
+    if ids.ndim != 1:
+        raise ValueError("embedding backward ids must be flattened to one dimension")
+    if grad_rows.ndim != 2 or grad_rows.shape != (ids.numel(), weight_shape[1]):
+        raise ValueError(
+            "embedding backward rows must have shape "
+            f"[{ids.numel()}, {weight_shape[1]}]"
+        )
+    if ids.device != grad_rows.device:
+        raise RuntimeError("embedding backward ids and rows must share a device")
+    if ids.is_floating_point() or ids.is_complex() or ids.dtype == torch.bool:
+        raise TypeError("embedding backward ids must use an integer dtype")
+    if weight_dtype not in _SUPPORTED_WEIGHT_DTYPES:
+        raise TypeError("embedding backward weight must use fp16, bf16, or fp32")
+
+
+def _embedding_grad_weight(
+    ids: torch.Tensor,
+    grad_rows: torch.Tensor,
+    *,
+    weight_shape: tuple[int, int],
+    weight_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Reduce rows in their supplied order after stable grouping by token id."""
+
+    _validate_embedding_backward_inputs(
+        ids,
+        grad_rows,
+        weight_shape=weight_shape,
+        weight_dtype=weight_dtype,
+    )
+    vocab, hidden = weight_shape
+    grad_weight = torch.zeros(
+        (vocab, hidden),
+        device=grad_rows.device,
+        dtype=weight_dtype,
+    )
+    if ids.numel() == 0:
+        return grad_weight
+
+    sorted_ids, sorted_grad_rows = _stable_sort_token_rows(ids, grad_rows)
+    _embedding_bwd[_embedding_backward_grid(ids.numel(), hidden)](
+        sorted_ids,
+        sorted_grad_rows,
+        grad_weight,
+        ids.numel(),
+        vocab,
+        hidden=hidden,
+        block_h=_BACKWARD_BLOCK_H,
+        num_warps=4,
+    )
+    return grad_weight
+
 
 @triton.jit
-def _embedding_fwd(ids, weight, out, n_tokens, hidden: tl.constexpr, block_h: tl.constexpr):
+def _embedding_fwd(
+    ids,
+    weight,
+    out,
+    n_tokens,
+    vocab_size,
+    hidden: tl.constexpr,
+    block_h: tl.constexpr,
+):
     row = tl.program_id(0)
     offs = tl.arange(0, block_h)
     token = tl.load(ids + row)
-    values = tl.load(weight + token * hidden + offs, mask=offs < hidden, other=0.0)
+    valid_token = (token >= 0) & (token < vocab_size)
+    values = tl.load(
+        weight + token * hidden + offs,
+        mask=valid_token & (offs < hidden),
+        other=0.0,
+    )
     tl.store(out + row * hidden + offs, values, mask=offs < hidden)
 
 
 @triton.jit
 def _embedding_bwd(
-    ids,
-    grad_rows,
+    sorted_ids,
+    sorted_grad_rows,
     grad_weight,
-    n_tokens: tl.constexpr,
+    n_tokens,
+    vocab_size,
     hidden: tl.constexpr,
-    block_t: tl.constexpr,
+    block_h: tl.constexpr,
 ):
-    token = tl.program_id(0)
-    col = tl.program_id(1)
-    offs = tl.arange(0, block_t)
-    acc = tl.zeros((), tl.float32)
-    for start in range(0, n_tokens, block_t):
-        rows = start + offs
-        mask = rows < n_tokens
-        row_ids = tl.load(ids + rows, mask=mask, other=-1)
-        values = tl.load(grad_rows + rows * hidden + col, mask=mask, other=0.0).to(tl.float32)
-        acc += tl.sum(tl.where(row_ids == token, values, 0.0), axis=0)
-    tl.store(grad_weight + token * hidden + col, acc)
+    sorted_position = tl.program_id(0)
+    column_block = tl.program_id(1)
+    columns = column_block * block_h + tl.arange(0, block_h)
+    token = tl.load(sorted_ids + sorted_position)
+    previous_token = tl.load(
+        sorted_ids + sorted_position - 1,
+        mask=sorted_position > 0,
+        other=-1,
+    )
+    segment_start = (sorted_position == 0) | (token != previous_token)
+    valid_token = (token >= 0) & (token < vocab_size)
+
+    accumulator = tl.zeros((block_h,), tl.float32)
+    row = sorted_position
+    continuing = segment_start & valid_token
+    while (row < n_tokens) & continuing:
+        row_token = tl.load(sorted_ids + row)
+        continuing = row_token == token
+        values = tl.load(
+            sorted_grad_rows + row * hidden + columns,
+            mask=continuing & (columns < hidden),
+            other=0.0,
+        ).to(tl.float32)
+        accumulator += values
+        row += 1
+
+    tl.store(
+        grad_weight + token * hidden + columns,
+        accumulator,
+        mask=segment_start & valid_token & (columns < hidden),
+    )
 
 
 class _TritonEmbeddingFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, token_ids: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        _validate_embedding_inputs(token_ids, weight)
         ids = token_ids.reshape(-1).to(dtype=torch.int64).contiguous()
         vocab, hidden = weight.shape
-        if ids.numel() and bool(((ids < 0) | (ids >= vocab)).any()):
-            raise ValueError(f"token_ids must be in [0, {vocab})")
-        out = torch.empty((ids.numel(), hidden), device=weight.device, dtype=weight.dtype)
-        _embedding_fwd[(ids.numel(),)](
-            ids,
-            weight.contiguous(),
-            out,
-            ids.numel(),
-            hidden=hidden,
-            block_h=triton.next_power_of_2(hidden),
+        _assert_valid_token_ids_async(ids, vocab)
+        out = torch.empty(
+            (ids.numel(), hidden), device=weight.device, dtype=weight.dtype
         )
+        if ids.numel():
+            _embedding_fwd[(ids.numel(),)](
+                ids,
+                weight.contiguous(),
+                out,
+                ids.numel(),
+                vocab,
+                hidden=hidden,
+                block_h=triton.next_power_of_2(hidden),
+            )
         ctx.save_for_backward(ids)
         ctx.weight_shape = tuple(weight.shape)
         ctx.weight_dtype = weight.dtype
@@ -69,29 +225,26 @@ class _TritonEmbeddingFunction(torch.autograd.Function):
     def backward(ctx, grad_output: torch.Tensor):
         (ids,) = ctx.saved_tensors
         vocab, hidden = ctx.weight_shape
-        grad_rows = grad_output.reshape(-1, hidden).contiguous()
-        grad_weight = torch.empty(
-            (vocab, hidden), device=grad_output.device, dtype=ctx.weight_dtype
-        )
-        _embedding_bwd[(vocab, hidden)](
-            ids,
-            grad_rows,
-            grad_weight,
-            n_tokens=ids.numel(),
-            hidden=hidden,
-            block_t=64,
-        )
+        grad_weight = None
+        if ctx.needs_input_grad[1]:
+            grad_rows = grad_output.reshape(-1, hidden).contiguous()
+            grad_weight = _embedding_grad_weight(
+                ids,
+                grad_rows,
+                weight_shape=(vocab, hidden),
+                weight_dtype=ctx.weight_dtype,
+            )
         record_backward(
             "embedding",
             kernel_id="rl_engine.kernels.ops.triton.linear.embedding._embedding_bwd",
-            impl="triton_embedding_bwd",
+            impl="triton_sorted_segment_bwd",
             family="triton",
         )
         return None, grad_weight
 
 
 class TritonEmbeddingOp:
-    """Table lookup with one program per row and deterministic weight VJP."""
+    """Table lookup with a stable sorted-segment weight VJP."""
 
     op_class = "elementwise"
     is_batch_invariant = True
@@ -103,3 +256,9 @@ class TritonEmbeddingOp:
         if not token_ids.is_cuda or not weight.is_cuda:
             raise RuntimeError("TritonEmbeddingOp requires CUDA tensors")
         return _TritonEmbeddingFunction.apply(token_ids, weight)
+
+    @staticmethod
+    def validate_token_ids(token_ids: torch.Tensor, vocab_size: int) -> None:
+        """Synchronously validate ids at an explicit input-validation boundary."""
+
+        _validate_token_ids_sync(token_ids, vocab_size)

--- a/tests/test_canonical_embedding.py
+++ b/tests/test_canonical_embedding.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from rl_engine.kernels.ops.canonical_backward import canonical_backward_session
+from rl_engine.kernels.ops.canonical_embedding import canonical_embedding
+
+
+def _run_permutation(order: list[int]) -> tuple[torch.Tensor, torch.Tensor]:
+    base_ids = torch.tensor([2, 2, 2, 1], dtype=torch.long)
+    base_grads = torch.tensor([[1.0e20], [-1.0e20], [3.0], [7.0]], dtype=torch.float32)
+    base_keys = torch.tensor([[0, 0], [0, 1], [0, 2], [0, 3]], dtype=torch.long)
+    permutation = torch.tensor(order, dtype=torch.long)
+    ids = base_ids.index_select(0, permutation)
+    grads = base_grads.index_select(0, permutation)
+    keys = base_keys.index_select(0, permutation)
+    weight = torch.zeros((4, 1), dtype=torch.float32, requires_grad=True)
+
+    with canonical_backward_session() as session:
+        output = canonical_embedding(
+            ids,
+            weight,
+            keys,
+            forward_op=lambda token_ids, table: table[token_ids],
+            family="cuda-sm90",
+        )
+        output.backward(grads)
+        session.validate_complete()
+
+    assert weight.grad is not None
+    return output.detach(), weight.grad.detach()
+
+
+def test_canonical_embedding_gradient_is_invariant_to_physical_permutation() -> None:
+    direct_output, direct_grad = _run_permutation([0, 1, 2, 3])
+    permuted_output, permuted_grad = _run_permutation([0, 2, 1, 3])
+
+    assert torch.equal(direct_output[[0, 2, 1, 3]], permuted_output)
+    assert torch.equal(direct_grad, permuted_grad)
+    assert direct_grad[2, 0].item() == 3.0
+
+
+def test_canonical_embedding_excludes_inactive_logical_rows() -> None:
+    ids = torch.tensor([2, 2], dtype=torch.long)
+    keys = torch.tensor([[0, 0], [-1, -1]], dtype=torch.long)
+    weight = torch.zeros((4, 1), dtype=torch.float32, requires_grad=True)
+
+    with canonical_backward_session() as session:
+        output = canonical_embedding(
+            ids,
+            weight,
+            keys,
+            forward_op=lambda token_ids, table: table[token_ids],
+            family="cuda",
+        )
+        output.backward(torch.tensor([[5.0], [100.0]]))
+        session.validate_complete()
+
+    assert weight.grad is not None
+    assert weight.grad[2, 0].item() == 5.0
+
+
+def _run_chunked_uses(chunks: list[list[int]]) -> torch.Tensor:
+    base_ids = torch.tensor([2, 2, 2, 1], dtype=torch.long)
+    base_grads = torch.tensor([[1.0e20], [-1.0e20], [3.0], [7.0]], dtype=torch.float32)
+    base_keys = torch.tensor([[0, 0], [0, 1], [0, 2], [0, 3]], dtype=torch.long)
+    weight = torch.zeros((4, 1), dtype=torch.float32, requires_grad=True)
+
+    outputs: list[torch.Tensor] = []
+    gradients: list[torch.Tensor] = []
+    with canonical_backward_session() as session:
+        for indices in chunks:
+            selection = torch.tensor(indices, dtype=torch.long)
+            outputs.append(
+                canonical_embedding(
+                    base_ids.index_select(0, selection),
+                    weight,
+                    base_keys.index_select(0, selection),
+                    forward_op=lambda token_ids, table: table[token_ids],
+                    family="cuda",
+                )
+            )
+            gradients.append(base_grads.index_select(0, selection))
+        torch.autograd.backward(outputs, gradients)
+        session.validate_complete()
+
+    assert weight.grad is not None
+    return weight.grad.detach()
+
+
+def test_canonical_embedding_combines_multiple_uses_in_logical_order() -> None:
+    single_use = _run_chunked_uses([[0, 1, 2, 3]])
+    reversed_chunks = _run_chunked_uses([[2, 3], [0, 1]])
+
+    assert torch.equal(single_use, reversed_chunks)
+    assert single_use[2, 0].item() == 3.0
+
+
+def test_canonical_embedding_rejects_unknown_backward_family() -> None:
+    ids = torch.tensor([1], dtype=torch.long)
+    keys = torch.tensor([[0, 0]], dtype=torch.long)
+    weight = torch.zeros((2, 1), dtype=torch.float32, requires_grad=True)
+
+    with canonical_backward_session():
+        with pytest.raises(RuntimeError, match="unsupported canonical embedding backend"):
+            canonical_embedding(
+                ids,
+                weight,
+                keys,
+                forward_op=lambda token_ids, table: table[token_ids],
+                family="unknown",
+            )
+
+
+def test_canonical_embedding_rejects_misaligned_logical_keys() -> None:
+    ids = torch.tensor([0, 1], dtype=torch.long)
+    weight = torch.zeros((2, 1), dtype=torch.float32, requires_grad=True)
+
+    with canonical_backward_session():
+        with pytest.raises(ValueError, match="logical keys"):
+            canonical_embedding(
+                ids,
+                weight,
+                torch.tensor([0, 1], dtype=torch.long),
+                forward_op=lambda token_ids, table: table[token_ids],
+                family="pytorch",
+            )

--- a/tests/test_flashinfer_pr7_attention.py
+++ b/tests/test_flashinfer_pr7_attention.py
@@ -32,7 +32,9 @@ from rl_engine.kernels.ops.cuda.attention.cp_comm import (
     P2PNCCLAttentionCPCommunication,
     sort_attention_cp_partial_states,
 )
-from rl_engine.kernels.ops.cuda.attention.deterministic_attn import DeterministicAttentionCoreResult
+from rl_engine.kernels.ops.cuda.attention.deterministic_attn import (
+    DeterministicAttentionCoreResult,
+)
 from rl_engine.kernels.ops.cuda.attention.flash_attn import (
     StrictFlashAttention4Core,
     StrictFlashAttentionUnavailable,
@@ -1913,6 +1915,7 @@ def test_fa4_core_fixes_reduction_controls_and_exports_fp32_lse(monkeypatch):
 
     core = StrictFlashAttention4Core(_op=fake_fa4, _package_version="4.test")
     monkeypatch.setattr(core, "_validate_inputs", lambda *_args: None)
+    monkeypatch.setattr(core, "_validate_bshd_inputs", lambda *_args: None)
     q = torch.randn(1, 4, 2, 8, dtype=torch.bfloat16)
     k = torch.randn(1, 2, 3, 8, dtype=torch.bfloat16)
     v = torch.randn(1, 2, 3, 8, dtype=torch.bfloat16)
@@ -1947,6 +1950,63 @@ def test_fa4_core_fixes_reduction_controls_and_exports_fp32_lse(monkeypatch):
     assert result.provenance["dropout_p"] == 0.0
     assert result.provenance["native_attention_arithmetic"] is True
     assert result.provenance["production_ready"] is True
+
+
+def test_fa4_core_bshd_entrypoint_preserves_framework_layout(monkeypatch):
+    calls = []
+
+    def fake_fa4(
+        q,
+        k,
+        v,
+        *,
+        softmax_scale=None,
+        causal=False,
+        num_splits=0,
+        pack_gqa=None,
+        deterministic=False,
+        return_lse=False,
+    ):
+        calls.append(
+            {
+                "q_shape": tuple(q.shape),
+                "k_shape": tuple(k.shape),
+                "pack_gqa": pack_gqa,
+                "num_splits": num_splits,
+                "return_lse": return_lse,
+            }
+        )
+        return q.clone(), torch.zeros(
+            q.size(0), q.size(2), q.size(1), dtype=torch.float32, device=q.device
+        )
+
+    core = StrictFlashAttention4Core(_op=fake_fa4, _package_version="4.test")
+    monkeypatch.setattr(core, "_validate_bshd_inputs", lambda *_args: None)
+    q = torch.randn(1, 2, 4, 8, dtype=torch.bfloat16)
+    k = torch.randn(1, 3, 2, 8, dtype=torch.bfloat16)
+    v = torch.randn(1, 3, 2, 8, dtype=torch.bfloat16)
+
+    result = core.forward_bshd_with_lse(
+        q,
+        k,
+        v,
+        causal=False,
+        query_position_ids=torch.tensor([[2, 3]]),
+        key_position_ids=torch.tensor([[0, 1, 2]]),
+    )
+
+    assert calls == [
+        {
+            "q_shape": (1, 2, 4, 8),
+            "k_shape": (1, 3, 2, 8),
+            "pack_gqa": True,
+            "num_splits": 1,
+            "return_lse": True,
+        }
+    ]
+    assert result.out.shape == q.shape
+    assert result.lse.shape == (1, 4, 2)
+    assert result.lse.dtype is torch.float32
 
 
 def test_strict_paged_default_selects_fa4_production_core(monkeypatch):

--- a/tests/test_framework_runtime_adapters.py
+++ b/tests/test_framework_runtime_adapters.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 
 import ast
 import os
+from collections import namedtuple
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-import rl_engine.integrations.framework_operators as framework_operators
 import torch
+
+import rl_engine.integrations.framework_operators as framework_operators
 from rl_engine.integrations.ablation import (
     IntegrationPlan,
     configure_integration_environment,
@@ -19,14 +22,21 @@ from rl_engine.integrations.ablation import (
 from rl_engine.integrations.framework_operators import (
     MegatronAttentionOperator,
     SemanticOperatorHandle,
+    VllmLogpOperator,
     _megatron_zigzag_layout,
     _packed_local_sequence_layout,
     _vllm_kv_cache_views,
 )
-from rl_engine.integrations.megatron_runtime import install_megatron_integration
+from rl_engine.integrations.megatron_runtime import (
+    _patch_strict_attention_projections,
+    install_megatron_integration,
+)
 from rl_engine.integrations.runtime import FrameworkOperatorIntegration
 from rl_engine.integrations.state import clear_active_integration
-from rl_engine.integrations.vllm_runtime import configure_vllm_environment
+from rl_engine.integrations.vllm_runtime import (
+    _patch_qwen3_strict_model,
+    configure_vllm_environment,
+)
 from rl_engine.kernels.attention_contract import (
     STRICT_ATTENTION_FA4_SCHEDULE_ID,
     STRICT_ATTENTION_PRODUCTION_CORE_ID,
@@ -37,7 +47,9 @@ from rl_engine.kernels.attention_contract import (
     ReductionSpec,
     ShardingSpec,
 )
-from rl_engine.kernels.ops.cuda.attention.strict_runtime import StrictCUDAAttentionRuntime
+from rl_engine.kernels.ops.cuda.attention.strict_runtime import (
+    StrictCUDAAttentionRuntime,
+)
 
 
 def test_framework_adapters_do_not_construct_registered_kernels_directly():
@@ -249,6 +261,141 @@ def test_vllm_current_flash_attention_kv_cache_layout_is_materialized():
     assert value.shape == (2, 4, 3, 5)
     assert torch.equal(key, cache.transpose(1, 2)[..., :5])
     assert torch.equal(value, cache.transpose(1, 2)[..., 5:])
+
+
+def test_megatron_strict_attention_projections_install_without_debug_environment(
+    monkeypatch,
+):
+    monkeypatch.delenv("RL_KERNEL_MODEL_DEBUG_DIR", raising=False)
+
+    class ColumnLinear:
+        def __init__(self):
+            self.allreduce_dgrad = True
+
+        def _forward_impl(self, input, weight, *args, **kwargs):
+            del args, kwargs
+            return input.new_full((*input.shape[:-1], weight.shape[0]), -1)
+
+    class RowLinear:
+        def _forward_impl(self, input, weight, *args, **kwargs):
+            del args, kwargs
+            return input.new_full((*input.shape[:-1], weight.shape[0]), -1)
+
+    class SelfAttention:
+        def __init__(self):
+            self.linear_qkv = ColumnLinear()
+            self.linear_proj = RowLinear()
+
+    _patch_strict_attention_projections(
+        self_attention_cls=SelfAttention,
+        column_linear_cls=ColumnLinear,
+        row_linear_cls=RowLinear,
+        det_gemm=lambda lhs, rhs: lhs @ rhs,
+    )
+    attention = SelfAttention()
+    value = torch.tensor([[1.0, 2.0]])
+    weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+
+    qkv = attention.linear_qkv._forward_impl(value, weight, bias=None)
+    projection = attention.linear_proj._forward_impl(value, weight, bias=None)
+    native = ColumnLinear()._forward_impl(value, weight, bias=None)
+
+    assert torch.equal(qkv, torch.tensor([[1.0, 2.0, 3.0]]))
+    assert torch.equal(projection, qkv)
+    assert torch.equal(native, torch.full((1, 3), -1.0))
+    assert attention.linear_qkv.allreduce_dgrad is False
+
+
+def test_vllm_qwen3_strict_model_installs_without_debug_environment(monkeypatch):
+    monkeypatch.delenv("RL_KERNEL_MODEL_DEBUG_DIR", raising=False)
+
+    class RMSNorm:
+        def __init__(self):
+            self.variance_size_override = None
+            self.has_weight = True
+            self.hidden_size = 2
+            self.weight = torch.tensor([1.5, 0.5])
+            self.variance_epsilon = 1e-6
+
+        def forward_cuda(self, x, residual=None):
+            del residual
+            return x.new_full(x.shape, -1)
+
+        def forward_native(self, x, residual=None):
+            del residual
+            return x.new_full(x.shape, -2)
+
+    class LinearLayer:
+        def __init__(self):
+            self.weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+
+    class LinearMethod:
+        def apply(self, layer, x, bias=None):
+            del bias
+            return x.new_full((*x.shape[:-1], layer.weight.shape[0]), -1)
+
+    class Attention:
+        def __init__(self):
+            self.qkv_proj = LinearLayer()
+            self.o_proj = LinearLayer()
+
+    _patch_qwen3_strict_model(
+        rms_norm_cls=RMSNorm,
+        linear_method_cls=LinearMethod,
+        attention_cls=Attention,
+        det_gemm=lambda lhs, rhs: lhs @ rhs,
+    )
+    attention = Attention()
+    method = LinearMethod()
+    value = torch.tensor([[1.0, 2.0]])
+    norm = RMSNorm()
+
+    assert torch.equal(
+        method.apply(attention.qkv_proj, value),
+        torch.tensor([[1.0, 2.0, 3.0]]),
+    )
+    assert torch.equal(
+        method.apply(LinearLayer(), value),
+        torch.full((1, 3), -1.0),
+    )
+    assert torch.equal(
+        norm.forward_cuda(value),
+        torch.nn.functional.rms_norm(value, (2,), norm.weight, 1e-6),
+    )
+
+
+def test_vllm_logp_replaces_every_duplicate_sampled_token_column():
+    logprobs_type = namedtuple(
+        "LogprobsTensors",
+        ("logprob_token_ids", "logprobs", "selected_token_ranks"),
+    )
+
+    @dataclass(frozen=True)
+    class SamplerResult:
+        sampled_token_ids: torch.Tensor
+        logprobs_tensors: object
+
+    operator = VllmLogpOperator(lambda *_args, **_kwargs: None)
+    result = SamplerResult(
+        sampled_token_ids=torch.tensor([[7], [8]]),
+        logprobs_tensors=logprobs_type(
+            logprob_token_ids=torch.tensor([[7, 7], [8, 9]]),
+            logprobs=torch.tensor([[-0.1, -0.1], [-0.2, -0.3]]),
+            selected_token_ranks=torch.tensor([1, 2]),
+        ),
+    )
+
+    updated = operator._replace_sampled_value(
+        result,
+        token_ids=torch.tensor([7, 8]),
+        selected=torch.tensor([-1.25, -2.5]),
+        provenance={},
+    )
+
+    assert torch.equal(
+        updated.logprobs_tensors.logprobs,
+        torch.tensor([[-1.25, -1.25], [-2.5, -0.3]]),
+    )
 
 
 def _cp1_contract(tokens: int) -> AttentionContract:

--- a/tests/test_triton_embedding.py
+++ b/tests/test_triton_embedding.py
@@ -1,0 +1,406 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+import torch
+
+pytest.importorskip("triton")
+
+from rl_engine.kernels.ops.triton.linear import embedding as embedding_module
+
+
+@dataclass
+class _FakeForwardKernel:
+    grids: list[tuple[int, ...]] = field(default_factory=list)
+
+    def __getitem__(self, grid: tuple[int, ...]):
+        self.grids.append(grid)
+
+        def launch(
+            ids: torch.Tensor,
+            weight: torch.Tensor,
+            out: torch.Tensor,
+            n_tokens: int,
+            vocab_size: int,
+            *,
+            hidden: int,
+            block_h: int,
+        ) -> None:
+            del vocab_size, block_h
+            assert n_tokens == ids.numel()
+            assert hidden == weight.size(1)
+            out.copy_(weight.index_select(0, ids))
+
+        return launch
+
+
+@dataclass
+class _FakeBackwardKernel:
+    grids: list[tuple[int, ...]] = field(default_factory=list)
+
+    def __getitem__(self, grid: tuple[int, ...]):
+        self.grids.append(grid)
+
+        def launch(
+            sorted_ids: torch.Tensor,
+            sorted_grad_rows: torch.Tensor,
+            grad_weight: torch.Tensor,
+            n_tokens: int,
+            vocab_size: int,
+            *,
+            hidden: int,
+            block_h: int,
+            num_warps: int,
+        ) -> None:
+            del block_h, num_warps
+            assert n_tokens == sorted_ids.numel()
+            assert hidden == sorted_grad_rows.size(1)
+            for position in range(n_tokens):
+                token = int(sorted_ids[position])
+                if position and token == int(sorted_ids[position - 1]):
+                    continue
+                if token < 0 or token >= vocab_size:
+                    continue
+                accumulator = torch.zeros(hidden, dtype=torch.float32)
+                row = position
+                while row < n_tokens and int(sorted_ids[row]) == token:
+                    accumulator = accumulator + sorted_grad_rows[row].float()
+                    row += 1
+                grad_weight[token].copy_(accumulator.to(grad_weight.dtype))
+
+        return launch
+
+
+def _install_fake_kernels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[_FakeForwardKernel, _FakeBackwardKernel]:
+    forward = _FakeForwardKernel()
+    backward = _FakeBackwardKernel()
+    monkeypatch.setattr(embedding_module, "_embedding_fwd", forward)
+    monkeypatch.setattr(embedding_module, "_embedding_bwd", backward)
+    monkeypatch.setattr(
+        embedding_module, "record_backward", lambda *args, **kwargs: None
+    )
+    return forward, backward
+
+
+def _left_fold_grad_weight(
+    token_ids: torch.Tensor,
+    grad_output: torch.Tensor,
+    *,
+    vocab_size: int,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    ids = token_ids.reshape(-1).long()
+    rows = grad_output.reshape(ids.numel(), grad_output.shape[-1])
+    result = torch.zeros((vocab_size, rows.size(1)), dtype=output_dtype)
+    for token in range(vocab_size):
+        accumulator = torch.zeros(rows.size(1), dtype=torch.float32)
+        for position in range(ids.numel()):
+            if int(ids[position]) == token:
+                accumulator = accumulator + rows[position].float()
+        result[token].copy_(accumulator.to(output_dtype))
+    return result
+
+
+def _run_fake_autograd(
+    token_ids: torch.Tensor,
+    weight: torch.Tensor,
+    grad_output: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    differentiable_weight = weight.detach().clone().requires_grad_(True)
+    output = embedding_module._TritonEmbeddingFunction.apply(
+        token_ids, differentiable_weight
+    )
+    output.backward(grad_output)
+    assert differentiable_weight.grad is not None
+    return output.detach(), differentiable_weight.grad.detach()
+
+
+def test_stable_sort_preserves_original_positions_within_each_token() -> None:
+    ids = torch.tensor([4, 1, 4, 2, 1, 4], dtype=torch.long)
+    positions = torch.arange(ids.numel(), dtype=torch.float32).unsqueeze(1)
+
+    sorted_ids, sorted_positions = embedding_module._stable_sort_token_rows(
+        ids, positions
+    )
+
+    assert sorted_ids.tolist() == [1, 1, 2, 4, 4, 4]
+    assert sorted_positions.squeeze(1).tolist() == [1.0, 4.0, 3.0, 0.0, 2.0, 5.0]
+
+
+def test_backward_grid_scales_with_tokens_instead_of_vocab() -> None:
+    grid = embedding_module._embedding_backward_grid(n_tokens=32, hidden=4096)
+
+    assert grid == (32, 32)
+    assert grid[0] * grid[1] == 1024
+    assert grid[0] * grid[1] < 151936 * 4096
+
+
+def test_embedding_backward_contract_rejects_misaligned_rows() -> None:
+    ids = torch.tensor([1, 2, 1], dtype=torch.long)
+
+    with pytest.raises(ValueError, match=r"shape \[3, 4\]"):
+        embedding_module._embedding_grad_weight(
+            ids,
+            torch.ones(2, 4),
+            weight_shape=(8, 4),
+            weight_dtype=torch.float32,
+        )
+    with pytest.raises(ValueError, match="flattened"):
+        embedding_module._embedding_grad_weight(
+            ids.reshape(1, 3),
+            torch.ones(3, 4),
+            weight_shape=(8, 4),
+            weight_dtype=torch.float32,
+        )
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "shape,flat_ids",
+    [
+        ((2, 3), [5, 1, 5, 2, 1, 5]),
+        ((2, 3), [5, 1, 4, 2, 0, 3]),
+        ((0, 3), []),
+    ],
+)
+def test_fake_autograd_matches_stable_fp32_left_fold(
+    monkeypatch: pytest.MonkeyPatch,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    flat_ids: list[int],
+) -> None:
+    forward_kernel, backward_kernel = _install_fake_kernels(monkeypatch)
+    vocab_size, hidden = 8, 7
+    token_ids = torch.tensor(flat_ids, dtype=torch.int32).reshape(shape)
+    weight = torch.linspace(
+        -1.0, 1.0, vocab_size * hidden, dtype=torch.float32
+    ).reshape(vocab_size, hidden)
+    weight = weight.to(dtype)
+    grad_output = torch.arange(
+        token_ids.numel() * hidden,
+        dtype=torch.float32,
+    ).reshape(*shape, hidden)
+    grad_output = (grad_output / 13.0).to(dtype)
+
+    output, grad_weight = _run_fake_autograd(token_ids, weight, grad_output)
+    expected_grad = _left_fold_grad_weight(
+        token_ids,
+        grad_output,
+        vocab_size=vocab_size,
+        output_dtype=dtype,
+    )
+
+    assert output.dtype == dtype
+    assert torch.equal(output, weight[token_ids.long()])
+    assert torch.equal(grad_weight, expected_grad)
+    if token_ids.numel():
+        assert forward_kernel.grids == [(token_ids.numel(),)]
+        assert backward_kernel.grids == [
+            embedding_module._embedding_backward_grid(token_ids.numel(), hidden)
+        ]
+    else:
+        assert not forward_kernel.grids
+        assert not backward_kernel.grids
+
+
+def test_backward_uses_each_permutations_original_position_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_kernels(monkeypatch)
+    vocab_size, hidden = 6, 3
+    base_ids = torch.tensor([2, 1, 2, 2, 1, 2], dtype=torch.long)
+    base_rows = torch.tensor(
+        [
+            [8192.0, 1.0, 0.5],
+            [3.0, 2.0, 1.0],
+            [1.0, -1.0, 0.25],
+            [-8192.0, 4.0, -0.5],
+            [5.0, 6.0, 7.0],
+            [2.0, 3.0, 4.0],
+        ],
+        dtype=torch.float16,
+    )
+    weight = torch.zeros((vocab_size, hidden), dtype=torch.float16)
+
+    for order in ([0, 1, 2, 3, 4, 5], [3, 4, 2, 0, 1, 5], [5, 2, 0, 1, 4, 3]):
+        permutation = torch.tensor(order, dtype=torch.long)
+        ids = base_ids.index_select(0, permutation).reshape(2, 3)
+        rows = base_rows.index_select(0, permutation).reshape(2, 3, hidden)
+        _, grad_weight = _run_fake_autograd(ids, weight, rows)
+        expected = _left_fold_grad_weight(
+            ids,
+            rows,
+            vocab_size=vocab_size,
+            output_dtype=weight.dtype,
+        )
+        assert torch.equal(grad_weight, expected)
+
+
+def test_flatten_equivalent_batch_shapes_share_forward_and_gradient(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_kernels(monkeypatch)
+    flat_ids = torch.tensor([3, 1, 3, 2, 3, 1], dtype=torch.long)
+    flat_rows = torch.arange(24, dtype=torch.float32).reshape(6, 4) / 7.0
+    weight = torch.arange(24, dtype=torch.float32).reshape(6, 4) / 11.0
+
+    baseline_output, baseline_grad = _run_fake_autograd(flat_ids, weight, flat_rows)
+    for leading_shape in ((2, 3), (3, 2), (1, 6)):
+        output, grad = _run_fake_autograd(
+            flat_ids.reshape(leading_shape),
+            weight,
+            flat_rows.reshape(*leading_shape, 4),
+        )
+        assert torch.equal(output.reshape(-1, 4), baseline_output)
+        assert torch.equal(grad, baseline_grad)
+
+
+def test_forward_path_does_not_depend_on_weight_requires_grad(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    forward_kernel, _ = _install_fake_kernels(monkeypatch)
+    ids = torch.tensor([[2, 0, 2], [1, 4, 3]], dtype=torch.int16)
+    weight = torch.randn(5, 4, dtype=torch.bfloat16)
+
+    inference = embedding_module._TritonEmbeddingFunction.apply(ids, weight)
+    training = embedding_module._TritonEmbeddingFunction.apply(
+        ids, weight.requires_grad_(True)
+    )
+
+    assert torch.equal(inference, training)
+    assert len(forward_kernel.grids) == 2
+
+
+def test_explicit_token_validation_accepts_boundaries_and_rejects_invalid_ids() -> None:
+    embedding_module.TritonEmbeddingOp.validate_token_ids(torch.tensor([0, 4]), 5)
+
+    with pytest.raises(ValueError, match=r"\[0, 5\)"):
+        embedding_module.TritonEmbeddingOp.validate_token_ids(torch.tensor([-1, 2]), 5)
+    with pytest.raises(ValueError, match=r"\[0, 5\)"):
+        embedding_module.TritonEmbeddingOp.validate_token_ids(torch.tensor([1, 5]), 5)
+    with pytest.raises(TypeError, match="integer dtype"):
+        embedding_module.TritonEmbeddingOp.validate_token_ids(torch.tensor([1.5]), 5)
+
+
+def test_hot_path_range_assertion_keeps_condition_as_a_tensor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[torch.Tensor, str]] = []
+
+    def capture(condition: torch.Tensor, message: str) -> None:
+        captured.append((condition, message))
+
+    monkeypatch.setattr(torch, "_assert_async", capture)
+    embedding_module._assert_valid_token_ids_async(torch.tensor([0, 3, 1]), 4)
+
+    assert len(captured) == 1
+    assert captured[0][0].dtype == torch.bool
+    assert captured[0][0].ndim == 0
+    assert captured[0][1] == "embedding token_ids must be in [0, 4)"
+
+
+@pytest.mark.parametrize(
+    "token_ids,weight,error_type,message",
+    [
+        (torch.tensor([0.0]), torch.ones(3, 2), TypeError, "integer dtype"),
+        (torch.tensor([True]), torch.ones(3, 2), TypeError, "integer dtype"),
+        (torch.tensor([0]), torch.ones(3, 2, dtype=torch.int32), TypeError, "fp16"),
+        (torch.tensor([0]), torch.ones(3), ValueError, "weight must be"),
+    ],
+)
+def test_embedding_input_contract_rejects_invalid_dtypes_and_shapes(
+    token_ids: torch.Tensor,
+    weight: torch.Tensor,
+    error_type: type[Exception],
+    message: str,
+) -> None:
+    with pytest.raises(error_type, match=message):
+        embedding_module._validate_embedding_inputs(token_ids, weight)
+
+
+def test_backward_kernel_has_no_atomic_updates() -> None:
+    source = embedding_module._embedding_bwd.src
+
+    assert "atomic_" not in source
+    assert "while (row < n_tokens) & continuing" in source
+
+
+requires_nvidia_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.version.hip is not None,
+    reason="NVIDIA CUDA is required",
+)
+
+
+@requires_nvidia_cuda
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "shape,flat_ids",
+    [
+        ((2, 4), [7, 1, 7, 2, 1, 7, 3, 7]),
+        ((2, 4), [7, 1, 6, 2, 0, 5, 3, 4]),
+        ((0, 4), []),
+    ],
+)
+def test_triton_embedding_cuda_matches_stable_fp32_left_fold(
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    flat_ids: list[int],
+) -> None:
+    vocab_size, hidden = 11, 64
+    token_ids = torch.tensor(flat_ids, device="cuda", dtype=torch.int32).reshape(shape)
+    weight = torch.linspace(
+        -1.0,
+        1.0,
+        vocab_size * hidden,
+        device="cuda",
+        dtype=torch.float32,
+    ).reshape(vocab_size, hidden)
+    weight = weight.to(dtype).requires_grad_(True)
+    grad_output = torch.arange(
+        token_ids.numel() * hidden,
+        device="cuda",
+        dtype=torch.float32,
+    ).reshape(*shape, hidden)
+    grad_output = (grad_output / 17.0).to(dtype)
+
+    output = embedding_module.TritonEmbeddingOp().forward(token_ids, weight)
+    output.backward(grad_output)
+    expected_grad = _left_fold_grad_weight(
+        token_ids.cpu(),
+        grad_output.cpu(),
+        vocab_size=vocab_size,
+        output_dtype=dtype,
+    )
+
+    assert torch.equal(output, weight.detach()[token_ids.long()])
+    assert weight.grad is not None
+    assert torch.equal(weight.grad.cpu(), expected_grad)
+
+
+@requires_nvidia_cuda
+def test_triton_embedding_cuda_backward_is_repeatable() -> None:
+    token_ids = torch.tensor(
+        [[5, 2, 5, 1], [2, 5, 5, 2]],
+        device="cuda",
+        dtype=torch.long,
+    )
+    weight = torch.randn(8, 128, device="cuda", dtype=torch.bfloat16)
+    grad_output = torch.randn(2, 4, 128, device="cuda", dtype=torch.bfloat16)
+
+    gradients = []
+    for _ in range(3):
+        differentiable_weight = weight.detach().clone().requires_grad_(True)
+        embedding_module.TritonEmbeddingOp().forward(
+            token_ids, differentiable_weight
+        ).backward(grad_output)
+        assert differentiable_weight.grad is not None
+        gradients.append(differentiable_weight.grad.detach())
+
+    assert torch.equal(gradients[0], gradients[1])
+    assert torch.equal(gradients[0], gradients[2])


### PR DESCRIPTION
> Depends on #339. Please merge #339 before this PR.

## Summary

- Replace the `vocab × hidden` backward grid with a stable sorted-segment reduction over active token rows.
- Keep duplicate-token accumulation deterministic, atomic-free, and bitwise aligned with the ascending FP32 left-fold reference.
- Canonicalize strict Qwen embedding gradients by logical row order.

The launch grid is reduced from `vocab × hidden` to `tokens × ceil(hidden / 128)`.

## Performance



The following measurements time exactly one Triton backward kernel launch. Input sorting, allocation, and output zeroing are excluded.

 H100 80GB, BF16, PyTorch 2.9.1+cu128, Triton 3.5.1:

| Tokens | Vocab | Hidden | Previous kernel | New kernel | Speedup |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 8 | 32,000 | 1,024 | 19.725 ms | 0.0256 ms | 771.5× |
| 32 | 151,936 | 1,024 | 93.581 ms | 0.0240 ms | 3,904.4× |
| 32 | 151,936 | 2,048 | 187.142 ms | 0.0237 ms | 7,892.3× |
| 32 | 32,000 | 4,096 | 78.846 ms | 0.0244 ms | 3,231.4× |
| 32 | 128,256 | 4,096 | 315.886 ms | 0.0234 ms | 13,504.0× |
| 32 | 151,936 | 4,096 | 374.177 ms | 0.0232 ms | 16,161.8× |
| 128 | 151,936 | 4,096 | 944.681 ms | 0.0236 ms | 40,083.2× |
| 512 | 151,936 | 4,096 | 3,698.262 ms | 0.0270 ms | 136,851.0× |

## Validation

- Bitwise equal to the per-token FP32 left-fold reference in original row order across all benchmark configurations.
- Unused embedding rows remain zero after output initialization in the full backward path.
- Covers duplicate IDs, empty inputs, invalid IDs, layout changes, repeated execution, and canonical chunk/permutation invariance.
