### PR TITLE
Feat/strict qk norm reduction

### DIFF
--- a/csrc/cuda/rmsnorm.cu
+++ b/csrc/cuda/rmsnorm.cu
@@ -1,5 +1,9 @@
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
+#if !defined(USE_ROCM)
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#endif
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
@@ -70,6 +74,29 @@ static int choose_threads(int H) {
 
 constexpr int RMSNORM_DW_ROWS_PER_CHUNK = 256;
 constexpr int RMSNORM_DW_H_TILE = 128;
+
+#if !defined(USE_ROCM)
+constexpr int FP32_LEFT_FOLD_THREADS = 256;
+
+__global__ void reduce_rows_fp32_left_fold_kernel(
+    const float* __restrict__ rows,
+    float* __restrict__ output,
+    int64_t row_count,
+    int64_t columns
+) {
+    int64_t column = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (column >= columns) {
+        return;
+    }
+
+    float acc = 0.0f;
+#pragma unroll 1
+    for (int64_t row = 0; row < row_count; ++row) {
+        acc = __fadd_rn(acc, rows[row * columns + column]);
+    }
+    output[column] = acc;
+}
+#endif
 
 int64_t rmsnorm_backward_dw_chunks_cuda(int64_t rows) {
     return (rows + RMSNORM_DW_ROWS_PER_CHUNK - 1) / RMSNORM_DW_ROWS_PER_CHUNK;
@@ -330,3 +357,23 @@ void rmsnorm_backward_reduce_dw_cuda(
         H
     );
 }
+
+#if !defined(USE_ROCM)
+void reduce_rows_fp32_left_fold_cuda(
+    torch::Tensor rows,
+    torch::Tensor output
+) {
+    const c10::cuda::CUDAGuard device_guard(rows.device());
+    int64_t columns = rows.size(1);
+    int64_t blocks = (columns + FP32_LEFT_FOLD_THREADS - 1) / FP32_LEFT_FOLD_THREADS;
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    reduce_rows_fp32_left_fold_kernel<<<blocks, FP32_LEFT_FOLD_THREADS, 0, stream>>>(
+        rows.data_ptr<float>(),
+        output.data_ptr<float>(),
+        rows.size(0),
+        columns
+    );
+    C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+#endif

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -149,6 +149,12 @@ void rmsnorm_backward_reduce_dw_cuda(
 
 int64_t rmsnorm_backward_dw_chunks_cuda(int64_t rows);
 
+#if !defined(USE_ROCM)
+void reduce_rows_fp32_left_fold_cuda(
+  torch::Tensor rows,
+  torch::Tensor output);
+#endif
+
 static void rmsnorm_check_input(const torch::Tensor& x, const char* name) {
   TORCH_CHECK(x.is_cuda(), name, " must be a CUDA tensor");
   TORCH_CHECK(x.is_contiguous(), name, " must be contiguous");
@@ -230,6 +236,21 @@ torch::Tensor rmsnorm_backward_dw(
 
   return dw;
 }
+
+#if !defined(USE_ROCM)
+torch::Tensor reduce_rows_fp32_left_fold(torch::Tensor rows)
+{
+  rmsnorm_check_input(rows, "rows");
+  TORCH_CHECK(rows.dim() == 2, "rows must be 2D [R, C]");
+  TORCH_CHECK(rows.scalar_type() == torch::kFloat32, "rows must be float32");
+
+  auto output = torch::empty({rows.size(1)}, rows.options());
+  if (rows.size(1) != 0) {
+    reduce_rows_fp32_left_fold_cuda(rows, output);
+  }
+  return output;
+}
+#endif
 
 // SiLU / SwiGLU wrappers (WS1 elementwise activations)
 torch::Tensor silu_forward(torch::Tensor x) {
@@ -426,6 +447,12 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("rmsnorm_forward", &rmsnorm_forward, "Batch-invariant RMSNorm forward CUDA");
     m.def("rmsnorm_backward_dx", &rmsnorm_backward_dx, "Batch-invariant RMSNorm backward dx CUDA");
     m.def("rmsnorm_backward_dw", &rmsnorm_backward_dw, "Deterministic RMSNorm backward dweight CUDA");
+#if !defined(USE_ROCM)
+    m.def(
+        "reduce_rows_fp32_left_fold",
+        &reduce_rows_fp32_left_fold,
+        "Ascending-row FP32 left-fold reduction CUDA");
+#endif
 
     // registry SiLU / SwiGLU (elementwise activation)
     m.def("silu_forward", &silu_forward, "Batch-invariant SiLU forward CUDA");

--- a/rl_engine/integrations/framework_operators.py
+++ b/rl_engine/integrations/framework_operators.py
@@ -16,8 +16,12 @@ from threading import Lock
 from typing import Any, Mapping, cast
 
 import torch
+
 from rl_engine.alignment.cross_config.operators import OperatorBridge, OperatorOverride
-from rl_engine.integrations.linear_logp import LinearLogpWrapper, take_rollout_linear_logp_context
+from rl_engine.integrations.linear_logp import (
+    LinearLogpWrapper,
+    take_rollout_linear_logp_context,
+)
 from rl_engine.kernels.attention_contract import (
     STRICT_ATTENTION_FA4_SCHEDULE_ID,
     STRICT_ATTENTION_PRODUCTION_CORE_ID,
@@ -28,13 +32,22 @@ from rl_engine.kernels.attention_contract import (
 )
 from rl_engine.kernels.attention_contract import ReductionSpec as AttentionReductionSpec
 from rl_engine.kernels.attention_contract import ShardingSpec as AttentionShardingSpec
-from rl_engine.kernels.attention_contract import SplitKVSpec
-from rl_engine.kernels.logprob_contract import LogprobContract, LogprobDType, LogprobRole, MaskSpec
+from rl_engine.kernels.attention_contract import (
+    SplitKVSpec,
+)
+from rl_engine.kernels.logprob_contract import (
+    LogprobContract,
+    LogprobDType,
+    LogprobRole,
+    MaskSpec,
+)
 from rl_engine.kernels.logprob_contract import ReductionSpec as LogprobReductionSpec
 from rl_engine.kernels.logprob_contract import ShardingSpec as LogprobShardingSpec
 from rl_engine.kernels.ops.pytorch.attention.ablation import AttentionAblationConfig
 from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import BACKEND_ID as LOGP_BACKEND_ID
-from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import DEFAULT_NUM_VOCAB_TILES
+from rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp import (
+    DEFAULT_NUM_VOCAB_TILES,
+)
 from rl_engine.kernels.registry import kernel_registry
 from rl_engine.kernels.semantic_registry import OperatorRequirements
 
@@ -1087,7 +1100,10 @@ class VllmLogpOperator:
         native_selected = values[
             torch.arange(values.size(0), device=values.device), columns
         ].clone()
-        values[torch.arange(values.size(0), device=values.device), columns] = selected
+        # vLLM prepends the sampled token and then appends top-k tokens. When
+        # the sample is also in top-k, its API conversion keeps the last
+        # duplicate, so every matching column must carry the strict value.
+        values = torch.where(matches, selected.unsqueeze(1), values)
         self._last_provenance = {
             **dict(provenance),
             "sampled_token_ids": _tensor_debug_stats(token_ids),

--- a/rl_engine/integrations/megatron_runtime.py
+++ b/rl_engine/integrations/megatron_runtime.py
@@ -9,6 +9,8 @@ import importlib
 from collections.abc import Iterable
 from typing import Any
 
+import torch
+
 from rl_engine.integrations.ablation import Implementation, IntegrationPlan
 from rl_engine.integrations.framework_operators import (
     MegatronAttentionOperator,
@@ -21,6 +23,8 @@ from rl_engine.integrations.state import get_active_integration, set_active_inte
 from rl_engine.integrations.vime.logp import _provider_impl
 
 _PATCH_MARKER = "__rl_kernel_original_forward__"
+_STRICT_ATTENTION_PATCH_MARKER = "__rl_kernel_original_strict_attention_init__"
+_STRICT_ATTENTION_PROJECTION_MARKER = "__rl_kernel_strict_attention_projection__"
 
 
 def _optional_class(path: str) -> type[Any] | None:
@@ -72,6 +76,81 @@ def _patch_forward(
     cls.forward = wrapped
 
 
+def _patch_strict_attention_projections(
+    *,
+    self_attention_cls: type[Any] | None = None,
+    column_linear_cls: type[Any] | None = None,
+    row_linear_cls: type[Any] | None = None,
+    det_gemm: Any | None = None,
+) -> None:
+    """Use the shared deterministic GEMM for Megatron Attention projections."""
+
+    if self_attention_cls is None or column_linear_cls is None or row_linear_cls is None:
+        from megatron.core.tensor_parallel.layers import (
+            ColumnParallelLinear,
+            RowParallelLinear,
+        )
+        from megatron.core.transformer.attention import SelfAttention
+
+        self_attention_cls = SelfAttention
+        column_linear_cls = ColumnParallelLinear
+        row_linear_cls = RowParallelLinear
+    if hasattr(self_attention_cls, _STRICT_ATTENTION_PATCH_MARKER):
+        return
+    if det_gemm is None:
+        from rl_engine.kernels.ops.cuda.matmul.det_gemm import DetGemmOp
+
+        det_gemm = DetGemmOp()
+
+    attention_init = self_attention_cls.__init__
+    column_forward_impl = column_linear_cls._forward_impl
+    row_forward_impl = row_linear_cls._forward_impl
+
+    def deterministic_projection(
+        input_value: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        input_2d = input_value.reshape(-1, input_value.shape[-1])
+        output_2d = det_gemm(input_2d, weight.t().contiguous())
+        output = output_2d.reshape(*input_value.shape[:-1], weight.shape[0])
+        return output if bias is None else output + bias
+
+    def attention_init_wrapped(instance: Any, *args: Any, **kwargs: Any) -> None:
+        attention_init(instance, *args, **kwargs)
+        setattr(instance.linear_qkv, _STRICT_ATTENTION_PROJECTION_MARKER, "qkv")
+        setattr(instance.linear_proj, _STRICT_ATTENTION_PROJECTION_MARKER, "o_proj")
+        # copy_to_tensor_model_parallel_region already owns this TP dgrad reduction.
+        instance.linear_qkv.allreduce_dgrad = False
+
+    def column_forward_impl_wrapped(
+        instance: Any,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if hasattr(instance, _STRICT_ATTENTION_PROJECTION_MARKER):
+            return deterministic_projection(input, weight, kwargs.get("bias"))
+        return column_forward_impl(instance, input, weight, *args, **kwargs)
+
+    def row_forward_impl_wrapped(
+        instance: Any,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        *args: Any,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if hasattr(instance, _STRICT_ATTENTION_PROJECTION_MARKER):
+            return deterministic_projection(input, weight, kwargs.get("bias"))
+        return row_forward_impl(instance, input, weight, *args, **kwargs)
+
+    setattr(self_attention_cls, _STRICT_ATTENTION_PATCH_MARKER, attention_init)
+    self_attention_cls.__init__ = attention_init_wrapped
+    column_linear_cls._forward_impl = column_forward_impl_wrapped
+    row_linear_cls._forward_impl = row_forward_impl_wrapped
+
+
 def install_megatron_integration(
     plan: IntegrationPlan,
     *,
@@ -112,6 +191,8 @@ def install_megatron_integration(
         raise RuntimeError("R/R Megatron FFN selected but no supported class was found")
 
     set_active_integration("megatron", integration)
+    if plan.implementation_for("attention", "training") is Implementation.RL_KERNEL:
+        _patch_strict_attention_projections()
     for cls in resolved_attention:
         _patch_forward(cls, integration=integration, module="attention")
     if resolved_attention:

--- a/rl_engine/integrations/vllm_runtime.py
+++ b/rl_engine/integrations/vllm_runtime.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
+import importlib
 import os
+import sys
 from typing import Any
 
 import torch
+
 from rl_engine.integrations.ablation import (
     Implementation,
     IntegrationPlan,
@@ -28,6 +31,8 @@ from rl_engine.integrations.state import get_active_integration, set_active_inte
 from rl_engine.integrations.vllm import VllmIntegration
 
 _PATCH_MARKER = "__rl_kernel_original_forward__"
+_STRICT_MODEL_PATCH_MARKER = "__rl_kernel_original_strict_model_init__"
+_STRICT_PROJECTION_MARKER = "__rl_kernel_strict_attention_projection__"
 _RLK_ATTENTION_BACKEND: type[Any] | None = None
 _RLK_ATTENTION_IMPL: type[Any] | None = None
 
@@ -237,6 +242,96 @@ def _patch_qwen_ffn(integration: VllmIntegration) -> None:
     integration.record_installed_hook("ffn", "vllm.model_executor.models.qwen2.Qwen2MLP.forward")
 
 
+def _install_flash_attn_ops_compatibility() -> None:
+    """Supply the legacy rotary import tree when an FA4-only package is installed."""
+
+    try:
+        importlib.import_module("flash_attn.ops.triton.rotary")
+        return
+    except (ImportError, OSError, RuntimeError):
+        pass
+
+    from vllm.vllm_flash_attn import ops as bundled_ops
+    from vllm.vllm_flash_attn.ops import triton as bundled_triton
+    from vllm.vllm_flash_attn.ops.triton import rotary as bundled_rotary
+
+    sys.modules.setdefault("flash_attn.ops", bundled_ops)
+    sys.modules.setdefault("flash_attn.ops.triton", bundled_triton)
+    sys.modules.setdefault("flash_attn.ops.triton.rotary", bundled_rotary)
+
+
+def _patch_qwen3_strict_model(
+    *,
+    rms_norm_cls: type[Any] | None = None,
+    linear_method_cls: type[Any] | None = None,
+    attention_cls: type[Any] | None = None,
+    det_gemm: Any | None = None,
+) -> None:
+    """Align vLLM's RMSNorm and Attention projections with Megatron."""
+
+    if rms_norm_cls is None or linear_method_cls is None or attention_cls is None:
+        from vllm.model_executor.layers.layernorm import RMSNorm
+        from vllm.model_executor.layers.linear import UnquantizedLinearMethod
+        from vllm.model_executor.models.qwen3 import Qwen3Attention
+
+        rms_norm_cls = RMSNorm
+        linear_method_cls = UnquantizedLinearMethod
+        attention_cls = Qwen3Attention
+    if hasattr(attention_cls, _STRICT_MODEL_PATCH_MARKER):
+        return
+    if det_gemm is None:
+        from rl_engine.kernels.ops.cuda.matmul.det_gemm import DetGemmOp
+
+        det_gemm = DetGemmOp()
+
+    attention_init = attention_cls.__init__
+    unquantized_apply = linear_method_cls.apply
+
+    def deterministic_linear_apply(
+        method: Any,
+        layer: Any,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if not hasattr(layer, _STRICT_PROJECTION_MARKER):
+            return unquantized_apply(method, layer, x, bias)
+        x_2d = x.reshape(-1, x.shape[-1])
+        output_2d = det_gemm(x_2d, layer.weight.t().contiguous())
+        output = output_2d.reshape(*x.shape[:-1], layer.weight.shape[0])
+        return output if bias is None else output + bias
+
+    def strict_rms_norm_forward_cuda(
+        instance: Any,
+        x: torch.Tensor,
+        residual: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        if instance.variance_size_override is not None:
+            return instance.forward_native(x, residual)
+        if residual is not None:
+            residual = x + residual
+            x = residual
+        weight = instance.weight.data if instance.has_weight else None
+        normalized = torch.nn.functional.rms_norm(
+            x,
+            (instance.hidden_size,),
+            weight,
+            instance.variance_epsilon,
+        )
+        if residual is None:
+            return normalized
+        return normalized, residual
+
+    def attention_init_wrapped(instance: Any, *args: Any, **kwargs: Any) -> None:
+        attention_init(instance, *args, **kwargs)
+        setattr(instance.qkv_proj, _STRICT_PROJECTION_MARKER, "qkv")
+        setattr(instance.o_proj, _STRICT_PROJECTION_MARKER, "o_proj")
+
+    setattr(attention_cls, _STRICT_MODEL_PATCH_MARKER, attention_init)
+    rms_norm_cls.forward_cuda = strict_rms_norm_forward_cuda
+    linear_method_cls.apply = deterministic_linear_apply
+    attention_cls.__init__ = attention_init_wrapped
+
+
 def _patch_sampler(integration: VllmIntegration, *, strict_linear_logp: bool) -> None:
     from vllm.v1.sample.sampler import Sampler
 
@@ -308,8 +403,14 @@ def _patch_worker_sampler(integration: VllmIntegration, *, strict_linear_logp: b
 def _register_attention_backend(integration: VllmIntegration) -> None:
     global _RLK_ATTENTION_BACKEND, _RLK_ATTENTION_IMPL
 
-    from vllm.v1.attention.backends.flash_attn import FlashAttentionBackend, FlashAttentionImpl
-    from vllm.v1.attention.backends.registry import AttentionBackendEnum, register_backend
+    from vllm.v1.attention.backends.flash_attn import (
+        FlashAttentionBackend,
+        FlashAttentionImpl,
+    )
+    from vllm.v1.attention.backends.registry import (
+        AttentionBackendEnum,
+        register_backend,
+    )
 
     operator = VllmAttentionOperator()
     integration.install_operator("attention", operator)
@@ -361,6 +462,11 @@ def install_vllm_integration(plan: IntegrationPlan) -> VllmIntegration:
     integration = VllmIntegration(plan, rl_kernel_operators={})
     set_active_integration("vllm", integration)
     strict_linear_logp = plan.implementation_for("logp", "rollout") is Implementation.RL_KERNEL
+    strict_attention = plan.implementation_for("attention", "rollout") is Implementation.RL_KERNEL
+    if strict_attention or strict_linear_logp:
+        _install_flash_attn_ops_compatibility()
+    if strict_attention:
+        _patch_qwen3_strict_model()
     if strict_linear_logp:
         _patch_qwen_lm_head_padding()
         _patch_qwen_compute_logits(integration)

--- a/rl_engine/kernels/ops/cuda/attention/flash_attn.py
+++ b/rl_engine/kernels/ops/cuda/attention/flash_attn.py
@@ -24,6 +24,8 @@ from rl_engine.kernels.ops.cuda.attention.deterministic_attn import (
 from rl_engine.utils.logger import logger
 
 _FA4_API_SOURCE = "flash_attn.cute.interface"
+_FA4_COMPAT_API_SOURCE = "vllm.vllm_flash_attn.cute.interface"
+_FA4_API_SOURCES = (_FA4_API_SOURCE, _FA4_COMPAT_API_SOURCE)
 _FA4_REQUIRED_PARAMETERS = frozenset(
     {"softmax_scale", "causal", "num_splits", "pack_gqa", "deterministic", "return_lse"}
 )
@@ -33,19 +35,28 @@ class StrictFlashAttentionUnavailable(RuntimeError):
     """Raised when the exact FlashAttention production contract is unavailable."""
 
 
-def _load_fa4_cute_op() -> tuple[Callable[..., Any], str]:
-    try:
-        module = importlib.import_module(_FA4_API_SOURCE)
-        op = getattr(module, "flash_attn_func")
-    except (AttributeError, ImportError, OSError, RuntimeError) as exc:
-        raise StrictFlashAttentionUnavailable(
-            "strict CUDA Attention requires flash_attn.cute.interface.flash_attn_func"
-        ) from exc
-    try:
-        package_version = importlib.metadata.version("flash-attn")
-    except importlib.metadata.PackageNotFoundError:
-        package_version = "unknown"
-    return op, package_version
+def _load_fa4_cute_op() -> tuple[Callable[..., Any], str, str]:
+    errors: list[str] = []
+    for api_source in _FA4_API_SOURCES:
+        try:
+            module = importlib.import_module(api_source)
+            op = getattr(module, "flash_attn_func")
+        except (AttributeError, ImportError, OSError, RuntimeError) as exc:
+            errors.append(f"{api_source}: {exc}")
+            continue
+
+        package_name = "vllm" if api_source == _FA4_COMPAT_API_SOURCE else "flash-attn"
+        try:
+            package_version = importlib.metadata.version(package_name)
+        except importlib.metadata.PackageNotFoundError:
+            package_version = "unknown"
+        return op, package_version, api_source
+
+    raise StrictFlashAttentionUnavailable(
+        "strict CUDA Attention requires a FlashAttention CuTe API; tried "
+        + ", ".join(_FA4_API_SOURCES)
+        + (f" ({'; '.join(errors)})" if errors else "")
+    )
 
 
 class StrictFlashAttention4Core:
@@ -78,13 +89,15 @@ class StrictFlashAttention4Core:
         if requested.mode is not SplitKVMode.DISABLED:
             raise ValueError("strict FA4 Attention requires Split-KV to be disabled")
         if _op is None:
-            op, package_version = _load_fa4_cute_op()
+            op, package_version, api_source = _load_fa4_cute_op()
         else:
             op = _op
             package_version = "test-double" if _package_version is None else _package_version
+            api_source = _FA4_API_SOURCE
         self._validate_api(op)
         self.split_kv = requested
         self.package_version = package_version
+        self.api_source = api_source
         self._op = op
 
     @staticmethod
@@ -138,14 +151,57 @@ class StrictFlashAttention4Core:
         q_fa = q.transpose(1, 2).contiguous()
         k_fa = k.transpose(1, 2).contiguous()
         v_fa = v.transpose(1, 2).contiguous()
-        result = self._op(
+        result = self.forward_bshd_with_lse(
             q_fa,
             k_fa,
             v_fa,
+            causal=causal,
+            scale=scale,
+            key_padding_mask=key_padding_mask,
+            query_position_ids=query_position_ids,
+            key_position_ids=key_position_ids,
+            output_dtype=resolved_dtype,
+        )
+        return DeterministicAttentionCoreResult(
+            out=result.out.transpose(1, 2).contiguous(),
+            lse=result.lse,
+            provenance=result.provenance,
+        )
+
+    def forward_bshd_with_lse(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        *,
+        causal: bool = True,
+        scale: float | None = None,
+        key_padding_mask: torch.Tensor | None = None,
+        query_position_ids: torch.Tensor | None = None,
+        key_position_ids: torch.Tensor | None = None,
+        output_dtype: torch.dtype | None = None,
+    ) -> DeterministicAttentionCoreResult:
+        """Run strict FA4 on tensors already laid out as [B, S, H, D]."""
+        self._validate_bshd_inputs(q, k, v, key_padding_mask)
+        RLKernelDeterministicAttentionCore._validate_positions(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            causal=causal,
+            query_position_ids=query_position_ids,
+            key_position_ids=key_position_ids,
+        )
+        resolved_dtype = q.dtype if output_dtype is None else output_dtype
+        if resolved_dtype != q.dtype:
+            raise ValueError("strict Attention output_dtype must match the Q/K/V input dtype")
+
+        result = self._op(
+            q,
+            k,
+            v,
             softmax_scale=scale,
             causal=causal,
             num_splits=self.num_splits,
-            pack_gqa=q.size(1) > k.size(1),
+            pack_gqa=q.size(2) > k.size(2),
             deterministic=self.deterministic_backward,
             return_lse=True,
         )
@@ -156,9 +212,9 @@ class StrictFlashAttention4Core:
         out_fa, lse = result
         if not isinstance(out_fa, torch.Tensor) or not isinstance(lse, torch.Tensor):
             raise StrictFlashAttentionUnavailable("FlashAttention CuTe returned non-tensor output")
-        expected_out_shape = q_fa.shape
-        expected_lse_shape = (q.size(0), q.size(1), q.size(2))
-        if tuple(out_fa.shape) != tuple(expected_out_shape):
+        expected_out_shape = q.shape
+        expected_lse_shape = (q.size(0), q.size(2), q.size(1))
+        if tuple(out_fa.shape) != expected_out_shape:
             raise StrictFlashAttentionUnavailable(
                 f"FlashAttention output must have shape {tuple(expected_out_shape)}"
             )
@@ -175,9 +231,8 @@ class StrictFlashAttention4Core:
                 "FlashAttention attention-domain LSE must be FP32"
             )
 
-        out = out_fa.transpose(1, 2).contiguous()
         return DeterministicAttentionCoreResult(
-            out=out,
+            out=out_fa,
             lse=lse.contiguous(),
             provenance={
                 "strict_core_id": self.core_id,
@@ -188,7 +243,7 @@ class StrictFlashAttention4Core:
                 "num_splits": self.num_splits,
                 "deterministic_backward": self.deterministic_backward,
                 "dropout_p": 0.0,
-                "split_kv": self.split_kv.resolve(k.size(2), backend=self.backend_id).to_dict(),
+                "split_kv": self.split_kv.resolve(k.size(1), backend=self.backend_id).to_dict(),
                 "merge_order": self.merge_order,
                 "accum_dtype": self.accum_dtype,
                 "downcast_at": self.downcast_at,
@@ -199,6 +254,36 @@ class StrictFlashAttention4Core:
                 "reference_only": self.reference_only,
             },
         )
+
+    @staticmethod
+    def _validate_bshd_inputs(
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        key_padding_mask: torch.Tensor | None,
+    ) -> None:
+        if key_padding_mask is not None:
+            raise ValueError(
+                "strict FA4 core does not accept padding masks; materialize each logical row"
+            )
+        if q.ndim != 4 or k.ndim != 4 or v.ndim != 4:
+            raise ValueError("q/k/v must be 4-D [B, S, H, D]")
+        if q.size(0) != 1:
+            raise ValueError("strict FA4 core executes one logical batch row at a time")
+        if k.size(0) != 1 or v.size(0) != 1:
+            raise ValueError("q/k/v batch sizes must match")
+        if k.shape != v.shape or q.size(3) != k.size(3):
+            raise ValueError("k/v shapes and q/k/v head dimensions must match")
+        if q.size(2) % k.size(2) != 0:
+            raise ValueError("Q heads must be divisible by KV heads for GQA")
+        if q.dtype not in (torch.float16, torch.bfloat16):
+            raise ValueError("strict FA4 core supports FP16/BF16 only")
+        if k.dtype != q.dtype or v.dtype != q.dtype:
+            raise ValueError("q/k/v must share one dtype")
+        if not (q.is_cuda and k.is_cuda and v.is_cuda):
+            raise ValueError("strict FA4 core requires CUDA tensors")
+        if not (q.device == k.device == v.device):
+            raise ValueError("q/k/v must be on one CUDA device")
 
     @staticmethod
     def _validate_inputs(
@@ -273,7 +358,10 @@ class FlashAttentionOp:
             k: (batch, seqlen, nheads_k, headdim)
             v: (batch, seqlen, nheads_k, headdim)
         """
-        assert q.dtype in [torch.float16, torch.bfloat16], "FlashAttention requires FP16 or BF16"
+        assert q.dtype in [
+            torch.float16,
+            torch.bfloat16,
+        ], "FlashAttention requires FP16 or BF16"
         assert q.is_cuda and k.is_cuda and v.is_cuda, "Inputs must be on CUDA device"
 
         q, k, v = q.contiguous(), k.contiguous(), v.contiguous()

--- a/rl_engine/kernels/ops/cuda/norm/rmsnorm.py
+++ b/rl_engine/kernels/ops/cuda/norm/rmsnorm.py
@@ -57,16 +57,18 @@ class RMSNormCuda(torch.autograd.Function):
         """
         Backward:
           dx = CUDA row-wise deterministic kernel
-          dw = CUDA two-pass deterministic kernel
+          dw = FP32 row contributions followed by an ascending-row left fold
         """
         x, weight, rstd, mask = ctx.saved_tensors
         dy = grad_out.contiguous()
 
         dx = _C.rmsnorm_backward_dx(dy, x, weight, rstd)
 
-        # Explicit, shape-independent FP32 left fold. This is slower than
-        # the chunked extension but preserves the C2 Batch/Chunk reduction order.
+        # The shape-independent FP32 left fold preserves the C2 Batch/Chunk
+        # reduction order while the CUDA reducer executes it in one launch.
         rows = rmsnorm_dweight_rows_fp32(x, dy, rstd=rstd)
+        # Multiplication is part of the pre-existing mask contract, including
+        # IEEE propagation for non-finite inactive contributions.
         rows = rows * mask.to(dtype=rows.dtype).unsqueeze(-1)
         dw = reduce_rows_fp32(rows).to(weight.dtype)
         record_backward(

--- a/rl_engine/kernels/ops/vjp_fp32.py
+++ b/rl_engine/kernels/ops/vjp_fp32.py
@@ -10,8 +10,11 @@ walk rows in the caller's order so C10 can re-aggregate by logical token.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from math import prod
 
 import torch
+
+from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
 
 BACKWARD_IMPL = "row_local_fp32_vjp"
 
@@ -76,11 +79,26 @@ def rmsnorm_dweight_rows_fp32(
 def reduce_rows_fp32(rows: torch.Tensor) -> torch.Tensor:
     """Left-fold dim 0 in FP32. Deterministic for a fixed row order."""
 
-    flat = rows.reshape(rows.shape[0], -1).float()
+    if rows.dim() == 0:
+        raise ValueError("rows must have at least one dimension")
+
+    output_shape = tuple(rows.shape[1:])
+    columns = prod(output_shape)
+    flat = rows.reshape(rows.shape[0], columns).float()
+
+    if (
+        flat.is_cuda
+        and torch.version.hip is None
+        and _EXT_AVAILABLE
+        and hasattr(_C, "reduce_rows_fp32_left_fold")
+    ):
+        reduced = _C.reduce_rows_fp32_left_fold(flat.contiguous())
+        return reduced.reshape(output_shape)
+
     acc = torch.zeros((flat.shape[1],), device=flat.device, dtype=torch.float32)
     for index in range(flat.shape[0]):
         acc = acc + flat[index]
-    return acc.reshape(rows.shape[1:])
+    return acc.reshape(output_shape)
 
 
 def reduce_keyed_rows_fp32(

--- a/tests/test_flashinfer_pr7_attention.py
+++ b/tests/test_flashinfer_pr7_attention.py
@@ -32,7 +32,9 @@ from rl_engine.kernels.ops.cuda.attention.cp_comm import (
     P2PNCCLAttentionCPCommunication,
     sort_attention_cp_partial_states,
 )
-from rl_engine.kernels.ops.cuda.attention.deterministic_attn import DeterministicAttentionCoreResult
+from rl_engine.kernels.ops.cuda.attention.deterministic_attn import (
+    DeterministicAttentionCoreResult,
+)
 from rl_engine.kernels.ops.cuda.attention.flash_attn import (
     StrictFlashAttention4Core,
     StrictFlashAttentionUnavailable,
@@ -1913,6 +1915,7 @@ def test_fa4_core_fixes_reduction_controls_and_exports_fp32_lse(monkeypatch):
 
     core = StrictFlashAttention4Core(_op=fake_fa4, _package_version="4.test")
     monkeypatch.setattr(core, "_validate_inputs", lambda *_args: None)
+    monkeypatch.setattr(core, "_validate_bshd_inputs", lambda *_args: None)
     q = torch.randn(1, 4, 2, 8, dtype=torch.bfloat16)
     k = torch.randn(1, 2, 3, 8, dtype=torch.bfloat16)
     v = torch.randn(1, 2, 3, 8, dtype=torch.bfloat16)
@@ -1947,6 +1950,63 @@ def test_fa4_core_fixes_reduction_controls_and_exports_fp32_lse(monkeypatch):
     assert result.provenance["dropout_p"] == 0.0
     assert result.provenance["native_attention_arithmetic"] is True
     assert result.provenance["production_ready"] is True
+
+
+def test_fa4_core_bshd_entrypoint_preserves_framework_layout(monkeypatch):
+    calls = []
+
+    def fake_fa4(
+        q,
+        k,
+        v,
+        *,
+        softmax_scale=None,
+        causal=False,
+        num_splits=0,
+        pack_gqa=None,
+        deterministic=False,
+        return_lse=False,
+    ):
+        calls.append(
+            {
+                "q_shape": tuple(q.shape),
+                "k_shape": tuple(k.shape),
+                "pack_gqa": pack_gqa,
+                "num_splits": num_splits,
+                "return_lse": return_lse,
+            }
+        )
+        return q.clone(), torch.zeros(
+            q.size(0), q.size(2), q.size(1), dtype=torch.float32, device=q.device
+        )
+
+    core = StrictFlashAttention4Core(_op=fake_fa4, _package_version="4.test")
+    monkeypatch.setattr(core, "_validate_bshd_inputs", lambda *_args: None)
+    q = torch.randn(1, 2, 4, 8, dtype=torch.bfloat16)
+    k = torch.randn(1, 3, 2, 8, dtype=torch.bfloat16)
+    v = torch.randn(1, 3, 2, 8, dtype=torch.bfloat16)
+
+    result = core.forward_bshd_with_lse(
+        q,
+        k,
+        v,
+        causal=False,
+        query_position_ids=torch.tensor([[2, 3]]),
+        key_position_ids=torch.tensor([[0, 1, 2]]),
+    )
+
+    assert calls == [
+        {
+            "q_shape": (1, 2, 4, 8),
+            "k_shape": (1, 3, 2, 8),
+            "pack_gqa": True,
+            "num_splits": 1,
+            "return_lse": True,
+        }
+    ]
+    assert result.out.shape == q.shape
+    assert result.lse.shape == (1, 4, 2)
+    assert result.lse.dtype is torch.float32
 
 
 def test_strict_paged_default_selects_fa4_production_core(monkeypatch):

--- a/tests/test_framework_runtime_adapters.py
+++ b/tests/test_framework_runtime_adapters.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 
 import ast
 import os
+from collections import namedtuple
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-import rl_engine.integrations.framework_operators as framework_operators
 import torch
+
+import rl_engine.integrations.framework_operators as framework_operators
 from rl_engine.integrations.ablation import (
     IntegrationPlan,
     configure_integration_environment,
@@ -19,14 +22,21 @@ from rl_engine.integrations.ablation import (
 from rl_engine.integrations.framework_operators import (
     MegatronAttentionOperator,
     SemanticOperatorHandle,
+    VllmLogpOperator,
     _megatron_zigzag_layout,
     _packed_local_sequence_layout,
     _vllm_kv_cache_views,
 )
-from rl_engine.integrations.megatron_runtime import install_megatron_integration
+from rl_engine.integrations.megatron_runtime import (
+    _patch_strict_attention_projections,
+    install_megatron_integration,
+)
 from rl_engine.integrations.runtime import FrameworkOperatorIntegration
 from rl_engine.integrations.state import clear_active_integration
-from rl_engine.integrations.vllm_runtime import configure_vllm_environment
+from rl_engine.integrations.vllm_runtime import (
+    _patch_qwen3_strict_model,
+    configure_vllm_environment,
+)
 from rl_engine.kernels.attention_contract import (
     STRICT_ATTENTION_FA4_SCHEDULE_ID,
     STRICT_ATTENTION_PRODUCTION_CORE_ID,
@@ -37,7 +47,9 @@ from rl_engine.kernels.attention_contract import (
     ReductionSpec,
     ShardingSpec,
 )
-from rl_engine.kernels.ops.cuda.attention.strict_runtime import StrictCUDAAttentionRuntime
+from rl_engine.kernels.ops.cuda.attention.strict_runtime import (
+    StrictCUDAAttentionRuntime,
+)
 
 
 def test_framework_adapters_do_not_construct_registered_kernels_directly():
@@ -249,6 +261,141 @@ def test_vllm_current_flash_attention_kv_cache_layout_is_materialized():
     assert value.shape == (2, 4, 3, 5)
     assert torch.equal(key, cache.transpose(1, 2)[..., :5])
     assert torch.equal(value, cache.transpose(1, 2)[..., 5:])
+
+
+def test_megatron_strict_attention_projections_install_without_debug_environment(
+    monkeypatch,
+):
+    monkeypatch.delenv("RL_KERNEL_MODEL_DEBUG_DIR", raising=False)
+
+    class ColumnLinear:
+        def __init__(self):
+            self.allreduce_dgrad = True
+
+        def _forward_impl(self, input, weight, *args, **kwargs):
+            del args, kwargs
+            return input.new_full((*input.shape[:-1], weight.shape[0]), -1)
+
+    class RowLinear:
+        def _forward_impl(self, input, weight, *args, **kwargs):
+            del args, kwargs
+            return input.new_full((*input.shape[:-1], weight.shape[0]), -1)
+
+    class SelfAttention:
+        def __init__(self):
+            self.linear_qkv = ColumnLinear()
+            self.linear_proj = RowLinear()
+
+    _patch_strict_attention_projections(
+        self_attention_cls=SelfAttention,
+        column_linear_cls=ColumnLinear,
+        row_linear_cls=RowLinear,
+        det_gemm=lambda lhs, rhs: lhs @ rhs,
+    )
+    attention = SelfAttention()
+    value = torch.tensor([[1.0, 2.0]])
+    weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+
+    qkv = attention.linear_qkv._forward_impl(value, weight, bias=None)
+    projection = attention.linear_proj._forward_impl(value, weight, bias=None)
+    native = ColumnLinear()._forward_impl(value, weight, bias=None)
+
+    assert torch.equal(qkv, torch.tensor([[1.0, 2.0, 3.0]]))
+    assert torch.equal(projection, qkv)
+    assert torch.equal(native, torch.full((1, 3), -1.0))
+    assert attention.linear_qkv.allreduce_dgrad is False
+
+
+def test_vllm_qwen3_strict_model_installs_without_debug_environment(monkeypatch):
+    monkeypatch.delenv("RL_KERNEL_MODEL_DEBUG_DIR", raising=False)
+
+    class RMSNorm:
+        def __init__(self):
+            self.variance_size_override = None
+            self.has_weight = True
+            self.hidden_size = 2
+            self.weight = torch.tensor([1.5, 0.5])
+            self.variance_epsilon = 1e-6
+
+        def forward_cuda(self, x, residual=None):
+            del residual
+            return x.new_full(x.shape, -1)
+
+        def forward_native(self, x, residual=None):
+            del residual
+            return x.new_full(x.shape, -2)
+
+    class LinearLayer:
+        def __init__(self):
+            self.weight = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+
+    class LinearMethod:
+        def apply(self, layer, x, bias=None):
+            del bias
+            return x.new_full((*x.shape[:-1], layer.weight.shape[0]), -1)
+
+    class Attention:
+        def __init__(self):
+            self.qkv_proj = LinearLayer()
+            self.o_proj = LinearLayer()
+
+    _patch_qwen3_strict_model(
+        rms_norm_cls=RMSNorm,
+        linear_method_cls=LinearMethod,
+        attention_cls=Attention,
+        det_gemm=lambda lhs, rhs: lhs @ rhs,
+    )
+    attention = Attention()
+    method = LinearMethod()
+    value = torch.tensor([[1.0, 2.0]])
+    norm = RMSNorm()
+
+    assert torch.equal(
+        method.apply(attention.qkv_proj, value),
+        torch.tensor([[1.0, 2.0, 3.0]]),
+    )
+    assert torch.equal(
+        method.apply(LinearLayer(), value),
+        torch.full((1, 3), -1.0),
+    )
+    assert torch.equal(
+        norm.forward_cuda(value),
+        torch.nn.functional.rms_norm(value, (2,), norm.weight, 1e-6),
+    )
+
+
+def test_vllm_logp_replaces_every_duplicate_sampled_token_column():
+    logprobs_type = namedtuple(
+        "LogprobsTensors",
+        ("logprob_token_ids", "logprobs", "selected_token_ranks"),
+    )
+
+    @dataclass(frozen=True)
+    class SamplerResult:
+        sampled_token_ids: torch.Tensor
+        logprobs_tensors: object
+
+    operator = VllmLogpOperator(lambda *_args, **_kwargs: None)
+    result = SamplerResult(
+        sampled_token_ids=torch.tensor([[7], [8]]),
+        logprobs_tensors=logprobs_type(
+            logprob_token_ids=torch.tensor([[7, 7], [8, 9]]),
+            logprobs=torch.tensor([[-0.1, -0.1], [-0.2, -0.3]]),
+            selected_token_ranks=torch.tensor([1, 2]),
+        ),
+    )
+
+    updated = operator._replace_sampled_value(
+        result,
+        token_ids=torch.tensor([7, 8]),
+        selected=torch.tensor([-1.25, -2.5]),
+        provenance={},
+    )
+
+    assert torch.equal(
+        updated.logprobs_tensors.logprobs,
+        torch.tensor([[-1.25, -1.25], [-2.5, -0.3]]),
+    )
 
 
 def _cp1_contract(tokens: int) -> AttentionContract:

--- a/tests/test_vjp_fp32.py
+++ b/tests/test_vjp_fp32.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+
+import rl_engine.kernels.ops.vjp_fp32 as vjp_fp32
+from rl_engine.kernels.ops.vjp_fp32 import reduce_rows_fp32
+
+_ROOT = Path(__file__).resolve().parents[1]
+_CUDA_SOURCE = _ROOT / "csrc" / "cuda" / "rmsnorm.cu"
+_OPS_SOURCE = _ROOT / "csrc" / "ops.cpp"
+_RMSNORM_BACKENDS = (
+    _ROOT / "rl_engine" / "kernels" / "ops" / "cuda" / "norm" / "rmsnorm.py",
+    _ROOT / "rl_engine" / "kernels" / "ops" / "triton" / "rmsnorm_triton.py",
+)
+
+
+def _left_fold_reference(rows: torch.Tensor) -> torch.Tensor:
+    output_shape = tuple(rows.shape[1:])
+    columns = 1
+    for extent in output_shape:
+        columns *= extent
+    flat = rows.reshape(rows.shape[0], columns).float()
+    acc = torch.zeros(columns, device=rows.device, dtype=torch.float32)
+    for row in range(flat.shape[0]):
+        acc = acc + flat[row]
+    return acc.reshape(output_shape)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1),
+        (32, 128),
+        (1024, 128),
+        (37, 127),
+        (3, 2, 5),
+        (4,),
+    ],
+)
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float16, torch.bfloat16, torch.float32, torch.float64],
+)
+def test_reduce_rows_fp32_matches_ascending_left_fold_on_cpu(shape, dtype):
+    values = torch.arange(torch.tensor(shape).prod().item(), dtype=torch.float32)
+    rows = ((values.remainder(29) - 14) / 8).reshape(shape).to(dtype)
+
+    reduced = reduce_rows_fp32(rows)
+
+    assert reduced.dtype == torch.float32
+    assert torch.equal(reduced, _left_fold_reference(rows))
+
+
+def test_reduce_rows_fp32_pins_non_associative_order():
+    rows = torch.tensor([[1.0e20], [1.0], [-1.0e20], [1.0]], dtype=torch.float32)
+
+    reduced = reduce_rows_fp32(rows)
+
+    assert torch.equal(reduced, torch.tensor([1.0], dtype=torch.float32))
+
+
+def test_reduce_rows_fp32_accepts_noncontiguous_rows():
+    rows = torch.arange(7 * 37, dtype=torch.float32).reshape(7, 37).transpose(0, 1)
+    assert not rows.is_contiguous()
+
+    assert torch.equal(reduce_rows_fp32(rows), _left_fold_reference(rows))
+
+
+@pytest.mark.parametrize("shape", [(0, 128), (0, 2, 3), (0,), (4, 0)])
+def test_reduce_rows_fp32_empty_boundaries(shape):
+    rows = torch.empty(shape, dtype=torch.bfloat16)
+
+    reduced = reduce_rows_fp32(rows)
+
+    assert reduced.shape == rows.shape[1:]
+    assert reduced.dtype == torch.float32
+    assert torch.equal(reduced, torch.zeros(rows.shape[1:], dtype=torch.float32))
+
+
+def test_reduce_rows_fp32_rejects_scalar_input():
+    with pytest.raises(ValueError, match="at least one dimension"):
+        reduce_rows_fp32(torch.tensor(1.0))
+
+
+def test_reduce_rows_fp32_keeps_cpu_fallback_when_extension_is_present(monkeypatch):
+    class _UnexpectedExtensionCall:
+        def reduce_rows_fp32_left_fold(self, rows):
+            raise AssertionError(f"CPU rows reached the CUDA extension: {rows.shape}")
+
+    monkeypatch.setattr(vjp_fp32, "_EXT_AVAILABLE", True)
+    monkeypatch.setattr(vjp_fp32, "_C", _UnexpectedExtensionCall())
+    rows = torch.arange(33 * 5, dtype=torch.float32).reshape(33, 5)
+
+    assert torch.equal(reduce_rows_fp32(rows), _left_fold_reference(rows))
+
+
+def test_cuda_left_fold_is_one_ordered_kernel_launch():
+    source = _CUDA_SOURCE.read_text(encoding="utf-8")
+    kernel_start = source.index("__global__ void reduce_rows_fp32_left_fold_kernel")
+    launcher_start = source.index("void reduce_rows_fp32_left_fold_cuda")
+    kernel = source[kernel_start:launcher_start]
+    launcher = source[launcher_start:]
+
+    assert "for (int64_t row = 0; row < row_count; ++row)" in kernel
+    assert "#pragma unroll 1" in kernel
+    assert "__fadd_rn(acc, rows[row * columns + column])" in kernel
+    assert "float acc = 0.0f;" in kernel
+    assert "output[column] = acc;" in kernel
+    assert "tl.sum" not in kernel
+    assert "cub::" not in kernel.lower()
+    assert launcher.count("reduce_rows_fp32_left_fold_kernel<<<") == 1
+
+
+def test_cuda_left_fold_binding_has_no_multilaunch_reduction():
+    source = _OPS_SOURCE.read_text(encoding="utf-8")
+    tree = ast.parse((_ROOT / "rl_engine" / "kernels" / "ops" / "vjp_fp32.py").read_text())
+    reduce_function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "reduce_rows_fp32"
+    )
+
+    extension_calls = [
+        node
+        for node in ast.walk(reduce_function)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "reduce_rows_fp32_left_fold"
+    ]
+    assert len(extension_calls) == 1
+    assert source.count('m.def(\n        "reduce_rows_fp32_left_fold"') == 1
+    assert "if (rows.size(1) != 0)" in source
+
+
+def test_cuda_and_triton_rmsnorm_share_the_left_fold_entrypoint():
+    for path in _RMSNORM_BACKENDS:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "reduce_rows_fp32"
+        ]
+        assert len(calls) == 1, path
+
+
+_HAS_CUDA_LEFT_FOLD = (
+    torch.cuda.is_available()
+    and torch.version.hip is None
+    and vjp_fp32._EXT_AVAILABLE
+    and hasattr(vjp_fp32._C, "reduce_rows_fp32_left_fold")
+)
+
+
+@pytest.mark.skipif(not _HAS_CUDA_LEFT_FOLD, reason="CUDA left-fold extension is unavailable")
+@pytest.mark.parametrize("shape", [(32, 128), (1024, 128), (37, 127), (0, 128), (4, 0)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_cuda_reduce_rows_fp32_is_bitwise_equal_to_original_row_loop(shape, dtype):
+    generator = torch.Generator().manual_seed(17)
+    rows = torch.randn(shape, generator=generator, dtype=torch.float32).to(
+        device="cuda", dtype=dtype
+    )
+
+    expected = _left_fold_reference(rows)
+    reduced = reduce_rows_fp32(rows)
+
+    assert torch.equal(reduced, expected)


### PR DESCRIPTION
> Depends on [#339](https://github.com/RL-Align/RL-Kernel/pull/339). Please merge #339 before this PR.

## Summary

- Replace the per-row Python reduction in RMSNorm `dweight` with a single CUDA kernel.
- Preserve the exact ascending FP32 left-fold order with `__fadd_rn`, without atomics or reassociation.
- Share the CUDA fast path across the CUDA and Triton RMSNorm backward implementations while keeping the existing CPU and ROCm fallbacks.

The reduction launch count is reduced from `rows` to `1`.

## Performance

The following measurements time one complete FP32 row-reduction invocation. RMSNorm contribution generation and input preparation are excluded. `Rows` is the flattened product of all leading dimensions; for QK-Norm, these are typically batch, token, and head dimensions.

H100 80GB, FP32, PyTorch 2.9.1+cu128, CUDA 12.8. Each value is the median synchronized wall time across seven repeats.

### QK-Norm head dimension

`columns=128`:

| Rows | Previous reduction | New reduction | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 0.0180 ms | 0.0087 ms | 2.1× |
| 2 | 0.0250 ms | 0.0087 ms | 2.9× |
| 4 | 0.0388 ms | 0.0088 ms | 4.4× |
| 8 | 0.0658 ms | 0.0087 ms | 7.6× |
| 16 | 0.1192 ms | 0.0087 ms | 13.8× |
| 32 | 0.2258 ms | 0.0088 ms | 25.6× |
| 64 | 0.4471 ms | 0.0116 ms | 38.5× |
| 128 | 0.8653 ms | 0.0214 ms | 40.4× |
| 256 | 1.7339 ms | 0.0412 ms | 42.1× |
| 512 | 3.4341 ms | 0.0805 ms | 42.7× |
| 1,024 | 6.8643 ms | 0.1589 ms | 43.2× |
| 2,048 | 13.8142 ms | 0.3167 ms | 43.6× |
| 4,096 | 27.5826 ms | 0.6308 ms | 43.7× |
| 8,192 | 54.9083 ms | 1.2598 ms | 43.6× |
| 16,384 | 109.7944 ms | 2.5178 ms | 43.6× |

### Model hidden dimension

`columns=4096`:

| Rows | Previous reduction | New reduction | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 0.0181 ms | 0.0088 ms | 2.1× |
| 8 | 0.0658 ms | 0.0088 ms | 7.5× |
| 32 | 0.2279 ms | 0.0088 ms | 25.8× |
| 128 | 0.8682 ms | 0.0224 ms | 38.8× |
| 512 | 3.4784 ms | 0.0837 ms | 41.6× |
| 1,024 | 6.9332 ms | 0.1657 ms | 41.8× |
| 2,048 | 13.9128 ms | 0.4558 ms | 30.5× |
| 4,096 | 27.6102 ms | 1.5472 ms | 17.9× |

### Column coverage

`rows=1024`:

| Columns | Previous reduction | New reduction | Speedup |
| ---: | ---: | ---: | ---: |
| 64 | 6.9214 ms | 0.1592 ms | 43.5× |
| 128 | 6.8643 ms | 0.1589 ms | 43.2× |
| 256 | 6.9481 ms | 0.1601 ms | 43.4× |
| 1,024 | 6.9287 ms | 0.1625 ms | 42.6× |
| 2,048 | 6.9533 ms | 0.1631 ms | 42.6× |
| 4,096 | 6.9332 ms | 0.1657 ms | 41.8× |
| 8,192 | 6.8612 ms | 0.2178 ms | 31.5× |

## Validation

- Bitwise equal to the original ascending FP32 `acc = acc + row` loop in all 28 benchmark configurations, with `max_abs_error = 0`.
- Preserves the non-associative left-fold order without atomics, tree reductions, or CUB reductions.
- Covers FP16, BF16, and FP32 CUDA inputs, empty boundaries, non-contiguous inputs, multidimensional rows, and the CPU fallback.
