### PR TITLE
[WS1][Ascend] [Qwen3-8b] Fused linear logp ops

### DIFF
--- a/csrc/ascend/fused_linear_logp_ascend.asc
+++ b/csrc/ascend/fused_linear_logp_ascend.asc
@@ -1,0 +1,434 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+//
+// Batch-invariant fused linear log-probability, Ascend C (CANN) forward
+// kernel.
+//
+//   logp[n] = log_softmax(hidden[n] @ W^T + b)[target[n]]
+//
+// Mirrors the SM90 CUDA fused kernel's bitwise reduction contract
+// (csrc/cuda/fused_linear_logp_sm90.cu, contract v1), without materializing
+// the [N, V] logits:
+//   - vocab rows are scanned in ascending index order (the CUDA contract's
+//     "cross-split ascending-index sequential chains");
+//   - the softmax statistics use the online rescale chain
+//       newM = max(m, z); sum = sum * exp(m - newM) + exp(z - newM);
+//     exactly like the CUDA per-split merge;
+//   - each per-row dot is a fixed tile order over D with fp32 accumulation
+//     (per-tile ReduceSum tree + sequential scalar chain);
+//   - bias is added in fp32; padding lanes are -inf so exp() is exact 0;
+//   - final clamp logp = min(zt - lse, 0), matching the CUDA contract.
+//
+// The hardware reduction trees and transcendental implementations are the
+// Ascend vector unit's own (fixed per D), so cross-platform bitwise parity
+// with the CUDA kernel is not claimed -- the guarantee is the same one the
+// CUDA kernel provides on its platform: batch-invariant determinism.
+//
+// Batch-invariance: every row is processed end-to-end by exactly one AI core
+// block with a fixed tile size and a fixed vocab/D scan order; rows are
+// strided across blocks (MAX_BLOCKS cap), so a row's logp depends only on
+// (D, V), never on N or block assignment.
+//
+// Build: see setup.py (AscendBuildExtension, bisheng -x asc), gated by
+// KERNEL_ALIGN_FORCE_ASCEND=1. Requires CANN toolkit + torch_npu.
+
+#include <type_traits>
+
+#include "kernel_operator.h"
+
+#include <torch/extension.h>
+
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+
+namespace {
+
+// Elements per hidden tile. Fixed for all rows and batch sizes; this is what
+// makes the reduction order batch-invariant. UB budget (hidden row cache +
+// weight tile + fp32 views + reduce scratch) stays well under the 192 KB UB
+// of current SoCs for D <= TILE_LENGTH (Qwen3: D = 4096).
+constexpr uint32_t TILE_LENGTH = 4096;
+// Cap on launched blocks. Rows are strided across blocks, so launching fewer
+// blocks than rows is fine and never changes per-row numerics.
+constexpr int64_t MAX_BLOCKS = 128;
+constexpr float NEG_INF = -3.402823466e+38f;  // -FLT_MAX
+
+template <typename T>
+class KernelFusedLinearLogp {
+public:
+    __aicore__ inline KernelFusedLinearLogp(AscendC::TPipe* pipe) : pipe_(pipe) {}
+
+    __aicore__ inline void Init(GM_ADDR hidden,
+                                GM_ADDR weight,
+                                GM_ADDR bias,
+                                GM_ADDR target,
+                                GM_ADDR logp,
+                                int64_t numRows,
+                                int64_t vocabSize,
+                                int64_t hiddenSize,
+                                bool hasBias)
+    {
+        numRows_ = numRows;
+        vocabSize_ = vocabSize;
+        hiddenSize_ = hiddenSize;
+        hasBias_ = hasBias;
+        // Hidden row cache: one fp32 tile; valid only when D <= TILE_LENGTH.
+        cacheHidden_ = hiddenSize_ <= static_cast<int64_t>(TILE_LENGTH);
+        hiddenGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(hidden));
+        weightGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(weight));
+        biasGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(bias));
+        targetGm_.SetGlobalBuffer(reinterpret_cast<__gm__ int64_t*>(target));
+        logpGm_.SetGlobalBuffer(reinterpret_cast<__gm__ float*>(logp));
+        pipe_->InitBuffer(wQueue_, 1, TILE_LENGTH * sizeof(T));
+        pipe_->InitBuffer(hFp32Buf_, TILE_LENGTH * sizeof(float));
+        pipe_->InitBuffer(wFp32Buf_, TILE_LENGTH * sizeof(float));
+        pipe_->InitBuffer(prodBuf_, TILE_LENGTH * sizeof(float));
+        pipe_->InitBuffer(reduceBuf_, TILE_LENGTH * sizeof(float));
+        // 64 B: floats [0,8) for reduce/log scratch, floats [8,16) for the
+        // output staging slots (both halves 32-byte aligned for DataCopyPad).
+        pipe_->InitBuffer(scalarBuf_, 64);
+        // 32 B windows for scalar reads via DataCopyPad (GM scalar
+        // GetValue/SetValue are unreliable on hardware; see cannbot
+        // ascendc-precision-debug common-traps).
+        pipe_->InitBuffer(targetBuf_, 32);
+        pipe_->InitBuffer(biasBuf_, 32);
+
+        // Intra-core pipeline events. NOTE: AscendC::SyncAll() is a cross-core
+        // barrier and deadlocks when more blocks are launched than there are
+        // physical cores (resident blocks wait for unscheduled ones), so all
+        // synchronization here uses per-pipe SetFlag/WaitFlag instead.
+        eventVS_ = pipe_->FetchEventID(AscendC::HardEvent::V_S);
+        eventSV_ = pipe_->FetchEventID(AscendC::HardEvent::S_V);
+        eventMTE2V_ = pipe_->FetchEventID(AscendC::HardEvent::MTE2_V);
+        eventMTE2S_ = pipe_->FetchEventID(AscendC::HardEvent::MTE2_S);
+        eventSMTE3_ = pipe_->FetchEventID(AscendC::HardEvent::S_MTE3);
+        eventMTE3S_ = pipe_->FetchEventID(AscendC::HardEvent::MTE3_S);
+    }
+
+    __aicore__ inline void Process()
+    {
+        for (int64_t row = AscendC::GetBlockIdx(); row < numRows_;
+             row += AscendC::GetBlockNum()) {
+            ProcessRow(row);
+        }
+    }
+
+private:
+    // Load one tile into the queue and return its fp32 view (cast when T is
+    // not fp32; in-place otherwise).
+    __aicore__ inline AscendC::LocalTensor<float> LoadTileFp32(AscendC::GlobalTensor<T> gm,
+                                                               int64_t offset,
+                                                               uint32_t count,
+                                                               AscendC::LocalTensor<float> fp32View)
+    {
+        AscendC::LocalTensor<T> tile = wQueue_.AllocTensor<T>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(count * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<T> padParams{false, 0, 0, 0};
+        AscendC::DataCopyPad(tile, gm[offset], copyParams, padParams);
+        wQueue_.EnQue(tile);
+        tile = wQueue_.DeQue<T>();
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_V>(eventMTE2V_);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_V>(eventMTE2V_);
+        if constexpr (std::is_same_v<T, float>) {
+            AscendC::DataCopy(fp32View, tile, VecAlignCount(count));
+        } else {
+            AscendC::Cast(fp32View, tile, AscendC::RoundMode::CAST_NONE, count);
+        }
+        wQueue_.FreeTensor(tile);
+        return fp32View;
+    }
+
+    // fp32 dot of the hidden row and weight row over one D tile.
+    __aicore__ inline float DotTile(AscendC::LocalTensor<float> hTile,
+                                    AscendC::LocalTensor<float> wTile,
+                                    uint32_t count)
+    {
+        AscendC::LocalTensor<float> prod = prodBuf_.Get<float>();
+        AscendC::Mul(prod, hTile, wTile, count);
+        AscendC::LocalTensor<float> rTmp = reduceBuf_.Get<float>();
+        AscendC::LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        AscendC::ReduceSum<float, true>(scalar, prod, rTmp, static_cast<int32_t>(count));
+        WaitVector();  // vector -> scalar read
+        return scalar.GetValue(0);
+    }
+
+    // Per-vocab-row dot over D with a fixed tile order.
+    __aicore__ inline float DotRow(int64_t row, int64_t col)
+    {
+        const int64_t tileCount = (hiddenSize_ + TILE_LENGTH - 1) / TILE_LENGTH;
+        AscendC::LocalTensor<float> hFp32 = hFp32Buf_.Get<float>();
+        float acc = 0.0f;
+        for (int64_t tile = 0; tile < tileCount; ++tile) {
+            const int64_t start = tile * TILE_LENGTH;
+            const uint32_t count = TileCount(start);
+            AscendC::LocalTensor<float> wFp32 = wFp32Buf_.Get<float>();
+            if (!(cacheHidden_ && tile == 0)) {
+                // Reload the hidden tile when D > TILE_LENGTH (or on demand).
+                LoadTileFp32(hiddenGm_, row * hiddenSize_ + start, count, hFp32);
+            }
+            LoadTileFp32(weightGm_, col * hiddenSize_ + start, count, wFp32);
+            acc += DotTile(hFp32, wFp32, count);
+        }
+        return acc;
+    }
+
+    __aicore__ inline void ProcessRow(int64_t row)
+    {
+        const int64_t target = LoadTarget(row);
+        const bool valid = target >= 0 && target < vocabSize_;
+        float m = NEG_INF;
+        float sumExp = 0.0f;
+        float zt = 0.0f;
+
+        // Cache the hidden row (D <= TILE_LENGTH fast path).
+        if (cacheHidden_) {
+            LoadTileFp32(hiddenGm_, row * hiddenSize_, TileCount(0), hFp32Buf_.Get<float>());
+        }
+
+        // Vocab rows in ascending index order, online rescale chain.
+        for (int64_t v = 0; v < vocabSize_; ++v) {
+            float z = DotRow(row, v);
+            if (hasBias_) {
+                z += LoadBias(v);
+            }
+            if (v == target) {
+                zt = z;
+            }
+            const float newM = z > m ? z : m;
+            // Two scalar exps per vocab row via one padded vector Exp.
+            AscendC::LocalTensor<float> scalar = scalarBuf_.Get<float>();
+            scalar.SetValue(0, m - newM);
+            scalar.SetValue(1, z - newM);
+            AscendC::SetFlag<AscendC::HardEvent::S_V>(eventSV_);
+            AscendC::WaitFlag<AscendC::HardEvent::S_V>(eventSV_);
+            AscendC::Exp(scalar, scalar, 8);
+            WaitVector();  // vector -> scalar read
+            sumExp = sumExp * scalar.GetValue(0) + scalar.GetValue(1);
+            m = newM;
+        }
+
+        // lse = m + log(sumExp) via a padded 1-element vector Log.
+        AscendC::LocalTensor<float> scalar = scalarBuf_.Get<float>();
+        scalar.SetValue(0, sumExp);
+        AscendC::SetFlag<AscendC::HardEvent::S_V>(eventSV_);
+        AscendC::WaitFlag<AscendC::HardEvent::S_V>(eventSV_);
+        AscendC::Log(scalar, scalar, 8);
+        WaitVector();  // vector -> scalar read
+        const float lse = m + scalar.GetValue(0);
+
+        // Stage the output in UB, then DataCopyPad to GM. GlobalTensor.SetValue
+        // is unreliable on hardware (cannbot ascendc-precision-debug
+        // common-traps), so scalar GM stores are not used. Out-of-range
+        // targets produce 0.0; the final clamp matches the CUDA contract.
+        float logp = 0.0f;
+        if (valid) {
+            logp = zt - lse;
+            logp = logp < 0.0f ? logp : 0.0f;
+        }
+        scalar.SetValue(0, logp);
+        AscendC::SetFlag<AscendC::HardEvent::S_MTE3>(eventSMTE3_);
+        AscendC::WaitFlag<AscendC::HardEvent::S_MTE3>(eventSMTE3_);
+        AscendC::DataCopyExtParams outParams{1, sizeof(float), 0, 0, 0};
+        AscendC::DataCopyPad(logpGm_[row], scalar[0], outParams);
+        // Drain MTE3 before the next row stages new values into scalarBuf_.
+        AscendC::SetFlag<AscendC::HardEvent::MTE3_S>(eventMTE3S_);
+        AscendC::WaitFlag<AscendC::HardEvent::MTE3_S>(eventMTE3S_);
+    }
+
+    // Wait until all outstanding vector-pipe results are readable as scalars.
+    __aicore__ inline void WaitVector()
+    {
+        AscendC::SetFlag<AscendC::HardEvent::V_S>(eventVS_);
+        AscendC::WaitFlag<AscendC::HardEvent::V_S>(eventVS_);
+    }
+
+    // Read target[row] through a 32-byte-aligned DataCopyPad window.
+    __aicore__ inline int64_t LoadTarget(int64_t row)
+    {
+        const int64_t alignedRow = row & ~3LL;  // 4 x int64 per 32 B
+        const int64_t remaining = numRows_ - alignedRow;
+        const uint32_t winCount = static_cast<uint32_t>(remaining < 4 ? remaining : 4);
+        AscendC::LocalTensor<int64_t> tLocal = targetBuf_.Get<int64_t>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(winCount * sizeof(int64_t)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<int64_t> padParams{false, 0, 0, 0};
+        AscendC::DataCopyPad(tLocal, targetGm_[alignedRow], copyParams, padParams);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);  // copy-in -> scalar read
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        return static_cast<int64_t>(tLocal.GetValue(static_cast<uint32_t>(row - alignedRow)));
+    }
+
+    // Read bias[col] through a 32-byte-aligned DataCopyPad window.
+    __aicore__ inline float LoadBias(int64_t col)
+    {
+        const int64_t alignedCol = col & ~7LL;  // 8 x fp32 per 32 B
+        const int64_t remaining = vocabSize_ - alignedCol;
+        const uint32_t winCount = static_cast<uint32_t>(remaining < 8 ? remaining : 8);
+        AscendC::LocalTensor<float> bLocal = biasBuf_.Get<float>();
+        AscendC::DataCopyExtParams copyParams{
+            1, static_cast<uint32_t>(winCount * sizeof(float)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<float> padParams{false, 0, 0, 0};
+        AscendC::DataCopyPad(bLocal, biasGm_[alignedCol], copyParams, padParams);
+        AscendC::SetFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);  // copy-in -> scalar read
+        AscendC::WaitFlag<AscendC::HardEvent::MTE2_S>(eventMTE2S_);
+        return bLocal.GetValue(static_cast<uint32_t>(col - alignedCol));
+    }
+
+    __aicore__ inline uint32_t TileCount(int64_t start) const
+    {
+        const int64_t remaining = hiddenSize_ - start;
+        return static_cast<uint32_t>(remaining < TILE_LENGTH ? remaining : TILE_LENGTH);
+    }
+
+    // Round an element count up to a 32 B boundary (vector-pipe minimum).
+    __aicore__ inline uint32_t VecAlignCount(uint32_t count) const
+    {
+        constexpr uint32_t elemsPer32B = 32 / sizeof(T);
+        return (count + elemsPer32B - 1) / elemsPer32B * elemsPer32B;
+    }
+
+    AscendC::TPipe* pipe_;
+    AscendC::GlobalTensor<T> hiddenGm_;
+    AscendC::GlobalTensor<T> weightGm_;
+    AscendC::GlobalTensor<float> biasGm_;
+    AscendC::GlobalTensor<int64_t> targetGm_;
+    AscendC::GlobalTensor<float> logpGm_;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> wQueue_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> hFp32Buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> wFp32Buf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> prodBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> reduceBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> scalarBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> targetBuf_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> biasBuf_;
+    AscendC::TEventID eventVS_;
+    AscendC::TEventID eventSV_;
+    AscendC::TEventID eventMTE2V_;
+    AscendC::TEventID eventMTE2S_;
+    AscendC::TEventID eventSMTE3_;
+    AscendC::TEventID eventMTE3S_;
+    int64_t numRows_;
+    int64_t vocabSize_;
+    int64_t hiddenSize_;
+    bool hasBias_;
+    bool cacheHidden_;
+};
+
+}  // namespace
+
+extern "C" __global__ __vector__ void fused_linear_logp_ascend_kernel_fp32(
+    GM_ADDR hidden, GM_ADDR weight, GM_ADDR bias, GM_ADDR target, GM_ADDR logp,
+    int64_t numRows, int64_t vocabSize, int64_t hiddenSize, bool hasBias)
+{
+    AscendC::TPipe pipe;
+    KernelFusedLinearLogp<float> op(&pipe);
+    op.Init(hidden, weight, bias, target, logp, numRows, vocabSize, hiddenSize, hasBias);
+    op.Process();
+}
+
+extern "C" __global__ __vector__ void fused_linear_logp_ascend_kernel_bf16(
+    GM_ADDR hidden, GM_ADDR weight, GM_ADDR bias, GM_ADDR target, GM_ADDR logp,
+    int64_t numRows, int64_t vocabSize, int64_t hiddenSize, bool hasBias)
+{
+    AscendC::TPipe pipe;
+    KernelFusedLinearLogp<bfloat16_t> op(&pipe);
+    op.Init(hidden, weight, bias, target, logp, numRows, vocabSize, hiddenSize, hasBias);
+    op.Process();
+}
+
+extern "C" __global__ __vector__ void fused_linear_logp_ascend_kernel_fp16(
+    GM_ADDR hidden, GM_ADDR weight, GM_ADDR bias, GM_ADDR target, GM_ADDR logp,
+    int64_t numRows, int64_t vocabSize, int64_t hiddenSize, bool hasBias)
+{
+    AscendC::TPipe pipe;
+    KernelFusedLinearLogp<half> op(&pipe);
+    op.Init(hidden, weight, bias, target, logp, numRows, vocabSize, hiddenSize, hasBias);
+    op.Process();
+}
+
+torch::Tensor fused_linear_logp_ascend_forward(torch::Tensor hidden,
+                                               torch::Tensor weight,
+                                               torch::optional<torch::Tensor> bias,
+                                               torch::Tensor target)
+{
+    TORCH_CHECK(hidden.is_privateuseone(), "hidden must be on an NPU device");
+    TORCH_CHECK(weight.is_privateuseone(), "lm_head_weight must be on an NPU device");
+    TORCH_CHECK(hidden.device() == weight.device(),
+                "hidden and lm_head_weight must be on the same NPU device");
+    TORCH_CHECK(hidden.dim() == 2, "hidden must be 2-D [N, D]");
+    TORCH_CHECK(weight.dim() == 2, "lm_head_weight must be 2-D [V, D]");
+    TORCH_CHECK(hidden.size(-1) == weight.size(1), "hidden/weight hidden-dim mismatch");
+    TORCH_CHECK(hidden.scalar_type() == at::kFloat || hidden.scalar_type() == at::kHalf ||
+                    hidden.scalar_type() == at::kBFloat16,
+                "fused_linear_logp_ascend supports fp32, fp16, and bf16 hidden states");
+    TORCH_CHECK(weight.scalar_type() == hidden.scalar_type(),
+                "fused_linear_logp_ascend requires weight to match the hidden dtype");
+    TORCH_CHECK(hidden.size(-1) > 0, "hidden dimension must be positive");
+    TORCH_CHECK(target.is_privateuseone(), "target must be on the same NPU device as hidden");
+    TORCH_CHECK(target.dim() == 1, "target must be 1-D [N]");
+    TORCH_CHECK(target.scalar_type() == at::kLong, "target must be int64");
+    TORCH_CHECK(target.numel() == hidden.size(0), "target must have one entry per row");
+
+    const int64_t numRows = hidden.size(0);
+    const int64_t hiddenSize = hidden.size(1);
+    const int64_t vocabSize = weight.size(0);
+
+    torch::Tensor biasF;
+    uint8_t* biasPtr = nullptr;
+    bool hasBias = false;
+    if (bias.has_value()) {
+        TORCH_CHECK(bias->is_privateuseone(), "bias must be on an NPU device");
+        TORCH_CHECK(bias->device() == hidden.device(), "bias must be on the same NPU device");
+        TORCH_CHECK(bias->dim() == 1 && bias->numel() == vocabSize,
+                    "bias must be 1-D [V]");
+        biasF = bias->reshape({vocabSize}).to(at::kFloat).contiguous();
+        biasPtr = reinterpret_cast<uint8_t*>(biasF.mutable_data_ptr());
+        hasBias = true;
+    }
+
+    // fp32 output, matching the gold reference's contract.
+    torch::Tensor logp = at::empty({numRows}, hidden.options().dtype(at::kFloat));
+    if (numRows == 0 || vocabSize == 0) {
+        return logp;
+    }
+
+    auto hiddenContig = hidden.contiguous();
+    auto weightContig = weight.contiguous();
+    auto targetContig = target.contiguous();
+
+    // stream(true): flush the task queue before launch so the kernel cannot
+    // overtake earlier NPU work; outputs were allocated with at::empty (no
+    // queued initializer) for the same reason.
+    auto aclStream = c10_npu::getCurrentNPUStream().stream(true);
+    const uint32_t blockNum = static_cast<uint32_t>(std::min(numRows, MAX_BLOCKS));
+
+    if (hidden.scalar_type() == at::kBFloat16) {
+        fused_linear_logp_ascend_kernel_bf16<<<blockNum, nullptr, aclStream>>>(
+            reinterpret_cast<uint8_t*>(hiddenContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(weightContig.mutable_data_ptr()),
+            biasPtr,
+            reinterpret_cast<uint8_t*>(targetContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(logp.mutable_data_ptr()),
+            numRows, vocabSize, hiddenSize, hasBias);
+    } else if (hidden.scalar_type() == at::kHalf) {
+        fused_linear_logp_ascend_kernel_fp16<<<blockNum, nullptr, aclStream>>>(
+            reinterpret_cast<uint8_t*>(hiddenContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(weightContig.mutable_data_ptr()),
+            biasPtr,
+            reinterpret_cast<uint8_t*>(targetContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(logp.mutable_data_ptr()),
+            numRows, vocabSize, hiddenSize, hasBias);
+    } else {
+        fused_linear_logp_ascend_kernel_fp32<<<blockNum, nullptr, aclStream>>>(
+            reinterpret_cast<uint8_t*>(hiddenContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(weightContig.mutable_data_ptr()),
+            biasPtr,
+            reinterpret_cast<uint8_t*>(targetContig.mutable_data_ptr()),
+            reinterpret_cast<uint8_t*>(logp.mutable_data_ptr()),
+            numRows, vocabSize, hiddenSize, hasBias);
+    }
+    return logp;
+}
+
+// The PYBIND11_MODULE for rl_engine._C_npu lives in npu_module.cpp so that
+// every Ascend op shares one compiled module.

--- a/csrc/ascend/npu_module.cpp
+++ b/csrc/ascend/npu_module.cpp
@@ -37,6 +37,11 @@ torch::Tensor lm_head_ascend_forward(torch::Tensor hidden,
                                      torch::optional<torch::Tensor> bias,
                                      bool output_fp32);
 
+torch::Tensor fused_linear_logp_ascend_forward(torch::Tensor hidden,
+                                               torch::Tensor weight,
+                                               torch::optional<torch::Tensor> bias,
+                                               torch::Tensor target);
+
 torch::Tensor rmsnorm_ascend_forward(torch::Tensor x,
                                      torch::Tensor weight,
                                      torch::Tensor rstd);
@@ -86,4 +91,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("lm_head_ascend",
           &lm_head_ascend_forward,
           "Batch-invariant LM-head projection (Ascend C forward)");
+    m.def("fused_linear_logp_ascend",
+          &fused_linear_logp_ascend_forward,
+          "Batch-invariant fused linear log-probability (Ascend C forward)");
 }

--- a/docs/operators/linear-logp.md
+++ b/docs/operators/linear-logp.md
@@ -39,6 +39,7 @@ logp.sum().backward()  # gradients flow into hidden, lm_head_weight, bias
 | --- | --- | --- |
 | CUDA SM90 (Hopper) | `FusedLinearLogpSM90Op` | TMA-streamed, Double Buffering, tensor-core forward (`mma.sync.m16n8k16`), online softmax in smem; chunked backward. Compiles for `sm_90a`; validated fp32-accurate on H100. Falls back to Triton/native for fp32/fp16 inputs or hidden dims not divisible by 32. |
 | CUDA / ROCm (Triton) | `TritonLinearLogpOp` | Triton online-softmax forward; Liger-style chunked backward (cuBLAS matmuls, deterministic). Phase 1. |
+| Ascend NPU | `FusedLinearLogpAscendOp` | Batch-invariant Ascend C forward mirroring the SM90 reduction contract: ascending vocab-row scan with the online rescale chain, per-row fp32 dots over a fixed D-tile order, `min(zt - lse, 0)` clamp; the shared chunked backward. Output fp32. |
 | PyTorch native | `NativeLinearLogpOp` | Naive `F.linear` + `log_softmax` + `gather` reference; CPU / Triton-less fallback. |
 
 The SM90 backend (`csrc/cuda/fused_linear_logp_sm90.cu`) streams hidden/weight
@@ -168,10 +169,14 @@ For 4-GPU tensor-parallel validation, use
 ## Implementation Files
 
 - `rl_engine/kernels/ops/triton/loss/linear_logp.py`
-- `rl_engine/kernels/ops/pytorch/loss/linear_logp.py`
-- `rl_engine/kernels/ops/cuda/loss/linear_logp.py` (SM90 wrapper + chunked backward)
-- `csrc/cuda/fused_linear_logp_sm90.cu`, `csrc/ops.cpp`, `setup.py` (SM90 kernel + build)
+- `rl_engine/kernels/ops/pytorch/loss/linear_logp.py` — native reference, chunked backward, TP helpers
+- `rl_engine/kernels/ops/cuda/loss/linear_logp.py` — CUDA fused implementation (SM90 wrapper + chunked backward)
+- `rl_engine/kernels/ops/ascend/loss/linear_logp.py` — Ascend deterministic op
+- `csrc/cuda/fused_linear_logp_sm90.cu`, `csrc/ops.cpp`, `setup.py` — SM90 kernel + build
+- `csrc/ascend/fused_linear_logp_ascend.asc` — Ascend C forward kernel
+- `csrc/ascend/npu_module.cpp` — shared pybind entry for `rl_engine._C_npu`
 - `rl_engine/kernels/registry.py`
 - `tests/test_linear_logp.py`
+- `tests/test_linear_logp_ascend.py` — Ascend correctness + batch-invariance tests
 - `benchmarks/benchmark_linear_logp.py`
 - `docs/design/fused-linear-logp.md`

--- a/rl_engine/_C_npu.pyi
+++ b/rl_engine/_C_npu.pyi
@@ -69,3 +69,10 @@ def lm_head_ascend(
     bias: torch.Tensor | None,
     output_fp32: bool,
 ) -> torch.Tensor: ...
+
+def fused_linear_logp_ascend(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    target: torch.Tensor,
+) -> torch.Tensor: ...

--- a/rl_engine/kernels/gtest/operator_specs.py
+++ b/rl_engine/kernels/gtest/operator_specs.py
@@ -141,6 +141,7 @@ OP_SPECS = {
             "pytorch": "rl_engine.kernels.ops.pytorch.loss.linear_logp.NativeLinearLogpOp",
             "triton": "rl_engine.kernels.ops.triton.loss.linear_logp.TritonLinearLogpOp",
             "cuda-sm90": "rl_engine.kernels.ops.cuda.loss.linear_logp.FusedLinearLogpSM90Op",
+            "ascend": "rl_engine.kernels.ops.ascend.loss.linear_logp.FusedLinearLogpAscendOp",
         },
         grad_input_names=("hidden", "lm_head_weight"),
     ),

--- a/rl_engine/kernels/ops/ascend/loss/__init__.py
+++ b/rl_engine/kernels/ops/ascend/loss/__init__.py
@@ -2,4 +2,5 @@
 # Copyright (c) 2026 RL-Kernel Contributors
 
 from . import batch_invariant_logp  # noqa: F401
+from . import linear_logp  # noqa: F401
 from . import logp  # noqa: F401

--- a/rl_engine/kernels/ops/ascend/loss/linear_logp.py
+++ b/rl_engine/kernels/ops/ascend/loss/linear_logp.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+
+from rl_engine.utils.logger import logger
+
+_C_npu: Any = None
+try:
+    from rl_engine import _C_npu
+
+    _NPU_EXT_AVAILABLE = True
+except ImportError:  # pragma: no cover - Ascend extension not built
+    _NPU_EXT_AVAILABLE = False
+
+_SUPPORTED_DTYPES = {torch.float32, torch.float16, torch.bfloat16}
+
+
+class _FusedLinearLogpAscendFunction(torch.autograd.Function):
+    """Autograd bridge for the Ascend fused linear log-prob forward.
+
+    The backward is the shared Liger-style chunked formula from
+    ``rl_engine.kernels.ops.pytorch.loss.linear_logp.chunked_linear_logp_backward``
+    (the same formula the CUDA SM90 op falls back to), so gradients follow
+    the CUDA op's portable backward exactly.
+    """
+
+    @staticmethod
+    def forward(ctx, hidden, lm_head_weight, target_ids):
+        hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
+        weight = lm_head_weight.contiguous()
+        target_1d = (
+            target_ids.reshape(-1).to(device=hidden_2d.device, dtype=torch.long).contiguous()
+        )
+        output = _C_npu.fused_linear_logp_ascend(hidden_2d, weight, None, target_1d)
+        ctx.save_for_backward(hidden_2d, weight, target_1d)
+        ctx.lead_shape = hidden.shape[:-1]
+        ctx.hidden_dtype = hidden.dtype
+        ctx.weight_dtype = lm_head_weight.dtype
+        return output.reshape(hidden.shape[:-1])
+
+    @staticmethod
+    def backward(ctx, grad_logp):
+        from rl_engine.kernels.ops.pytorch.loss.linear_logp import chunked_linear_logp_backward
+
+        hidden_2d, weight, target_1d = ctx.saved_tensors
+        grad_hidden, grad_weight, _ = chunked_linear_logp_backward(
+            grad_logp,
+            hidden_2d,
+            weight,
+            target_1d,
+            hidden_2d,  # bias placeholder; has_bias=False
+            has_bias=False,
+            lead_shape=ctx.lead_shape,
+            hidden_dtype=ctx.hidden_dtype,
+            weight_dtype=ctx.weight_dtype,
+            bias_dtype=None,
+        )
+        return grad_hidden, grad_weight, None
+
+
+class FusedLinearLogpAscendOp:
+    """Batch-invariant fused linear log-prob for Ascend NPU.
+
+    Computes ``log_softmax(hidden @ W^T + b)[target]`` without materializing
+    the ``[N, V]`` logits. The Ascend C forward mirrors the SM90 kernel's
+    reduction contract: ascending vocab-row scan with the online rescale
+    chain, per-row fp32 dots over a fixed D-tile order, final
+    ``min(zt - lse, 0)`` clamp; the output is fp32.
+    """
+
+    is_fused_logp = True
+    is_batch_invariant = True
+
+    def __init__(self) -> None:
+        if not _NPU_EXT_AVAILABLE or not hasattr(_C_npu, "fused_linear_logp_ascend"):
+            raise RuntimeError(
+                "fused_linear_logp_ascend is not compiled into the extension. Rebuild with "
+                "KERNEL_ALIGN_FORCE_ASCEND=1 on an Ascend NPU host: 'pip install -e .'"
+            )
+        self.op = _C_npu.fused_linear_logp_ascend
+        logger.info("Successfully linked to precompiled _C_npu.fused_linear_logp_ascend kernel.")
+
+    def __call__(
+        self,
+        hidden: torch.Tensor,
+        lm_head_weight: torch.Tensor,
+        target_ids: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+        *,
+        tp_group: Any = None,
+        vocab_start_index: int = 0,
+        global_vocab_size: Optional[int] = None,
+    ) -> torch.Tensor:
+        return self.apply(
+            hidden,
+            lm_head_weight,
+            target_ids,
+            bias,
+            tp_group=tp_group,
+            vocab_start_index=vocab_start_index,
+            global_vocab_size=global_vocab_size,
+        )
+
+    def apply(
+        self,
+        hidden: torch.Tensor,
+        lm_head_weight: torch.Tensor,
+        target_ids: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+        *,
+        tp_group: Any = None,
+        vocab_start_index: int = 0,
+        global_vocab_size: Optional[int] = None,
+    ) -> torch.Tensor:
+        from rl_engine.kernels.ops.pytorch.loss.linear_logp import (
+            NativeLinearLogpOp,
+            should_use_tensor_parallel_linear_logp,
+        )
+
+        if lm_head_weight.size(-1) != hidden.size(-1):
+            raise ValueError(
+                f"hidden dim {hidden.size(-1)} must match lm_head_weight dim "
+                f"{lm_head_weight.size(-1)}"
+            )
+        if lm_head_weight.device != hidden.device:
+            raise ValueError(
+                f"lm_head_weight device {lm_head_weight.device} must match hidden "
+                f"device {hidden.device}"
+            )
+        if hidden.shape[:-1] != target_ids.shape:
+            raise ValueError(
+                f"hidden leading shape {tuple(hidden.shape[:-1])} must match "
+                f"target_ids shape {tuple(target_ids.shape)}"
+            )
+        # Tensor-parallel and bias paths are not covered by the Ascend forward;
+        # delegate to the native reference (same fallback as the CUDA op).
+        if (
+            should_use_tensor_parallel_linear_logp(
+                tp_group,
+                int(vocab_start_index),
+                global_vocab_size,
+                lm_head_weight.size(0),
+            )
+            or bias is not None
+        ):
+            return NativeLinearLogpOp().apply(
+                hidden,
+                lm_head_weight,
+                target_ids,
+                bias,
+                tp_group=tp_group,
+                vocab_start_index=vocab_start_index,
+                global_vocab_size=global_vocab_size,
+            )
+        if not self._ascend_supported(hidden, lm_head_weight):
+            return NativeLinearLogpOp().apply(hidden, lm_head_weight, target_ids)
+        return _FusedLinearLogpAscendFunction.apply(hidden, lm_head_weight, target_ids)
+
+    @staticmethod
+    def _ascend_supported(hidden: torch.Tensor, lm_head_weight: torch.Tensor) -> bool:
+        return (
+            hidden.device.type == "npu"
+            and lm_head_weight.device.type == "npu"
+            and hidden.is_contiguous()
+            and lm_head_weight.is_contiguous()
+            and hidden.dtype in _SUPPORTED_DTYPES
+            and lm_head_weight.dtype == hidden.dtype
+        )

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -129,6 +129,9 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     ASCEND_EMBEDDING = "rl_engine.kernels.ops.ascend.linear.embedding.AscendEmbeddingOp"
     ASCEND_FUSED_LOGP = "rl_engine.kernels.ops.ascend.loss.logp.FusedLogpAscendOp"
     ASCEND_LM_HEAD = "rl_engine.kernels.ops.ascend.linear.lm_head.AscendLMHeadOp"
+    ASCEND_FUSED_LINEAR_LOGP = (
+        "rl_engine.kernels.ops.ascend.loss.linear_logp.FusedLinearLogpAscendOp"
+    )
     # Deterministic vocab-parallel TP logprob reference (WS2 #241 PR3)
     PYTORCH_VOCAB_PARALLEL_LOGP = (
         "rl_engine.kernels.ops.pytorch.loss.vocab_parallel_logp.VocabParallelLogprobOp"
@@ -736,6 +739,10 @@ class KernelRegistry:
         self._priority_map["npu"]["lm_head"] = [
             OpBackend.ASCEND_LM_HEAD,
             OpBackend.PYTORCH_NATIVE_LM_HEAD,
+        ]
+        self._priority_map["npu"]["linear_logp"] = [
+            OpBackend.ASCEND_FUSED_LINEAR_LOGP,
+            OpBackend.PYTORCH_LINEAR_LOGP,
         ]
         logger.info(f"KernelRegistry initialized for {device_ctx.device_type}")
         self._adjust_priority_for_hardware()

--- a/rl_engine/tests/test_dispatch.py
+++ b/rl_engine/tests/test_dispatch.py
@@ -186,6 +186,10 @@ def test_npu_registry_preserves_per_operator_cpu_fallbacks(monkeypatch):
         OpBackend.ASCEND_LM_HEAD,
         OpBackend.PYTORCH_NATIVE_LM_HEAD,
     ]
+    assert registry._priority_map["npu"]["linear_logp"] == [
+        OpBackend.ASCEND_FUSED_LINEAR_LOGP,
+        OpBackend.PYTORCH_LINEAR_LOGP,
+    ]
 
 
 def test_npu_available_handles_runtime_failure(monkeypatch):

--- a/tests/test_linear_logp_ascend.py
+++ b/tests/test_linear_logp_ascend.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+"""Tests for the Ascend NPU batch-invariant fused linear log-prob.
+
+Validates the same two orthogonal properties as the CUDA deterministic op:
+
+1. **Correctness** - output matches a hand-computed fp32 reference
+   (``hidden.float() @ weight.float().T`` + ``log_softmax`` + gather +
+   clamp) within an honest reduction tolerance (~2e-4 at D=4096, pure
+   fp32-tree drift). The gtest's own forward comparison is stricter than
+   any independent kernel can meet (see Notes in the PR description): the
+   fp32 logprob tolerance is 1e-5 while two different fp32 reduction trees
+   over D=4096 drift ~1e-4, and the gold's dtype path accumulates the
+   matmul in bf16/fp16 while this kernel (like the CUDA SM90 kernel)
+   accumulates in fp32.
+2. **Batch-invariance** - a row's logp is bitwise identical regardless of
+   batch size, batch position, or how many AI-core blocks were launched
+   (each row is reduced end-to-end by one block over a fixed vocab scan).
+"""
+
+import pytest
+import torch
+
+_VOCAB = 129
+_HIDDEN = 1000
+
+# Honest forward tolerance vs the fp32 reference: pure fp32 reduction-tree
+# drift (measured 2.1e-4 at D=4096, V=257).
+_FWD_ATOL = 5.0e-4
+_FWD_RTOL = 1.0e-5
+# Gradient tolerance: the chunked backward casts to the input dtype, so
+# low-precision grads compare at their own quantization level.
+_GRAD_ATOL = {torch.float32: 5.0e-4, torch.bfloat16: 2.0e-2, torch.float16: 1.0e-2}
+
+
+def _npu_available() -> bool:
+    try:
+        import torch_npu  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(torch, "npu") and torch.npu.is_available()
+
+
+def _ascend_kernel_available() -> bool:
+    if not _npu_available():
+        return False
+    try:
+        from rl_engine.kernels.ops.ascend.loss.linear_logp import _NPU_EXT_AVAILABLE, _C_npu
+    except Exception:
+        return False
+    return _NPU_EXT_AVAILABLE and hasattr(_C_npu, "fused_linear_logp_ascend")
+
+
+requires_ascend = pytest.mark.skipif(
+    not _ascend_kernel_available(),
+    reason="fused_linear_logp_ascend kernel not compiled "
+    "(needs KERNEL_ALIGN_FORCE_ASCEND=1 on an Ascend NPU host).",
+)
+
+
+def _get_op():
+    from rl_engine.kernels.ops.ascend.loss.linear_logp import FusedLinearLogpAscendOp
+
+    return FusedLinearLogpAscendOp()
+
+
+def _make_inputs(shape, vocab=_VOCAB, hidden=_HIDDEN, dtype=torch.float32, seed=0):
+    generator = torch.Generator(device="cpu").manual_seed(seed)
+    hidden_t = torch.randn(*shape, hidden, dtype=dtype, generator=generator).to("npu")
+    weight = torch.randn(vocab, hidden, dtype=dtype, generator=generator).to("npu")
+    target_ids = torch.randint(0, vocab, shape, generator=generator).long().to("npu")
+    return hidden_t, weight, target_ids
+
+
+def _ref_fp32(hidden, weight, target_ids, bias=None):
+    """Hand-written fp32 reference matching the WS1 fp32-reference policy."""
+    logits = hidden.float().reshape(-1, hidden.size(-1)) @ weight.float().t()
+    if bias is not None:
+        logits = logits + bias.float()
+    flat = target_ids.reshape(-1)
+    logp = torch.log_softmax(logits, dim=-1)
+    selected = logp.gather(1, flat.unsqueeze(1)).squeeze(1)
+    return selected.clamp(max=0).reshape(hidden.shape[:-1])
+
+
+# ---------------------------------------------------------------------------
+# Correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+@requires_ascend
+class TestAscendFusedLinearLogpCorrectness:
+    def test_forward_matches_fp32_reference(self, dtype):
+        op = _get_op()
+        hidden, weight, target_ids = _make_inputs((3, 5), dtype=dtype)
+        out = op(hidden, weight, target_ids)
+        ref = _ref_fp32(hidden, weight, target_ids)
+        assert out.dtype == torch.float32
+        assert out.shape == (3, 5)
+        assert torch.allclose(out, ref, atol=_FWD_ATOL, rtol=_FWD_RTOL)
+
+    def test_forward_large_shape(self, dtype):
+        # gtest shape: D=4096 (single cached hidden tile), V=257.
+        op = _get_op()
+        hidden, weight, target_ids = _make_inputs((2, 16), vocab=257, hidden=4096, dtype=dtype)
+        out = op(hidden, weight, target_ids)
+        ref = _ref_fp32(hidden, weight, target_ids)
+        assert torch.allclose(out, ref, atol=_FWD_ATOL, rtol=_FWD_RTOL)
+
+    def test_out_of_range_target_is_zero(self, dtype):
+        op = _get_op()
+        hidden, weight, target_ids = _make_inputs((2, 4), vocab=32, dtype=dtype)
+        target_ids = target_ids.reshape(-1)
+        target_ids[1] = 32 + 5  # out of [0, V)
+        out = op(hidden, weight, target_ids.reshape(2, 4))
+        assert out.reshape(-1)[1].item() == 0.0
+
+    def test_bias_falls_back_to_native(self, dtype):
+        from rl_engine.kernels.ops.pytorch.loss.linear_logp import NativeLinearLogpOp
+
+        op = _get_op()
+        hidden, weight, target_ids = _make_inputs((2, 3), dtype=dtype)
+        bias = torch.randn(_VOCAB, device="npu", dtype=dtype)
+        out = op(hidden, weight, target_ids, bias)
+        ref = NativeLinearLogpOp().apply(hidden, weight, target_ids, bias)
+        assert torch.allclose(out.float(), ref.float(), atol=1e-5, rtol=1e-5)
+
+    def test_backward_matches_fp32_reference(self, dtype):
+        op = _get_op()
+        hidden, weight, target_ids = _make_inputs((3, 5), dtype=dtype)
+        grad_out = torch.randn(3, 5, device="npu", dtype=dtype)
+
+        h_a = hidden.clone().requires_grad_()
+        w_a = weight.clone().requires_grad_()
+        op(h_a, w_a, target_ids).backward(grad_out)
+
+        h_f = hidden.float().clone().requires_grad_()
+        w_f = weight.float().clone().requires_grad_()
+        _ref_fp32(h_f, w_f, target_ids).backward(grad_out.float())
+
+        # Compare at the quantized level for low-precision inputs: both
+        # backends compute the VJP in fp32 and cast to the input dtype, so
+        # the fp32 tree drift collapses into (usually identical) quantized
+        # bits; the tolerance only absorbs the rare 1-ULP straddle.
+        assert torch.allclose(
+            h_a.grad.float(), h_f.grad.to(dtype).float(), atol=_GRAD_ATOL[dtype], rtol=1.0e-4
+        )
+        assert torch.allclose(
+            w_a.grad.float(), w_f.grad.to(dtype).float(), atol=_GRAD_ATOL[dtype], rtol=1.0e-4
+        )
+
+    def test_backward_has_no_cross_row_leak(self, dtype):
+        """Row-local VJP: the same row's grad is bitwise identical wherever the
+        row sits in the batch."""
+        op = _get_op()
+        hidden, weight, target_ids = _make_inputs((4, 8), dtype=dtype)
+        hidden[1].copy_(hidden[0])
+        target_ids[1] = target_ids[0]
+
+        h_g = hidden.clone().requires_grad_()
+        grad_out = torch.randn(4, 8, device="npu", dtype=dtype)
+        grad_out[1] = grad_out[0]
+        op(h_g, weight, target_ids).backward(grad_out)
+        grad = h_g.grad
+        assert torch.equal(grad[0], grad[1])
+        for row in range(2, 4):
+            assert not torch.equal(grad[0], grad[row])
+
+
+# ---------------------------------------------------------------------------
+# Batch invariance
+# ---------------------------------------------------------------------------
+
+
+@requires_ascend
+class TestAscendFusedLinearLogpBatchInvariance:
+    def test_batch_size_1_vs_n(self):
+        # One fixed row embedded in batches of growing size: its logp must be
+        # bitwise identical regardless of batch size.
+        dtype = torch.bfloat16
+        op = _get_op()
+        alone_hidden, weight, alone_ids = _make_inputs((1,), dtype=dtype, seed=7)
+        alone = op(alone_hidden, weight, alone_ids)[0]
+        for batch in (2, 4, 16, 300):  # 300 rows -> > MAX_BLOCKS strided blocks
+            hidden, _, target_ids = _make_inputs((batch,), dtype=dtype, seed=7)
+            hidden[0].copy_(alone_hidden[0])
+            target_ids[0] = alone_ids[0]
+            in_batch = op(hidden, weight, target_ids)[0]
+            assert torch.equal(alone, in_batch), f"drift at batch_size={batch}"
+
+    def test_different_positions_in_batch(self):
+        # The same row content copied to every position reduces bitwise
+        # identically regardless of where it lands.
+        dtype = torch.float16
+        op = _get_op()
+        hidden, weight, target_ids = _make_inputs((8,), dtype=dtype, seed=11)
+        base, base_id = hidden[0].clone(), int(target_ids[0])
+        for pos in range(1, 8):
+            hidden[pos].copy_(base)
+            target_ids[pos] = base_id
+        out = op(hidden, weight, target_ids)
+        for pos in range(1, 8):
+            assert torch.equal(out[pos], out[0]), f"drift at position={pos}"
+
+    def test_multi_tile_rows(self):
+        # hidden > TILE_LENGTH (4096): the per-row dots span multiple tiles.
+        dtype = torch.float32
+        op = _get_op()
+        hidden, weight, target_ids = _make_inputs((4,), hidden=10000, dtype=dtype, seed=5)
+        out = op(hidden, weight, target_ids)
+        assert torch.equal(out, op(hidden, weight, target_ids))
+
+    def test_repeated_runs_deterministic(self):
+        dtype = torch.bfloat16
+        hidden, weight, target_ids = _make_inputs((3, 5), dtype=dtype, seed=5)
+        op = _get_op()
+        first = op(hidden, weight, target_ids)
+        for _ in range(3):
+            again = op(hidden, weight, target_ids)
+            assert torch.equal(first, again)
+
+
+# ---------------------------------------------------------------------------
+# Registry dispatch
+# ---------------------------------------------------------------------------
+
+
+@requires_ascend
+class TestAscendRegistryDispatch:
+    def test_get_op_linear_logp(self):
+        from rl_engine.kernels.registry import kernel_registry
+
+        op = kernel_registry.get_op("linear_logp", device="npu")
+        assert type(op).__name__ == "FusedLinearLogpAscendOp"


### PR DESCRIPTION
## Latest Status [1 Sep 2026]

Ready for review.

## Summary

Port of the CUDA fused linear log-prob (`csrc/cuda/fused_linear_logp_sm90.cu` + `FusedLinearLogpSM90Op`) to Ascend NPU:

- **Forward kernel** (`_C_npu.fused_linear_logp_ascend`): computes `log_softmax(hidden @ W^T + b)[target]` without materializing `[N, V]` logits, mirroring the SM90 kernel's bitwise reduction contract (contract v1):
  - vocab rows scanned in **ascending index order** (the contract's "cross-split ascending-index sequential chains");
  - the **online rescale chain** `newM = max(m, z); sum = sum * exp(m - newM) + exp(z - newM)` exactly like the CUDA per-split merge;
  - per-row fp32 dots over a **fixed D-tile order** (per-tile ReduceSum tree + sequential scalar chain; the hidden row is cached in UB for D ≤ 4096);
  - bias added in fp32; the final clamp **`logp = min(zt - lse, 0)`** matches the CUDA contract; out-of-range targets yield 0.
  - Batch-invariance: every row is processed end-to-end by one AI-core block over a fixed vocab/D scan order; rows are strided across blocks (`MAX_BLOCKS=128`), so a row's logp is **bitwise identical** across batch sizes, row positions, and block assignments on the NPU (verified with `torch.equal`).
  - Honest numerics note: the per-tile hardware reduction tree and the transcendental implementations are the Ascend vector unit's own, so cross-platform bitwise parity with the CUDA kernel is not claimed — the guarantee is the same one the CUDA kernel provides on its platform: batch-invariant determinism.
- **Wrapper**: `FusedLinearLogpAscendOp` mirrors `FusedLinearLogpSM90Op`'s surface (`apply(hidden, lm_head_weight, target_ids, bias=None)`, validation, fp32 output). TP and bias calls delegate to the native reference (same fallback shape as the CUDA op's non-SM90 paths). The backward is the **shared** Liger-style `chunked_linear_logp_backward` — the exact formula the CUDA SM90 op falls back to — so gradients follow the CUDA op's portable backward.
- **Registration**: gtest candidate `"ascend"` in the `linear_logp` spec; `ASCEND_FUSED_LINEAR_LOGP` in the registry NPU priority map (`[ASCEND_FUSED_LINEAR_LOGP, PYTORCH_LINEAR_LOGP]`); `scripts/check_operator.py` gains `--device npu` support.
- **Build**: `csrc/ascend/npu_module.cpp` consolidates the single `PYBIND11_MODULE`; `batch_invariant_logp_ascend.asc` only drops its `PYBIND11_MODULE` block. `setup.py` gains the Ascend extension build (bisheng, `**/*.asc` glob) with the CANN env export in `_find_ascend_home`.

> **gtest forward comparison note (read this first).** The gtest's `linear_logp` forward
> comparison is stricter than *any* independent kernel can meet, the CUDA candidate
> included (CI's gtest matrix gates registration only; it does not execute
> `linear_logp` candidates):
> - fp32: the logprob tolerance is `atol=1e-5`, but two different fp32 reduction trees
>   over D=4096 drift ~1e-4 (this kernel measured 2.1e-4 vs the gold; the CUDA kernel's
>   WGMMA tree drifts the same way).
> - bf16/fp16: the gold's `apply()` accumulates the matmul in the **input dtype**
>   (bf16/fp16 matmul), while this kernel — like the CUDA SM90 kernel — accumulates in
>   fp32 per the WS1 fp32-reference policy, so the bf16 comparison measures bf16
>   matmul noise (0.55 vs atol 6e-2).
> The gradients pass the gtest tolerances (fp32 2.4e-7 / 3.0e-8; the bf16/fp16 gradient
> rows fail for the same gold-accumulation-dtype reason). The dedicated pytest suite
> verifies the forward against a hand-computed fp32 reference at an honest reduction
> tolerance and the backward at the quantized level.

### Build notes (same pattern as PR #320 / #355)

Each `.asc` source file can define only one `PYBIND11_MODULE` (linking multiple sources with Bisheng causes a duplicate `PyInit__C_npu` error), so pybind registrations are consolidated in `csrc/ascend/npu_module.cpp`; `batch_invariant_logp_ascend.asc` only drops its `PYBIND11_MODULE` block.

## Files

| Path | Status |
| --- | --- |
| `csrc/ascend/fused_linear_logp_ascend.asc` | Ascend C fused linear logp forward kernel (fp32/bf16/fp16, optional fp32 bias, online softmax) + torch host wrapper. New. |
| `csrc/ascend/npu_module.cpp` | Aggregated `_C_npu` pybind registration. New. |
| `csrc/ascend/batch_invariant_logp_ascend.asc` | Only removes `PYBIND11_MODULE` (moved to the aggregated file). Kernel logic unchanged. |
| `rl_engine/kernels/ops/ascend/loss/linear_logp.py` | `FusedLinearLogpAscendOp` (Ascend C forward + shared chunked backward). New. |
| `rl_engine/kernels/ops/ascend/loss/__init__.py` | Imports the new module. |
| `rl_engine/_C_npu.pyi` | Adds the `fused_linear_logp_ascend` type stub. |
| `rl_engine/kernels/gtest/operator_specs.py` | Registers the `"ascend"` candidate for the `linear_logp` op. |
| `rl_engine/kernels/registry.py` | `ASCEND_FUSED_LINEAR_LOGP` backend + NPU priority map entry. |
| `rl_engine/tests/test_dispatch.py` | Covers the NPU linear_logp priority. |
| `scripts/check_operator.py` | `--device npu` / auto-detect support. |
| `tests/test_linear_logp_ascend.py` | Ascend correctness (honest reduction tolerance vs fp32 reference) + batch-invariance (bitwise) + registry dispatch. New. |
| `docs/operators/linear-logp.md` | Ascend backend row and implementation files. |
| `setup.py` | Ascend extension build (bisheng) + CANN env export in `_find_ascend_home`. |

## Test

```bash
# build
export KERNEL_ALIGN_FORCE_ASCEND=1
pip install -e . --no-build-isolation

# gtest registration + gradient checks (forward comparison: see the note above)
python scripts/check_operator.py --op linear_logp --candidate ascend --device npu \
    --dtype {fp32,bf16,fp16} --batch 2 --seq 16 --vocab 257 --normalized-dim 4096 --check-grad

# pytest suite (correctness tolerance, batch invariance bitwise, registry dispatch)
python -m pytest tests/test_linear_logp_ascend.py -v

# regression (shared module/build touched)
python -m pytest tests/test_batch_invariant_logp.py -q
python -m pytest rl_engine/tests/test_dispatch.py -q
```

## Test results

Environment: Ascend 910, CANN 8.5.1 (Bisheng), torch 2.10.0 + torch_npu 2.10.0.post2.

| Test | Result |
| --- | --- |
| Forward vs hand-computed fp32 reference (fp32/bf16/fp16, D=1000 and gtest D=4096 shape) | ✅ max_abs ≤ 2.2e-4 (pure fp32 tree drift; pytest atol 5e-4) |
| gtest gradients (fp32): hidden + lm_head_weight | ✅ max_abs 2.4e-7 / 3.0e-8 (atol 1e-5) |
| gtest forward comparison (fp32/bf16/fp16) | ⚠️ exceeds the logprob tolerance by design — see the note above (fp32 tree drift 2.1e-4 vs atol 1e-5; bf16/fp16 gold accumulates the matmul in the input dtype vs the kernel's fp32 accumulation) |
| Backward vs fp32-reference autograd (quantized level for bf16/fp16) | ✅ bf16 grads bitwise equal to the quantized reference in the test config; tolerance absorbs rare 1-ULP straddles |
| Out-of-range target → 0.0, empty input, bias fallback to native | ✅ |
| Batch invariance (bitwise): batch 1 vs {2, 4, 16, 300}, row positions 1..7, multi-tile D=10000, repeated runs | ✅ 0 mismatches (`torch.equal`) |
| pytest `tests/test_linear_logp_ascend.py` | ✅ 23 passed |
| Regression `tests/test_batch_invariant_logp.py` | ✅ 44 passed, 42 skipped |
| Regression `rl_engine/tests/test_dispatch.py` | ✅ 13 passed |

<details>

<summary>pytest: tests/test_linear_logp_ascend.py (summary)</summary>

```
======================= 23 passed, 15 warnings in 5.49s ========================
```

</details>

## Notes

- **Why the bitwise guarantee is batch invariance, not gold parity**: an independent kernel's fp32 reduction trees drift ~1e-4 against `torch.matmul` + `log_softmax` at D=4096 (fp32 addition is not associative); the CUDA kernel has the same property on its platform. The Ascend kernel pins its own fixed order, which makes the op batch-invariant bitwise on the NPU (`forward_invariance` contract row).
- The forward is fp32-accumulating regardless of input dtype, matching the CUDA SM90 contract and the WS1 fp32-reference policy; the gold's dtype path (bf16 matmul) is the source of the gtest's bf16 forward mismatch, not this kernel.
- Single-device operator; TP/vocab-parallel calls delegate to the native reference (the CUDA op's TP path is out of scope for this port).
- `black` / `isort` / `flake8` (line-length 100) pass for all modified Python files.
