### PR TITLE
[Bugfix]ROCm build for deterministic collectives

### DIFF
--- a/csrc/cuda/distributed/deterministic_collective.cu
+++ b/csrc/cuda/distributed/deterministic_collective.cu
@@ -51,12 +51,28 @@ struct FusedPeerPointers {
   PeerPointers slots[kFusedStagingSlots];
 };
 
+#if defined(__HIP_PLATFORM_AMD__)
+using nv_bfloat16 = __hip_bfloat16;
+using nv_bfloat162 = __hip_bfloat162;
+constexpr auto kPointerRangeStartAttribute =
+    HIP_POINTER_ATTRIBUTE_RANGE_START_ADDR;
+constexpr auto kPointerRangeSizeAttribute = HIP_POINTER_ATTRIBUTE_RANGE_SIZE;
+#else
+constexpr auto kPointerRangeStartAttribute =
+    CU_POINTER_ATTRIBUTE_RANGE_START_ADDR;
+constexpr auto kPointerRangeSizeAttribute = CU_POINTER_ATTRIBUTE_RANGE_SIZE;
+#endif
+
 bool is_supported_world_size(int64_t world_size) {
   return world_size == 1 || world_size == 2 || world_size == 4 || world_size == 8;
 }
 
 __device__ __forceinline__ uint64_t load_acquire_system(
     const uint64_t* address) {
+#if defined(__HIP_PLATFORM_AMD__)
+  return __hip_atomic_load(
+      address, __ATOMIC_ACQUIRE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
   uint64_t value;
   asm volatile(
       "ld.acquire.sys.global.u64 %0, [%1];"
@@ -64,16 +80,30 @@ __device__ __forceinline__ uint64_t load_acquire_system(
       : "l"(address)
       : "memory");
   return value;
+#endif
 }
 
 __device__ __forceinline__ void store_release_system(
     uint64_t* address,
     uint64_t value) {
+#if defined(__HIP_PLATFORM_AMD__)
+  __hip_atomic_store(
+      address, value, __ATOMIC_RELEASE, __HIP_MEMORY_SCOPE_SYSTEM);
+#else
   asm volatile(
       "st.release.sys.global.u64 [%0], %1;"
       :
       : "l"(address), "l"(value)
       : "memory");
+#endif
+}
+
+__device__ __forceinline__ void device_relax() {
+#if defined(__HIP_PLATFORM_AMD__)
+  __builtin_amdgcn_s_sleep(1);
+#else
+  __nanosleep(64);
+#endif
 }
 
 __global__ void wait_for_previous_done_kernel(
@@ -84,7 +114,7 @@ __global__ void wait_for_previous_done_kernel(
   const uint64_t sequence = load_acquire_system(local_stage_sequence);
   for (int peer = 0; peer < world_size; ++peer) {
     while (load_acquire_system(peers.done_sequences[peer]) < sequence) {
-      __nanosleep(64);
+      device_relax();
     }
   }
 }
@@ -103,7 +133,7 @@ __global__ void wait_for_staged_peers_kernel(
   const uint64_t sequence = load_acquire_system(local_stage_sequence);
   for (int peer = 0; peer < world_size; ++peer) {
     while (load_acquire_system(peers.stage_sequences[peer]) < sequence) {
-      __nanosleep(64);
+      device_relax();
     }
   }
 }
@@ -121,7 +151,7 @@ __global__ void wait_for_owner_done_kernel(
   if (blockIdx.x != 0 || threadIdx.x != 0) return;
   const uint64_t sequence = load_acquire_system(local_stage_sequence);
   while (load_acquire_system(peers.done_sequences[0]) < sequence) {
-    __nanosleep(64);
+    device_relax();
   }
 }
 
@@ -132,7 +162,7 @@ __device__ __forceinline__ void wait_for_stage_sequence(
   const uint64_t sequence = load_acquire_system(local_stage_sequence);
   for (int peer = 0; peer < world_size; ++peer) {
     while (load_acquire_system(peers.stage_sequences[peer]) < sequence) {
-      __nanosleep(64);
+      device_relax();
     }
   }
 }
@@ -151,7 +181,7 @@ __global__ void stage_payload_fast_kernel(
     const uint64_t sequence = load_acquire_system(local_stage_sequence);
     for (int peer = 0; peer < world_size; ++peer) {
       while (load_acquire_system(peers.done_sequences[peer]) < sequence) {
-        __nanosleep(64);
+        device_relax();
       }
     }
   }
@@ -270,7 +300,7 @@ __global__ void deterministic_all_reduce_fused_fast_kernel(
       for (int peer = 0; peer < WorldSize; ++peer) {
         while (load_acquire_system(reuse_peers.done_sequences[peer]) <
                reuse_after) {
-          __nanosleep(64);
+          device_relax();
         }
       }
     }
@@ -303,7 +333,7 @@ __global__ void deterministic_all_reduce_fused_fast_kernel(
         const_cast<uint64_t*>(peers.stage_sequences[rank]), sequence);
     for (int peer = 0; peer < WorldSize; ++peer) {
       while (load_acquire_system(peers.stage_sequences[peer]) < sequence) {
-        __nanosleep(64);
+        device_relax();
       }
     }
   }
@@ -398,9 +428,13 @@ __device__ __forceinline__ T ordered_add(T lower, T upper);
 
 template <>
 __device__ __forceinline__ float ordered_add(float lower, float upper) {
+#if defined(__HIP_PLATFORM_AMD__)
+  return __fadd_rn(lower, upper);
+#else
   float result;
   asm volatile("add.rn.f32 %0, %1, %2;" : "=f"(result) : "f"(lower), "f"(upper));
   return result;
+#endif
 }
 
 template <>
@@ -598,7 +632,7 @@ __global__ void deterministic_all_gather_fused_fast_kernel(
     sequence = load_acquire_system(local_stage_sequence);
     for (int peer = 0; peer < world_size; ++peer) {
       while (load_acquire_system(peers.done_sequences[peer]) < sequence) {
-        __nanosleep(64);
+        device_relax();
       }
     }
   }
@@ -626,7 +660,7 @@ __global__ void deterministic_all_gather_fused_fast_kernel(
     sequence += 1;
     for (int peer = 0; peer < world_size; ++peer) {
       while (load_acquire_system(peers.stage_sequences[peer]) < sequence) {
-        __nanosleep(64);
+        device_relax();
       }
     }
   }
@@ -1429,17 +1463,23 @@ std::tuple<std::vector<int64_t>, int64_t> deterministic_collective_ipc_meta(
   TORCH_CHECK(
       cuPointerGetAttribute(
           &allocation_base,
-          CU_POINTER_ATTRIBUTE_RANGE_START_ADDR,
+          kPointerRangeStartAttribute,
           pointer) == CUDA_SUCCESS,
       "failed to query CUDA allocation base");
   TORCH_CHECK(
       cuPointerGetAttribute(
           &allocation_size,
-          CU_POINTER_ATTRIBUTE_RANGE_SIZE,
+          kPointerRangeSizeAttribute,
           pointer) == CUDA_SUCCESS,
       "failed to query CUDA allocation size");
 
+#if defined(__HIP_PLATFORM_AMD__)
+  const int64_t offset = static_cast<int64_t>(
+      reinterpret_cast<uintptr_t>(pointer) -
+      reinterpret_cast<uintptr_t>(allocation_base));
+#else
   const int64_t offset = static_cast<int64_t>(pointer - allocation_base);
+#endif
   const int64_t tensor_bytes = tensor.numel() * tensor.element_size();
   TORCH_CHECK(offset >= 0, "invalid negative CUDA allocation offset");
   TORCH_CHECK(

--- a/setup.py
+++ b/setup.py
@@ -213,7 +213,7 @@ def get_extensions():
 
         cxx_flags = ["-O3", "-std=c++17", "-DKERNEL_ALIGN_WITH_CUDA"]
         extra_link_args = list(torch_rpath)
-        if os.name != "nt":
+        if os.name != "nt" and not is_rocm:
             # CUDA IPC metadata queries use the driver API (cuPointerGetAttribute).
             extra_link_args.append("-lcuda")
 


### PR DESCRIPTION
## Summary

Restore the ROCm/gfx942 extension build after the deterministic collective implementation introduced CUDA-specific device code and driver linkage.

This change:

- uses HIP system-scope atomics for sequence publication and observation;
- uses an AMD sleep intrinsic in polling loops;
- maps BF16 scalar/vector types and pointer-range attributes to their HIP equivalents;
- uses a HIP-compatible round-to-nearest FP32 add while preserving the fixed reduction order;
- avoids linking the NVIDIA driver library in ROCm builds.

## Root cause

Hipify converts CUDA API calls and kernel syntax, but it cannot translate NVIDIA-specific inline PTX, __nanosleep, or the nv_bfloat16, nv_bfloat162 identifiers. The generated deterministic_collective.hip therefore retained CUDA-only constructs and failed in hipcc.

In addition, setup.py added -lcuda to every non-Windows GPU build, including ROCm. Once the device-code errors were fixed, the final ROCm link failed because the NVIDIA driver library is not present.

## Build comparison

Test command on ROCm 7.14 with a gfx942 target:

```bash
python3 -m pip uninstall -y rl-kernel
rm -rf build/ .deps *.egg-info */*.so
PYTORCH_ROCM_ARCH=gfx942 python3 setup.py develop
```

### Before: main

```text
[1/8] hipcc ... csrc/hip/distributed/deterministic_collective.hip
... error: invalid output constraint '=l' in asm
... error: invalid input constraint 'l' in asm
... error: use of undeclared identifier '__nanosleep'
... error: unknown type name 'nv_bfloat162'; did you mean 'hip_bfloat16'?
20 errors generated when compiling for gfx942.
ninja: build stopped: subcommand failed.
RuntimeError: Error compiling objects for extension
```

After making the device code portable, the latent link issue became visible:

```text
/usr/bin/ld: cannot find -lcuda: No such file or directory
collect2: error: ld returned 1 exit status
```

### After

```text
csrc/cuda/distributed/deterministic_collective.cu
  -> csrc/hip/distributed/deterministic_collective.hip [ok]
...
[4/8] hipcc ... csrc/hip/distributed/deterministic_collective.hip
...
[8/8] hipcc ... csrc/hip/rmsnorm.hip
g++ -shared ... -lamdhip64 -lc10_hip -ltorch_hip ...
copying .../rl_engine/_C.cpython-312-x86_64-linux-gnu.so -> rl_engine
Installed /workspace/RL-Kernel
Finished processing dependencies for RL-Kernel==0.1.0
```

All eight compilation steps and the final shared-library link completed successfully.

## CUDA impact

The CUDA path remains unchanged behind platform guards: it still uses the existing PTX acquire/release operations, __nanosleep(64), NVIDIA BF16 types, PTX add.rn.f32, CUDA pointer attributes, and -lcuda. Only ROCm selects the new HIP-specific implementations and omits -lcuda.

A CUDA 13 header syntax check passed. A full CUDA build/runtime test was not run in this ROCm environment because `nvcc` and a CUDA GPU were unavailable.
