### PR TITLE
docs: add DCO 1.1 text and contributor sign-off guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,9 @@ requests, documentation improvements, and code contributions are all welcome.
 
 Every commit in a pull request must carry a `Signed-off-by:` trailer, per the
 [Developer Certificate of Origin](./DCO) (DCO), version 1.1. The DCO check is
-enforced as a required status check on every pull request.
+enforced as a required status check on every pull request. The only exception
+is automation explicitly exempted in the DCO app configuration (see the
+signing policies below).
 
 By signing off, you certify that you wrote the change or otherwise have the
 right to submit it under the project's open source license.
@@ -74,8 +76,9 @@ so commits are attributed to you and the DCO check passes.
   be signed off by its own author.
 - Commits authored by bots or other automation must satisfy the email-match
   rule like any other commit: the sign-off must carry the bot's own author
-  email, or the automation must be exempted in the DCO app configuration.
-  A human who submits or merges automation results remains responsible for
+  email. Automation that cannot sign its own commits may instead be exempted
+  in the DCO app configuration — the only exception to the rule above. A
+  human who submits or merges automation results remains responsible for
   the change.
 - AI-assisted contributions are welcome. The human submitter signs off and
   remains responsible for the correctness and licensing of the contribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,91 @@
+# Contributing to RL-Kernel
+
+Thank you for your interest in contributing to RL-Kernel. Bug reports, feature
+requests, documentation improvements, and code contributions are all welcome.
+
+- For bugs and feature requests, please
+  [open an issue](https://github.com/RL-Align/RL-Kernel/issues) first.
+- For code changes, open a pull request against `main` and keep it focused on
+  a single topic.
+- For questions and discussion, reach the community on
+  [Slack](https://rl-align.slack.com) or [WeChat](./docs/community/wechat.md).
+
+## Sign your work (DCO)
+
+Every commit in a pull request must carry a `Signed-off-by:` trailer, per the
+[Developer Certificate of Origin](./DCO) (DCO), version 1.1. The DCO check is
+enforced as a required status check on every pull request.
+
+By signing off, you certify that you wrote the change or otherwise have the
+right to submit it under the project's open source license.
+
+Sign a new commit:
+
+```bash
+git commit -s
+```
+
+This appends `Signed-off-by: Your Name <your.email@example.com>` to the commit
+message.
+
+Repair commits you have already pushed (for example, when the DCO check
+reports a missing sign-off). If you work from a fork, rebase onto the upstream
+repository:
+
+```bash
+git remote add upstream https://github.com/RL-Align/RL-Kernel.git  # once, if missing
+git fetch upstream
+git rebase --signoff upstream/main
+git push --force-with-lease
+```
+
+If you cloned the project repository directly, rebase onto `origin/main`
+instead:
+
+```bash
+git fetch origin
+git rebase --signoff origin/main
+git push --force-with-lease
+```
+
+The DCO check validates the **email address**: the `Signed-off-by:` email
+must match the commit author email. Using `git commit -s` guarantees this,
+since it signs with your configured `user.name` and `user.email`:
+
+```text
+Author:         Your Name <your.email@example.com>
+Signed-off-by:  Your Name <your.email@example.com>
+```
+
+Sign with a name that identifies you to the project — your real name, or a
+name or handle linked to your GitHub account. The automated check compares
+only the email; the name is what maintainers use to recognize who made the
+certification.
+
+### Email matching
+
+If you contribute from several machines, keep `git config user.email`
+consistent, and make sure the address is associated with your GitHub account
+so commits are attributed to you and the DCO check passes.
+
+### Signing policies
+
+- `Co-authored-by:` trailers do not replace `Signed-off-by:`; each commit must
+  be signed off by its own author.
+- Commits produced by bots or other automation must still be signed off by the
+  human who submits them. The submitting human is responsible for the change.
+- AI-assisted contributions are welcome. The human submitter signs off and
+  remains responsible for the correctness and licensing of the contribution.
+
+## Pull requests opened before the DCO check was enabled
+
+For pull requests created before the DCO check became a required status check,
+maintainers will leave a one-time comment pointing to this guide. Authors are
+asked to add the missing sign-offs within a four-week grace period. Pull
+requests that still fail the DCO check after the grace period may be closed,
+with an invitation to reopen once the commits are signed.
+
+## Development guide
+
+For setting up a development environment, running tests, and documentation
+conventions, see the [developer guide](./docs/contributing/README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,13 +51,22 @@ git push --force-with-lease
 ```
 
 The DCO check validates the **email address**: the `Signed-off-by:` email
-must match the commit author email. Using `git commit -s` guarantees this,
-since it signs with your configured `user.name` and `user.email`:
+must match the commit author email. `git commit -s` and
+`git rebase --signoff` sign with your configured `user.name` and
+`user.email` — the **committer** identity. The sign-off therefore matches
+whenever you are also the commit's author, which is the normal case for
+your own work:
 
 ```text
 Author:         Your Name <your.email@example.com>
 Signed-off-by:  Your Name <your.email@example.com>
 ```
+
+Your own sign-off cannot repair a commit authored by someone else — for
+example one you cherry-picked or applied from a patch: the trailer records
+your identity and will not match their author email. Such commits need a
+sign-off from their own author. Automation that cannot carry a matching
+sign-off falls under the exemption described in the signing policies below.
 
 Sign with a name that identifies you to the project — your real name, or a
 name or handle linked to your GitHub account. The automated check compares
@@ -67,8 +76,9 @@ certification.
 ### Email matching
 
 If you contribute from several machines, keep `git config user.email`
-consistent, and make sure the address is associated with your GitHub account
-so commits are attributed to you and the DCO check passes.
+consistent, and use an address associated with your GitHub account so commits
+are attributed to you. The DCO check itself only compares the commit author
+email with the sign-off email.
 
 ### Signing policies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,11 @@ so commits are attributed to you and the DCO check passes.
 
 - `Co-authored-by:` trailers do not replace `Signed-off-by:`; each commit must
   be signed off by its own author.
-- Commits produced by bots or other automation must still be signed off by the
-  human who submits them. The submitting human is responsible for the change.
+- Commits authored by bots or other automation must satisfy the email-match
+  rule like any other commit: the sign-off must carry the bot's own author
+  email, or the automation must be exempted in the DCO app configuration.
+  A human who submits or merges automation results remains responsible for
+  the change.
 - AI-assisted contributions are welcome. The human submitter signs off and
   remains responsible for the correctness and licensing of the contribution.
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,33 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ RL_KERNEL_REQUIRE_EXT=1 python -m pip install --no-build-isolation -e .
 python -c "import rl_engine._C as _C; assert hasattr(_C, 'fused_logp'); print(_C.__file__)"
 ```
 
-### Contributions
+### Contributing
+Contributions are welcome! Before opening a pull request, please read [CONTRIBUTING.md](./CONTRIBUTING.md). Every commit must include a `Signed-off-by:` line, per the [Developer Certificate of Origin](./DCO).
+
 Inspired by the kernel designs of vLLM and DeepSpeed. As an active contributor to the AI Infrastructure ecosystem, RL-Kernel aims to push the boundaries of RL efficiency.
 
 Target: Building the most efficient RLHF toolchain for the open-source community.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -3,6 +3,26 @@
 This section collects general contribution material, design documents, and operator
 development notes for RL-Kernel.
 
+## Sign your work (DCO)
+
+Every commit in a pull request must include a `Signed-off-by:` trailer
+matching the commit author. The DCO check is enforced as a required status
+check.
+
+```bash
+# Sign a new commit:
+git commit -s
+
+# Repair commits you have already pushed (fork workflow):
+git fetch upstream
+git rebase --signoff upstream/main
+git push --force-with-lease
+```
+
+For email-matching rules, signing policies, and the transition policy for
+older pull requests, see
+[CONTRIBUTING.md](https://github.com/RL-Align/RL-Kernel/blob/main/CONTRIBUTING.md).
+
 Before merging a new operator, include:
 
 - The implementation and dispatch registration.


### PR DESCRIPTION
## Motivation

The DCO GitHub App is installed and its check is required, but the
repository currently documents nothing about it — a contributor whose
pull request turns red on a missing sign-off has no in-repo guidance.
This adds the documentation planned in #358 (section 1, repository-side
items; implementation order, step 1).

## Changes

- **`DCO`** — the unmodified Developer Certificate of Origin 1.1 text,
  taken verbatim from <https://developercertificate.org/>.
- **`CONTRIBUTING.md`** — the canonical contribution guide: sign-off
  commands (`git commit -s`; fork-first `rebase --signoff` repair), email
  matching, co-author/bot/AI-assistance signing policies, and the
  transition policy for pull requests opened before the check was enabled.
- **`README.md`** — a short "Contributing" section linking the guide.
- **`docs/contributing/README.md`** — a compact sign-off quick reference
  for the documentation site; links to `CONTRIBUTING.md` for full rules.

## Verification

- `/DCO` byte-compared against the canonical text at
  developercertificate.org.
- Commit is signed off (`Signed-off-by` matches the commit author).
- Docs-only change; no code or workflow files touched. The mkdocs strict
  build in CI is the relevant check for the docs-site page.

## Notes for reviewers

- The **four-week grace period** in the transition policy is an initial
  proposal — please confirm or adjust.
- Sign-off commands intentionally appear in both `CONTRIBUTING.md`
  (canonical) and the docs-site quick reference (website readers should
  not have to leave the site). When editing one, please keep the other
  in sync.
- Out of scope, tracked in #358 as later steps:
  `.github/PULL_REQUEST_TEMPLATE.md` and title validation (step 2), and
  the new-PR welcome comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive contribution guidelines covering pull requests, commit sign-offs, email matching, contribution policies, automation, and AI-assisted contributions.
  - Added the complete Developer Certificate of Origin (DCO) text.
  - Updated the README and developer guide with contribution links, DCO requirements, and instructions for signing new commits or correcting existing commits.
  - Documented DCO enforcement and transition guidance for older pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->