### PR TITLE
[WS1][Ascend] [Qwen3-8b] Fused logp ops

### DIFF
--- a/csrc/ascend/fused_logp_ascend.asc
+++ b/csrc/ascend/fused_logp_ascend.asc
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+//
+// Batch-invariant fused selected-token log-probability, Ascend C (CANN)
+// forward kernel.
+//
+//   logp[n] = logits[n, target[n]] - logsumexp(logits[n, :])
+//
+// Mirrors the deterministic CUDA kernel in csrc/deterministic_logp_kernel.cu
+// (DeterministicLogpCUDAOp):
+//   - input  : logits [N, V] contiguous, bf16 / fp16 / fp32; target [N]
+//              int64, one per row
+//   - output : logp [N] fp32 (the CUDA deterministic op always returns fp32)
+//   - target[n] outside [0, V) -> logp[n] = 0.0 (same as the CUDA kernel)
+//
+// The math follows the same two-pass fixed-order reduction as the CUDA
+// kernel: row max over a fixed tile order, then sum(exp(x - max)) over the
+// same fixed tile order, lse = max + log(sum), logp = selected - lse. The
+// fp32 accumulation and the formula match the CUDA kernel exactly; the
+// hardware reduction trees and the transcendental implementations are the
+// Ascend vector unit's own (fixed per V), so cross-platform bitwise parity
+// with the CUDA kernel is not claimed -- the guarantee here is the same one
+// the CUDA kernel provides on its platform: batch-invariant determinism.
+//
+// Batch-invariance: every row is processed end-to-end by exactly one AI core
+// block with a fixed tile size and a fixed reduction order. The instruction
+// sequence for a row depends only on V, never on N or on the block the row
+// happens to land on, so a row's output is bitwise identical across batch
+// sizes, row positions, and block assignments on the NPU.
+//
+// Build: see setup.py (AscendBuildExtension, bisheng -x asc), gated by
+// KERNEL_ALIGN_FORCE_ASCEND=1. Requires CANN toolkit + torch_npu.
+
+#include <type_traits>
+
+#include "kernel_operator.h"
+
+#include <torch/extension.h>
+
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+
+namespace {
+
+// Elements per vocab tile. Fixed for all rows and batch sizes; this is what
+// makes the reduction order batch-invariant. UB budget (input tile + fp32
+// tile + reduce scratch) stays well under the 192 KB UB of current SoCs.
+constexpr uint32_t TILE_LENGTH = 4096;
+// Cap on launched blocks. Rows are strided across blocks, so launching fewer
+// blocks than rows is fine and never changes per-row numerics.
+constexpr int64_t MAX_BLOCKS = 128;
+constexpr float NEG_INF = -3.402823466e+38f;  // -FLT_MAX
+
+template <typename T>
+class KernelFusedLogp {
+public:
+    __aicore__ inline KernelFusedLogp(AscendC::TPipe* pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(GM_ADDR logits,
+                                GM_ADDR target,
+                                GM_ADDR logp,
+                                int64_t numRows,
+                                int64_t vocabSize)
+    {
+        numRows_ = numRows;
+        vocabSize_ = vocabSize;
+        logitsGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(logits));
+        targetGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t*>(target));
+        logpGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(logp));
+        pipe_->InitBuffer(inQueue_, 1, TILE_LENGTH * sizeof(T));
+        pipe_->InitBuffer(fp32Buf_, TILE_LENGTH * sizeof(float));
+        pipe_->InitBuffer(reduceBuf_, TILE_LENGTH * sizeof(float));
+        // 64 B: floats [0,8) for reduce/log scratch, floats [8,16) for the
+        // output staging slots (both halves 32-byte aligned for DataCopyPad).
+        pipe_->InitBuffer(scalarBuf_, 64);
+        // 32 B window for reading target[row] via DataCopyPad (GM scalar
+        // GetValue/SetValue are unreliable on hardware; see cannbot
+        // ascendc-precision-debug common-traps).
+        pipe_->InitBuffer(targetBuf_, 32);
+
+        // Intra-core pipeline events. NOTE: AscendC::SyncAll() is a cross-core
+        // barrier and deadlocks when more blocks are launched than there are
+        // physical cores (resident blocks wait for unscheduled ones), so all
+        // synchronization here uses per-pipe SetFlag/WaitFlag instead.
+        eventVS_ = pipe_->FetchEventID(AscendC::HardEvent::V_S);
+        eventSV_ = pipe_->FetchEventID(AscendC::HardEvent::S_V);
+        eventMTE2S_ = pipe_->FetchEventID(AscendC::HardEvent::MTE2_S);
+        eventSMTE3_ = pipe_->FetchEventID(AscendC::HardEvent::S_MTE3);
+        eventMTE3S_ = pipe_->FetchEventID(AscendC::HardEvent::MTE3_S);
+    }
+
+    __aicore__ inline void Process()
+    {
+        for (int64_t row = AscendC::GetBlockIdx(); row < numRows_;
+             row += AscendC::GetBlockNum()) {
+            ProcessRow(row);
+        }
+    }
+
+private:
+    // Load one vocab tile into UB and return its fp32 view. When T is fp32 the
+    // queue buffer is used in place; otherwise the tile is cast into fp32Buf_.
+    __aicore__ inline AscendC::LocalTensor<float> LoadTileFp32(int64_t row,
+                                                               int64_t start,
+                                                               uint32_t count)
+    {
+        AscendC::LocalTensor<T> xLocal = inQueue_.AllocTensor<T>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(count * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<T> padParams{false, 0, 0, 0};
+        AscendC::DataCopyPad(xLocal, logitsGm_[row * vocabSize_ + start], copyParams, padParams);
+        inQueue_.EnQue(xLocal);
+        xLocal = inQueue_.DeQue<T>();
+        inTile_ = xLocal;
+
+        if constexpr (std::is_same_v<T, float>) {
+            return xLocal;
+        } else {
+            AscendC::LocalTensor<float> fLocal = fp32Buf_.Get<float>();
+            AscendC::Cast(fLocal, xLocal, AscendC::RoundMode::CAST_NONE, count);
+            return fLocal;
+        }
+    }
+
+    // Release the queue-owned input buffer of the current tile.
+    __aicore__ inline void FreeTile()
+    {
+        inQueue_.FreeTensor(inTile_);
+    }
+
+    __aicore__ inline void ProcessRow(int64_t row)
+    {
+        const int64_t target = LoadTarget(row);
+        const bool valid = target >= 0 && target < vocabSize_;
+        const int64_t tileCount = (vocabSize_ + TILE_LENGTH - 1) / TILE_LENGTH;
+        float selected = 0.0f;
+
+        // Pass 1: row max (fixed tile order). Also grab logits[target] on the fly.
+        float rowMax = NEG_INF;
+        for (int64_t tile = 0; tile < tileCount; ++tile) {
+            const int64_t start = tile * TILE_LENGTH;
+            const uint32_t count = TileCount(start);
+            AscendC::LocalTensor<float> fLocal = LoadTileFp32(row, start, count);
+
+            AscendC::LocalTensor<float> rTmp = reduceBuf_.Get<float>();
+            AscendC::LocalTensor<float> scalar = scalarBuf_.Get<float>();
+            AscendC::ReduceMax<float>(scalar, fLocal, rTmp, static_cast<int32_t>(count), false);
+            WaitVector();  // vector -> scalar read
+            const float tileMax = scalar.GetValue(0);
+            rowMax = tileMax > rowMax ? tileMax : rowMax;
+
+            if (valid && target >= start && target < start + count) {
+                selected = fLocal.GetValue(static_cast<uint32_t>(target - start));
+            }
+            FreeTile();
+        }
+
+        // Pass 2: sum(exp(x - rowMax)) with the same fixed tile order.
+        float sumExp = 0.0f;
+        for (int64_t tile = 0; tile < tileCount; ++tile) {
+            const int64_t start = tile * TILE_LENGTH;
+            const uint32_t count = TileCount(start);
+            AscendC::LocalTensor<float> fLocal = LoadTileFp32(row, start, count);
+
+            AscendC::Adds(fLocal, fLocal, -rowMax, count);  // x - rowMax
+            AscendC::Exp(fLocal, fLocal, count);
+            AscendC::LocalTensor<float> rTmp = reduceBuf_.Get<float>();
+            AscendC::LocalTensor<float> scalar = scalarBuf_.Get<float>();
+            AscendC::ReduceSum<float, true>(scalar, fLocal, rTmp, static_cast<int32_t>(count));
+            WaitVector();  // vector -> scalar read
+            sumExp += scalar.GetValue(0);
+            FreeTile();
+        }
+
+        // lse = rowMax + log(sumExp). The scalar unit has no log, so run a
+        // 1-element vector Log (count padded to 8; scalarBuf_ is 32 B aligned).
+        AscendC::LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        scalar.SetValue(0, sumExp);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(eventSV_);  // scalar write -> vector op
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(eventSV_);
+        AscendC::Log(scalar, scalar, 8);
+        WaitVector();  // vector -> scalar read
+        const float lse = rowMax + scalar.GetValue(0);
+
+        // Stage the output in UB, then DataCopyPad to GM. GlobalTensor.SetValue
+        // is unreliable on hardware (cannbot ascendc-precision-debug
+        // common-traps), so scalar GM stores are not used. Out-of-range
+        // targets produce 0.0, matching the CUDA deterministic kernel.
+        scalar.SetValue(0, valid ? (selected - lse) : 0.0f);
+        AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(eventSMTE3_);  // scalar write -> copy-out
+        AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(eventSMTE3_);
+        AscendC::DataCopyExtParams outParams{1, sizeof(float), 0, 0, 0};
+        AscendC::DataCopyPad(logpGm_[row], scalar[0], outParams);
+        // Drain MTE3 before the next row stages new values into scalarBuf_.
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_S>(eventMTE3S_);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_S>(eventMTE3S_);
+    }
+
+    // Wait until all outstanding vector-pipe results are readable as scalars.
+    __aicore__ inline void WaitVector()
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(eventVS_);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(eventVS_);
+    }
+
+    // Read target[row] through a 32-byte-aligned DataCopyPad window.
+    __aicore__ inline int64_t LoadTarget(int64_t row)
+    {
+        const int64_t alignedRow = row & ~3LL;  // 4 x int64 per 32 B
+        const int64_t remaining = numRows_ - alignedRow;
+        const uint32_t winCount = static_cast<uint32_t>(remaining < 4 ? remaining : 4);
+        AscendC::LocalTensor<int64_t> tLocal = targetBuf_.Get<int64_t>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(winCount * sizeof(int64_t)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<int64_t> padParams{false, 0, 0, 0};
+        AscendC::DataCopyPad(tLocal, targetGm_[alignedRow], copyParams, padParams);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);  // copy-in -> scalar read
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        return static_cast<int64_t>(tLocal.GetValue(static_cast<uint32_t>(row - alignedRow)));
+    }
+
+    __aicore__ inline uint32_t TileCount(int64_t start) const
+    {
+        const int64_t remaining = vocabSize_ - start;
+        return static_cast<uint32_t>(remaining < TILE_LENGTH ? remaining : TILE_LENGTH);
+    }
+
+    AscendC::TPipe* pipe_;
+    AscendC::GlobalTensor<T> logitsGm_;
+    AscendC::GlobalTensor<int64_t> targetGm_;
+    AscendC::GlobalTensor<float> logpGm_;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> inQueue_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> fp32Buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> reduceBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> scalarBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> targetBuf_;
+    AscendC::LocalTensor<T> inTile_;
+    AscendC::TEventID eventVS_;
+    AscendC::TEventID eventSV_;
+    AscendC::TEventID eventMTE2S_;
+    AscendC::TEventID eventSMTE3_;
+    AscendC::TEventID eventMTE3S_;
+    int64_t numRows_;
+    int64_t vocabSize_;
+};
+
+}  // namespace
+
+extern "C" __global__ __vector__ void fused_logp_ascend_kernel_fp32(
+    GM_ADDR logits, GM_ADDR target, GM_ADDR logp,
+    int64_t numRows, int64_t vocabSize)
+{
+    AscendC::TPipe pipe;
+    KernelFusedLogp<float> op(&pipe);
+    op.Init(logits, target, logp, numRows, vocabSize);
+    op.Process();
+}
+
+extern "C" __global__ __vector__ void fused_logp_ascend_kernel_bf16(
+    GM_ADDR logits, GM_ADDR target, GM_ADDR logp,
+    int64_t numRows, int64_t vocabSize)
+{
+    AscendC::TPipe pipe;
+    KernelFusedLogp<bfloat16_t> op(&pipe);
+    op.Init(logits, target, logp, numRows, vocabSize);
+    op.Process();
+}
+
+extern "C" __global__ __vector__ void fused_logp_ascend_kernel_fp16(
+    GM_ADDR logits, GM_ADDR target, GM_ADDR logp,
+    int64_t numRows, int64_t vocabSize)
+{
+    AscendC::TPipe pipe;
+    KernelFusedLogp<half> op(&pipe);
+    op.Init(logits, target, logp, numRows, vocabSize);
+    op.Process();
+}
+
+torch::Tensor fused_logp_ascend_forward(torch::Tensor logits, torch::Tensor target)
+{
+    TORCH_CHECK(logits.is_privateuseone(), "logits must be on an NPU device");
+    TORCH_CHECK(logits.dim() == 2, "logits must be 2-D [N, V]");
+    TORCH_CHECK(logits.is_contiguous(), "logits must be contiguous");
+    TORCH_CHECK(logits.scalar_type() == at::kBFloat16 || logits.scalar_type() == at::kFloat ||
+                    logits.scalar_type() == at::kHalf,
+                "fused_logp_ascend supports fp32, fp16, and bf16 logits");
+    TORCH_CHECK(logits.size(-1) > 0, "vocab size must be positive");
+    TORCH_CHECK(target.is_privateuseone(), "target must be on the same NPU device as logits");
+    TORCH_CHECK(target.dim() == 1, "target must be 1-D [N]");
+    TORCH_CHECK(target.scalar_type() == at::kLong, "target must be int64");
+    TORCH_CHECK(target.numel() == logits.size(0), "target must have one entry per row");
+
+    const int64_t numRows = logits.size(0);
+    const int64_t vocabSize = logits.size(1);
+
+    // fp32 output, matching the CUDA deterministic logp op's contract.
+    torch::Tensor logp = at::empty({numRows}, logits.options().dtype(at::kFloat));
+    if (numRows == 0) {
+        return logp;
+    }
+
+    torch::Tensor targetContig = target.contiguous();
+
+    // stream(true): flush the task queue before launch so the kernel cannot
+    // overtake earlier NPU work; outputs were allocated with at::empty (no
+    // queued initializer) for the same reason.
+    auto aclStream = c10_npu::getCurrentNPUStream().stream(true);
+    const uint32_t blockNum = static_cast<uint32_t>(std::min(numRows, MAX_BLOCKS));
+
+    if (logits.scalar_type() == at::kBFloat16) {
+        fused_logp_ascend_kernel_bf16<<<blockNum, nullptr, aclStream>>>(
+            reinterpret_cast<uint8_t*>(logits.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(targetContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(logp.mutable_data_ptr()),
+            numRows, vocabSize);
+    } else if (logits.scalar_type() == at::kHalf) {
+        fused_logp_ascend_kernel_fp16<<<blockNum, nullptr, aclStream>>>(
+            reinterpret_cast<uint8_t*>(logits.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(targetContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(logp.mutable_data_ptr()),
+            numRows, vocabSize);
+    } else {
+        fused_logp_ascend_kernel_fp32<<<blockNum, nullptr, aclStream>>>(
+            reinterpret_cast<uint8_t*>(logits.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(targetContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(logp.mutable_data_ptr()),
+            numRows, vocabSize);
+    }
+    return logp;
+}
+
+// The PYBIND11_MODULE for rl_engine._C_npu lives in npu_module.cpp so that
+// every Ascend op shares one compiled module.

--- a/csrc/ascend/npu_module.cpp
+++ b/csrc/ascend/npu_module.cpp
@@ -29,6 +29,9 @@ torch::Tensor embedding_ascend_forward(torch::Tensor token_ids,
                                        torch::Tensor weight,
                                        bool output_fp32);
 
+torch::Tensor fused_logp_ascend_forward(torch::Tensor logits,
+                                        torch::Tensor target);
+
 torch::Tensor rmsnorm_ascend_forward(torch::Tensor x,
                                      torch::Tensor weight,
                                      torch::Tensor rstd);
@@ -72,4 +75,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("embedding_ascend",
           &embedding_ascend_forward,
           "Batch-invariant token embedding (Ascend C forward)");
+    m.def("fused_logp_ascend",
+          &fused_logp_ascend_forward,
+          "Batch-invariant fused selected-token log-probability (Ascend C forward)");
 }

--- a/docs/operators/fused-logp.md
+++ b/docs/operators/fused-logp.md
@@ -31,6 +31,7 @@ reference = logp_ref.forward_fp32(logits, token_ids)
 | --- | --- | --- | --- |
 | CUDA SM90 | `FusedLogpSM90Op` | `_C.fused_logp_sm90` | Experimental TMA-oriented path for 2D contiguous bf16 logits on Hopper-class GPUs. It is disabled by default and requires `RL_KERNEL_ENABLE_EXPERIMENTAL_SM90_LOGP=1`; otherwise the wrapper delegates to the CUDA generic fallback. |
 | CUDA generic | `FusedLogpGenericOp` | `_C.fused_logp` | Generic compiled extension fallback. |
+| Ascend NPU | `FusedLogpAscendOp` | `_C_npu.fused_logp_ascend` | Batch-invariant Ascend C forward: two-pass (row max, then sum-exp) fp32 reduction with a fixed tile order, mirroring the CUDA deterministic kernel. Output is fp32, matching `DeterministicLogpCUDAOp`'s contract; out-of-range targets yield 0.0. |
 | PyTorch native | `NativeLogpOp` | None | PyTorch baseline/reference path. |
 
 ## Tensor Contract
@@ -62,9 +63,14 @@ operator accuracy tests continue to validate native/CUDA fused API compatibility
 ## Implementation Files
 
 - `rl_engine/kernels/registry.py`
-- `rl_engine/kernels/ops/pytorch/loss/logp.py`
-- `rl_engine/kernels/ops/cuda/loss/logp.py`
+- `rl_engine/kernels/ops/pytorch/loss/logp.py` — PyTorch native reference
+- `rl_engine/kernels/ops/cuda/loss/logp.py` — CUDA fused LogP (SM90 + generic)
+- `rl_engine/kernels/ops/ascend/loss/logp.py` — Ascend deterministic op
 - `csrc/ops.cpp`
 - `csrc/fused_logp_kernel.cu`
 - `csrc/cuda/fused_logp_sm90.cu`
+- `csrc/deterministic_logp_kernel.cu` — CUDA deterministic kernel (reference reduction)
+- `csrc/ascend/fused_logp_ascend.asc` — Ascend C forward kernel
+- `csrc/ascend/npu_module.cpp` — shared pybind entry for `rl_engine._C_npu`
 - `tests/test_logp.py`
+- `tests/test_logp_ascend.py` — Ascend correctness + batch-invariance tests

--- a/rl_engine/_C_npu.pyi
+++ b/rl_engine/_C_npu.pyi
@@ -58,3 +58,8 @@ def embedding_ascend(
     weight: torch.Tensor,
     output_fp32: bool,
 ) -> torch.Tensor: ...
+
+def fused_logp_ascend(
+    logits: torch.Tensor,
+    target: torch.Tensor,
+) -> torch.Tensor: ...

--- a/rl_engine/kernels/gtest/operator_specs.py
+++ b/rl_engine/kernels/gtest/operator_specs.py
@@ -128,6 +128,7 @@ OP_SPECS = {
             "cuda": "rl_engine.kernels.ops.cuda.loss.logp.FusedLogpGenericOp",
             "cuda-generic": "rl_engine.kernels.ops.cuda.loss.logp.FusedLogpGenericOp",
             "cuda-sm90": "rl_engine.kernels.ops.cuda.loss.logp.FusedLogpSM90Op",
+            "ascend": "rl_engine.kernels.ops.ascend.loss.logp.FusedLogpAscendOp",
         },
         grad_input_names=("logits",),
     ),

--- a/rl_engine/kernels/ops/ascend/loss/__init__.py
+++ b/rl_engine/kernels/ops/ascend/loss/__init__.py
@@ -1,2 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
+
+from . import batch_invariant_logp  # noqa: F401
+from . import logp  # noqa: F401

--- a/rl_engine/kernels/ops/ascend/loss/logp.py
+++ b/rl_engine/kernels/ops/ascend/loss/logp.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from rl_engine.utils.logger import logger
+
+_C_npu: Any = None
+try:
+    from rl_engine import _C_npu
+
+    _NPU_EXT_AVAILABLE = True
+except ImportError:  # pragma: no cover - Ascend extension not built
+    _NPU_EXT_AVAILABLE = False
+
+
+class _FusedLogpAscendAutograd(torch.autograd.Function):
+    """Autograd bridge for the Ascend fused selected-logprob forward.
+
+    Mirrors the CUDA ``_FusedLogpAutograd``: the VJP is row-local
+    (``dlogits = grad * (one_hot(target) - softmax)``), computed in FP32 and
+    cast only the final input VJP back to the input dtype. There is no
+    cross-token reduction, so Batch/Chunk layout cannot change the result.
+    """
+
+    @staticmethod
+    def forward(ctx, logits: torch.Tensor, token_ids: torch.Tensor):
+        logits_2d = logits.reshape(-1, logits.size(-1)).contiguous()
+        labels = token_ids.reshape(-1).to(device=logits.device, dtype=torch.long).contiguous()
+        output = _C_npu.fused_logp_ascend(logits_2d, labels)
+        ctx.save_for_backward(logits_2d, labels)
+        ctx.input_shape = tuple(logits.shape)
+        ctx.input_dtype = logits.dtype
+        return output.reshape(logits.shape[:-1])
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        logits, labels = ctx.saved_tensors
+        probs = torch.softmax(logits.float(), dim=-1)
+        rows = torch.arange(logits.size(0), device=logits.device)
+        probs[rows, labels] -= 1.0
+        grad = -grad_output.reshape(-1, 1).float() * probs
+        return grad.to(ctx.input_dtype).reshape(ctx.input_shape), None
+
+
+class FusedLogpAscendOp:
+    """Batch-invariant fused LogP for Ascend NPU.
+
+    The Ascend C forward mirrors the deterministic CUDA kernel's two-pass
+    (row max, then sum-exp) fp32 reduction with a fixed tile order; the
+    output is fp32, matching ``DeterministicLogpCUDAOp``'s contract.
+    """
+
+    is_fused_logp = True
+    is_batch_invariant = True
+
+    def __init__(self):
+        if not _NPU_EXT_AVAILABLE or not hasattr(_C_npu, "fused_logp_ascend"):
+            raise RuntimeError(
+                "fused_logp_ascend is not compiled into the extension. Rebuild with "
+                "KERNEL_ALIGN_FORCE_ASCEND=1 on an Ascend NPU host: 'pip install -e .'"
+            )
+        self.op = _C_npu.fused_logp_ascend
+        logger.info("Successfully linked to precompiled _C_npu.fused_logp_ascend kernel.")
+
+    def __call__(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.apply(logits, token_ids)
+
+    def _ascend_supported(self, logits: torch.Tensor) -> bool:
+        """NPU tensors only; bf16/fp16/fp32 (mirrors the CUDA kernel's gate)."""
+        return (
+            logits.device.type == "npu"
+            and logits.is_contiguous()
+            and logits.dtype in (torch.bfloat16, torch.float16, torch.float32)
+        )
+
+    def apply(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
+        if not self._ascend_supported(logits):
+            from rl_engine.kernels.ops.pytorch.loss.logp import NativeLogpOp
+
+            return NativeLogpOp()(logits, token_ids)
+        return _FusedLogpAscendAutograd.apply(logits, token_ids)
+
+    def apply_fp32(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
+        if not self._ascend_supported(logits):
+            from rl_engine.kernels.ops.pytorch.loss.logp import NativeLogpOp
+
+            return NativeLogpOp().forward_fp32(logits, token_ids)
+        return _FusedLogpAscendAutograd.apply(logits, token_ids)

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -126,7 +126,8 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
         "rl_engine.kernels.ops.ascend.loss.batch_invariant_logp.BatchInvariantLogpAscendOp"
     )
     ASCEND_RMS_NORM = "rl_engine.kernels.ops.ascend.norm.rmsnorm.RMSNormAscendOp"
-    ASCEND_EMBEDDING = "rl_engine.kernels.ops.ascend.linear.embedding.AscendEmbeddingOp" 
+    ASCEND_EMBEDDING = "rl_engine.kernels.ops.ascend.linear.embedding.AscendEmbeddingOp"
+    ASCEND_FUSED_LOGP = "rl_engine.kernels.ops.ascend.loss.logp.FusedLogpAscendOp"
     # Deterministic vocab-parallel TP logprob reference (WS2 #241 PR3)
     PYTORCH_VOCAB_PARALLEL_LOGP = (
         "rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp.VocabParallelLogprobOp"
@@ -726,6 +727,10 @@ class KernelRegistry:
         self._priority_map["npu"]["embedding"] = [
             OpBackend.ASCEND_EMBEDDING,
             OpBackend.PYTORCH_NATIVE_EMBEDDING,
+        ]
+        self._priority_map["npu"]["logp"] = [
+            OpBackend.ASCEND_FUSED_LOGP,
+            OpBackend.PYTORCH_NATIVE,
         ]
         logger.info(f"KernelRegistry initialized for {device_ctx.device_type}")
         self._adjust_priority_for_hardware()

--- a/rl_engine/tests/test_dispatch.py
+++ b/rl_engine/tests/test_dispatch.py
@@ -178,6 +178,10 @@ def test_npu_registry_preserves_per_operator_cpu_fallbacks(monkeypatch):
         OpBackend.ASCEND_EMBEDDING,
         OpBackend.PYTORCH_NATIVE_EMBEDDING,
     ]
+    assert registry._priority_map["npu"]["logp"] == [
+        OpBackend.ASCEND_FUSED_LOGP,
+        OpBackend.PYTORCH_NATIVE,
+    ]
 
 
 def test_npu_available_handles_runtime_failure(monkeypatch):

--- a/tests/test_logp_ascend.py
+++ b/tests/test_logp_ascend.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Tests for the Ascend NPU batch-invariant fused selected-token logp.
+
+Validates the same two orthogonal properties as the CUDA deterministic op:
+
+1. **Correctness** - output matches the ``NativeLogpOp.forward_fp32`` ground
+   truth within the logprob contract tolerance. The Ascend C kernel mirrors
+   the CUDA deterministic kernel's two-pass (row max, then sum-exp) fp32
+   reduction with a fixed tile order; the hardware reduction trees differ
+   from CUDA's, so the comparison is tolerance-based (fp32 drift ~1e-7).
+2. **Batch-invariance** - a row's logp is bitwise identical regardless of
+   batch size, batch position, or how many AI-core blocks were launched
+   (each row is reduced end-to-end by one block; no split-K merge exists).
+"""
+
+import pytest
+import torch
+
+from rl_engine.kernels.ops.pytorch.loss.logp import NativeLogpOp
+
+# Accuracy tolerances from the gtest contract, "logprob" op class.
+_ATOL = {
+    torch.float32: 1.0e-5,
+    torch.bfloat16: 6.0e-2,
+    torch.float16: 5.0e-3,
+}
+
+
+def _npu_available() -> bool:
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(torch, "npu") and torch.npu.is_available()
+
+
+def _ascend_kernel_available() -> bool:
+    if not _npu_available():
+        return False
+    try:
+        from rl_engine.kernels.ops.ascend.loss.logp import _NPU_EXT_AVAILABLE, _C_npu
+    except Exception:
+        return False
+    return _NPU_EXT_AVAILABLE and hasattr(_C_npu, "fused_logp_ascend")
+
+
+requires_ascend = pytest.mark.skipif(
+    not _ascend_kernel_available(),
+    reason="fused_logp_ascend kernel not compiled "
+    "(needs KERNEL_ALIGN_FORCE_ASCEND=1 on an Ascend NPU host).",
+)
+
+
+def _get_op():
+    from rl_engine.kernels.ops.ascend.loss.logp import FusedLogpAscendOp
+
+    return FusedLogpAscendOp()
+
+
+def _make_inputs(shape, vocab, dtype, seed=0):
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    logits = torch.randn(*shape, vocab, dtype=dtype, generator=generator).to("npu")
+    token_ids = torch.randint(0, vocab, shape, generator=generator).long().to("npu")
+    return logits, token_ids
+
+
+# ---------------------------------------------------------------------------
+# Correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@requires_ascend
+class TestAscendFusedLogpCorrectness:
+    def test_forward_matches_pytorch_reference(self, dtype):
+        op = _get_op()
+        logits, token_ids = _make_inputs((3, 5), 257, dtype)
+        out = op(logits, token_ids)
+        ref = NativeLogpOp().forward_fp32(logits, token_ids)
+        assert out.dtype == torch.float32  # matches DeterministicLogpCUDAOp's contract
+        assert out.shape == (3, 5)
+        assert torch.allclose(out.float(), ref, atol=_ATOL[dtype], rtol=0.0)
+
+    def test_apply_fp32_matches_reference(self, dtype):
+        op = _get_op()
+        logits, token_ids = _make_inputs((3, 5), 257, dtype)
+        out = op.apply_fp32(logits, token_ids)
+        ref = NativeLogpOp().forward_fp32(logits, token_ids)
+        assert torch.allclose(out.float(), ref, atol=_ATOL[dtype], rtol=0.0)
+
+    def test_out_of_range_target_is_zero(self, dtype):
+        op = _get_op()
+        logits, token_ids = _make_inputs((2, 4), 32, dtype)
+        token_ids = token_ids.reshape(-1)
+        token_ids[1] = 32 + 5  # out of [0, V)
+        out = op(logits, token_ids.reshape(2, 4))
+        assert out.reshape(-1)[1].item() == 0.0
+
+    def test_backward_matches_native_reference(self, dtype):
+        op = _get_op()
+        logits, token_ids = _make_inputs((3, 5), 257, dtype)
+
+        logits_a = logits.clone().requires_grad_()
+        op(logits_a, token_ids).backward(torch.ones(3, 5, device="npu", dtype=dtype))
+
+        logits_n = logits.clone().requires_grad_()
+        NativeLogpOp()(logits_n, token_ids).backward(torch.ones(3, 5, device="npu", dtype=dtype))
+
+        assert torch.allclose(
+            logits_a.grad.float(), logits_n.grad.float(), atol=1.0e-4, rtol=1.0e-4
+        )
+
+    def test_backward_has_no_cross_row_leak(self, dtype):
+        """Row-local VJP: the same row's grad is bitwise identical wherever the
+        row sits in the batch."""
+        op = _get_op()
+        logits, token_ids = _make_inputs((4, 8), 257, dtype)
+        logits[1].copy_(logits[0])
+        token_ids[1] = token_ids[0]
+
+        logits_g = logits.clone().requires_grad_()
+        grad_out = torch.randn(4, 8, device="npu", dtype=dtype)
+        grad_out[1] = grad_out[0]  # identical (logits, target, dy) triples
+        op(logits_g, token_ids).backward(grad_out)
+        grad = logits_g.grad
+        # Rows 0 and 1 saw identical inputs, so their VJPs must be bitwise
+        # identical; rows 2/3 stay independent.
+        assert torch.equal(grad[0], grad[1])
+        for row in range(2, 4):
+            assert not torch.equal(grad[0], grad[row])
+
+# ---------------------------------------------------------------------------
+# Fallback
+# ---------------------------------------------------------------------------
+
+
+@requires_ascend
+class TestAscendFusedLogpFallback:
+    def test_rejects_non_npu_falls_back_to_native(self):
+        op = _get_op()
+        logits, token_ids = _make_inputs((2, 3), 17, torch.float32)
+        out = op(logits.cpu(), token_ids.cpu())
+        ref = NativeLogpOp()(logits.cpu(), token_ids.cpu())
+        assert torch.equal(out, ref)
+
+
+# ---------------------------------------------------------------------------
+# Batch invariance
+# ---------------------------------------------------------------------------
+
+
+@requires_ascend
+class TestAscendFusedLogpBatchInvariance:
+    def _run_row(self, batch, vocab, dtype, pos, seed=7):
+        """One fixed row embedded at position `pos` of a random batch."""
+        op = _get_op()
+        logits, token_ids = _make_inputs((batch,), vocab, dtype, seed=seed)
+        out = op(logits, token_ids)
+        return out[pos].clone()
+
+    def test_batch_size_1_vs_n(self):
+        # One fixed (row, target) pair embedded in batches of growing size:
+        # its logp must be bitwise identical regardless of batch size.
+        dtype = torch.bfloat16
+        op = _get_op()
+        alone_logits, alone_ids = _make_inputs((1,), 257, dtype, seed=7)
+        alone = op(alone_logits, alone_ids)[0]
+        for batch in (2, 4, 16, 300):  # 300 > MAX_BLOCKS -> strided blocks
+            logits, token_ids = _make_inputs((batch,), 257, dtype, seed=7)
+            logits[0].copy_(alone_logits[0])
+            token_ids[0] = alone_ids[0]
+            in_batch = op(logits, token_ids)[0]
+            assert torch.equal(alone, in_batch), f"drift at batch_size={batch}"
+
+    def test_different_positions_in_batch(self):
+        # The same row content copied to every position reduces bitwise
+        # identically regardless of where it lands.
+        dtype = torch.float16
+        op = _get_op()
+        logits, token_ids = _make_inputs((8,), 257, dtype, seed=11)
+        base, base_id = logits[0].clone(), int(token_ids[0])
+        for pos in range(1, 8):
+            logits[pos].copy_(base)
+            token_ids[pos] = base_id
+        out = op(logits, token_ids)
+        for pos in range(1, 8):
+            assert torch.equal(out[pos], out[0]), f"drift at position={pos}"
+
+    def test_block_striding(self):
+        # 300 rows > MAX_BLOCKS (128): rows are strided across blocks, so
+        # numerics must not depend on block assignment.
+        dtype = torch.bfloat16
+        op = _get_op()
+        logits, token_ids = _make_inputs((300,), 257, dtype, seed=13)
+        out = op(logits, token_ids)
+        again = op(logits, token_ids)
+        assert torch.equal(out, again)
+
+    def test_multi_tile_rows(self):
+        # vocab > TILE_LENGTH (4096): rows span multiple fixed-order tiles.
+        dtype = torch.float32
+        op = _get_op()
+        logits, token_ids = _make_inputs((4,), 10000, dtype, seed=5)
+        out = op(logits, token_ids)
+        assert torch.equal(out, op(logits, token_ids))
+
+    def test_repeated_runs_deterministic(self):
+        dtype = torch.bfloat16
+        logits, token_ids = _make_inputs((3, 5), 257, dtype, seed=5)
+        op = _get_op()
+        first = op(logits, token_ids)
+        for _ in range(3):
+            again = op(logits, token_ids)
+            assert torch.equal(first, again)
+
+
+# ---------------------------------------------------------------------------
+# Registry dispatch
+# ---------------------------------------------------------------------------
+
+
+@requires_ascend
+class TestAscendRegistryDispatch:
+    def test_get_op_logp(self):
+        from rl_engine.kernels.registry import kernel_registry
+
+        op = kernel_registry.get_op("logp", device="npu")
+        assert type(op).__name__ == "FusedLogpAscendOp"


### PR DESCRIPTION
## Latest Status [1 Sep 2026]

Ready for review.

## Summary

Port of the CUDA deterministic fused logp (`csrc/deterministic_logp_kernel.cu` + `DeterministicLogpCUDAOp`) to Ascend NPU:

- **Forward kernel** (`_C_npu.fused_logp_ascend`): mirrors the CUDA deterministic kernel's math — `logp[n] = logits[n, target[n]] - logsumexp(logits[n, :])` — with the same two-pass fixed-order reduction: row max over a fixed tile order, then `sum(exp(x - max))` over the same fixed tile order, `lse = max + log(sum)`, `logp = selected - lse`, all in fp32. Out-of-range targets produce `0.0`, matching the CUDA kernel. Output is fp32, matching `DeterministicLogpCUDAOp`'s contract.
  - Batch-invariance: every row is processed end-to-end by exactly one AI-core block with a fixed tile size (4096 elements) and a fixed reduction order; rows are strided across blocks (`MAX_BLOCKS=128`). The instruction sequence for a row depends only on `V`, never on `N` or block assignment, so a row's logp is **bitwise identical** across batch sizes, row positions, and block assignments on the NPU (verified).
  - Honest numerics note: the fp32 accumulation and formula match the CUDA kernel exactly, but the hardware reduction trees and transcendental implementations are the Ascend vector unit's own (fixed per V) — cross-platform bitwise parity with the CUDA kernel is **not** claimed (CUDA `expf` is a software polynomial; the Ascend `Exp` is a hardware instruction). The guarantee is the same one the CUDA kernel provides on its platform: batch-invariant determinism. Measured drift vs the fp32 gold reference is ~1e-7.
- **Wrapper**: `FusedLogpAscendOp` mirrors the CUDA `_FusedLogpAutograd` bridge — lead-shape support (`[..., V] -> [...]`), row-local fp32 VJP backward (`dlogits = grad * (one_hot(target) - softmax)`), native fallback for non-NPU/non-contiguous inputs. Registered as the `"ascend"` candidate in the `logp` gtest spec and as `ASCEND_FUSED_LOGP` in the registry's NPU priority map (`[ASCEND_FUSED_LOGP, PYTORCH_NATIVE]`).
- **Build**: `csrc/ascend/npu_module.cpp` consolidates the single `PYBIND11_MODULE` (logp + fused logp); `batch_invariant_logp_ascend.asc` only drops its `PYBIND11_MODULE` block. `setup.py` gains the Ascend extension build (bisheng, `**/*.asc` glob) with the CANN env export in `_find_ascend_home` (durable fresh-shell fix). `scripts/check_operator.py` gains `--device npu` support.

### Build notes (same pattern as PR #320 / #355)

Each `.asc` source file can define only one `PYBIND11_MODULE` (linking multiple sources with Bisheng causes a duplicate `PyInit__C_npu` error), so pybind registrations are consolidated in `csrc/ascend/npu_module.cpp`; `batch_invariant_logp_ascend.asc` only drops its `PYBIND11_MODULE` block.

## Files

| Path | Status |
| --- | --- |
| `csrc/ascend/fused_logp_ascend.asc` | Ascend C two-pass fused logp forward kernel (fp32/bf16/fp16 inputs, fp32 output) + torch host wrapper. New. |
| `csrc/ascend/npu_module.cpp` | Aggregated `_C_npu` pybind registration (batch_invariant_logp + fused logp). New. |
| `csrc/ascend/batch_invariant_logp_ascend.asc` | Only removes `PYBIND11_MODULE` (moved to the aggregated file). Kernel logic unchanged. |
| `rl_engine/kernels/ops/ascend/loss/logp.py` | `FusedLogpAscendOp` (Ascend C forward + row-local fp32 VJP backward). New. |
| `rl_engine/kernels/ops/ascend/loss/__init__.py` | Imports the new module. |
| `rl_engine/_C_npu.pyi` | Adds the `fused_logp_ascend` type stub. |
| `rl_engine/kernels/gtest/operator_specs.py` | Registers the `"ascend"` candidate for the `logp` op. |
| `rl_engine/kernels/registry.py` | `ASCEND_FUSED_LOGP` backend + NPU priority map entry. |
| `rl_engine/tests/test_dispatch.py` | Covers the NPU logp priority. |
| `scripts/check_operator.py` | `--device npu` / auto-detect support. |
| `tests/test_logp_ascend.py` | Ascend correctness (contract tolerance) + batch-invariance (bitwise) + registry dispatch. New. |
| `docs/operators/fused-logp.md` | Ascend backend row and implementation files. |
| `setup.py` | Ascend extension build (bisheng) + CANN env export in `_find_ascend_home`. |

## Test

```bash
# build
export KERNEL_ALIGN_FORCE_ASCEND=1
pip install -e . --no-build-isolation

# gtest (single-op check, ascend candidate vs the PyTorch gold)
python scripts/check_operator.py --op logp --candidate ascend --device npu \
    --dtype {fp32,bf16,fp16} --batch 2 --seq 16 --vocab 257 --check-grad

# pytest suite (correctness tolerance, batch invariance bitwise, registry dispatch)
python -m pytest tests/test_logp_ascend.py -v

# regression (shared module/build touched)
python -m pytest tests/test_batch_invariant_logp.py -q
python -m pytest rl_engine/tests/test_dispatch.py -q
```

## Test results

Environment: Ascend 910, CANN 8.5.1 (Bisheng), torch 2.10.0 + torch_npu 2.10.0.post2.

| Test | Result |
| --- | --- |
| gtest `logp` ascend candidate, fp32 × 2x16x257, output + gradient | ✅ output max_abs=9.5e-7, grad max_abs=1.2e-7 (tol atol=1e-5) |
| gtest `logp` ascend candidate, bf16 × 2x16x257, output + gradient | ✅ output max_abs=4.8e-7, grad max_abs=7.6e-6 (tol atol=6e-2 / 5e-2) |
| gtest `logp` ascend candidate, fp16 × 2x16x257, output + gradient | ✅ output max_abs=4.8e-7, grad max_abs=1.9e-6 (tol atol=5e-3) |
| Batch invariance (bitwise): batch 1 vs {2, 4, 16, 300}, row positions 1..7, multi-tile V=10000, repeated runs | ✅ 0 mismatches (`torch.equal`) |
| Out-of-range target → 0.0, empty input, fp32 output dtype | ✅ |
| pytest `tests/test_logp_ascend.py` | ✅ 22 passed |
| Regression `tests/test_batch_invariant_logp.py` | ✅ 44 passed, 42 skipped |
| Regression `rl_engine/tests/test_dispatch.py` | ✅ 13 passed |

<details>

<summary>gtest raw output (fp32, representative)</summary>

```
suite=logp passed=True pass_rate=1.0000
  case=logp-torch.float32-2x16x257 output=0 shape=(2, 16) dtype=torch.float32 max_abs=9.53674316e-07 mean_abs=2.23517418e-07 max_rel=1.29912607e-07 tol=(atol=1.000e-05, rtol=0.000e+00) passed=True
  case=logp-torch.float32-2x16x257 output=1 gradient:logits shape=(2, 16, 257) dtype=torch.float32 max_abs=1.19209290e-07 mean_abs=4.15880497e-10 max_rel=6.74039995e-07 tol=(atol=1.000e-05, rtol=0.000e+00) passed=True
```

</details>

<details>

<summary>pytest: tests/test_logp_ascend.py (summary)</summary>

```
======================= 22 passed, 14 warnings in 5.43s ========================
```

</details>

## Notes

- **Why tolerance vs the gold, bitwise only for invariance**: the CUDA deterministic kernel's reduction tree (strided-thread partials + warp shuffle tree) is CUDA-specific, and the transcendental implementations differ per platform (`expf` polynomial vs the Ascend vector `Exp` instruction). The Ascend kernel mirrors the formula and the two-pass fixed-order structure; on the NPU its own fixed tree makes the op batch-invariant bitwise, which is the property the WS1 contract's `forward_invariance` row requires (bitwise) — the `forward_accuracy` row is tolerance-based (fp32 drift ~1e-7, well inside atol=1e-5).
- The backward is the same row-local VJP formula as the CUDA wrapper's `_FusedLogpAutograd`, computed in fp32 and cast back to the input dtype; no cross-token reduction, so gradients are batch-layout independent.
- Single-device operator; no TP/vocab-parallel path (consistent with the CUDA deterministic op's scope).
- `black` / `isort` / `flake8` (line-length 100) pass for all modified Python files.
