### PR TITLE
fix: restore NPU dispatch for PR #361 unit-tests

### DIFF
--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -104,6 +104,9 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     CUDA_BATCH_INVARIANT_LOGP_SM90 = (
         "rl_engine.kernels.ops.cuda.loss.batch_invariant_logp.BatchInvariantLogpSM90Op"
     )
+    ASCEND_BATCH_INVARIANT_LOGP = (
+        "rl_engine.kernels.ops.ascend.loss.batch_invariant_logp.BatchInvariantLogpAscendOp"
+    )
     # Deterministic vocab-parallel TP logprob reference (WS2 #241 PR3)
     PYTORCH_VOCAB_PARALLEL_LOGP = (
         "rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp.VocabParallelLogprobOp"
@@ -610,6 +613,15 @@ class KernelRegistry:
                 "swiglu": [OpBackend.PYTORCH_NATIVE_SWIGLU],
             },
         }
+        # Preserve the former CPU fallback behavior for every operator on NPU,
+        # then override only the operator with an Ascend-specific backend.
+        self._priority_map["npu"] = {
+            op_type: candidates.copy() for op_type, candidates in self._priority_map["cpu"].items()
+        }
+        self._priority_map["npu"]["batch_invariant_logp"] = [
+            OpBackend.ASCEND_BATCH_INVARIANT_LOGP,
+            OpBackend.PYTORCH_BATCH_INVARIANT_LOGP,
+        ]
         logger.info(f"KernelRegistry initialized for {device_ctx.device_type}")
         self._adjust_priority_for_hardware()
         self._adjust_priority_from_env()
@@ -993,6 +1005,10 @@ class KernelRegistry:
             return "rocm"
         if device_ctx.device_type == "cuda":
             return "cuda"
+        if device_ctx.device_type == "npu":
+            return "npu"
+        if device_ctx.is_musa or device_ctx.device_type == "musa":
+            return "musa"
         return "cpu"
 
     def _get_or_create_backend(self, backend: OpBackend) -> Optional[Any]:

--- a/tests/test_cross_config_drift_report.py
+++ b/tests/test_cross_config_drift_report.py
@@ -258,6 +258,7 @@ def test_consistency_trace_is_expandable_chrome_trace_json(tmp_path: Path):
 
 @pytest.mark.unit
 def test_consistency_bundle_contains_report_trace_and_preview(tmp_path: Path):
+    pytest.importorskip("PIL")
     manifest, cube = _artifacts()
     report = build_drift_report(replay_manifest=manifest, result_cube=cube)
 

--- a/tests/test_qwen_ffn.py
+++ b/tests/test_qwen_ffn.py
@@ -818,6 +818,10 @@ def test_qwen_ffn_backward_matches_autograd_reference(monkeypatch):
     monkeypatch.setattr(ffn_module, "_C", stub)
     monkeypatch.setattr(ffn_module, "_EXT_AVAILABLE", True)
     monkeypatch.setattr(ffn_module, "_validate_ffn_inputs", lambda *args: None)
+    monkeypatch.setattr(
+        "rl_engine.kernels.ops.cuda.matmul.det_gemm._require_sm90_backend",
+        lambda: None,
+    )
 
     hidden = _randn((2, 3, 8), seed=0)
     gate_weight = _randn((12, 8), seed=1)
@@ -903,7 +907,7 @@ def test_qwen_ffn_deterministic_false_uses_production_gemm(monkeypatch):
 
     tensors = [torch.empty(1)] * 4
     assert qwen3_ffn(*tensors, deterministic=False) is False
-    assert modes == [{"disable_split_k": False}]
+    assert modes == [{"disable_split_k": False, "packed_gate_up": False}]
 
 
 def test_qwen_ffn_rejects_conflicting_backend_switches():


### PR DESCRIPTION
## Summary

Fixes the CPU `unit-tests` job currently failing on PR #361.

`KernelRegistry` lost the NPU priority map, so `rl_engine/tests/test_dispatch.py` failed immediately (`KeyError: 'npu'`). This restores Ascend batch-invariant logp dispatch and updates two CPU-safe tests that would fail next: drift-report PNG preview without Pillow, and Qwen FFN stub tests after `det_gemm_linear` / `packed_gate_up`.

WS1 gtest files and the WS1 CI workflow are unchanged.

## Test plan

- [x] `pytest rl_engine/tests/test_dispatch.py`
- [x] CPU-safe unit-tests CI steps excluding WS1 GPU jobs
