### PR TITLE
feat(ascend): add SwiGLU forward and backward kernels

### DIFF
--- a/csrc/ascend/activation.asc
+++ b/csrc/ascend/activation.asc
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+// SwiGLU: out = (gate * sigmoid(gate)) * up, with FP32 intermediates.
+// Fixed elementwise tiles have no reductions or inter-core synchronization.
+
+#include <algorithm>
+#include <type_traits>
+
+#include "kernel_operator.h"
+#include <torch/extension.h>
+#include <c10/core/DeviceGuard.h>
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+
+namespace {
+
+constexpr uint32_t TILE_LENGTH = 2048;
+constexpr int64_t MAX_BLOCKS = 32;
+
+template <typename T, bool Backward>
+class KernelSwiGLU {
+public:
+    __aicore__ inline void Init(AscendC::TPipe* pipe, GM_ADDR gate, GM_ADDR up,
+                                GM_ADDR grad, GM_ADDR out, GM_ADDR dUp, int64_t n)
+    {
+        n_ = n;
+        gateGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(gate));
+        upGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(up));
+        outGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(out));
+        if constexpr (Backward) {
+            gradGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(grad));
+            dUpGm_.SetGlobalBuffer(reinterpret_cast<__gm__ T*>(dUp));
+        }
+        // Each segment starts on a 32-byte boundary, including for short tails.
+        // Worst-case UB use: (3 inputs + 2 outputs + 5 FP32 tiles) * 8 KiB = 80 KiB.
+        pipe->InitBuffer(inQueue_, 1, (Backward ? 3 : 2) * TILE_LENGTH * sizeof(T));
+        pipe->InitBuffer(outQueue_, 1, (Backward ? 2 : 1) * TILE_LENGTH * sizeof(T));
+        pipe->InitBuffer(work_, 5 * TILE_LENGTH * sizeof(float));
+    }
+
+    __aicore__ inline void Process()
+    {
+        for (int64_t offset = static_cast<int64_t>(AscendC::GetBlockIdx()) * TILE_LENGTH;
+             offset < n_;
+             offset += static_cast<int64_t>(AscendC::GetBlockNum()) * TILE_LENGTH) {
+            const uint32_t count = static_cast<uint32_t>(
+                n_ - offset < TILE_LENGTH ? n_ - offset : TILE_LENGTH);
+            CopyIn(offset, count);
+            Compute(count);
+            CopyOut(offset, count);
+        }
+    }
+
+private:
+    __aicore__ inline void CopyIn(int64_t offset, uint32_t count)
+    {
+        auto input = inQueue_.AllocTensor<T>();
+        AscendC::DataCopyExtParams params{
+            1, static_cast<uint32_t>(count * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPadExtParams<T> pad{false, 0, 0, 0};
+        AscendC::DataCopyPad(input, gateGm_[offset], params, pad);
+        AscendC::DataCopyPad(input[TILE_LENGTH], upGm_[offset], params, pad);
+        if constexpr (Backward) {
+            AscendC::DataCopyPad(input[2 * TILE_LENGTH], gradGm_[offset], params, pad);
+        }
+        inQueue_.EnQue(input);
+    }
+
+    __aicore__ inline void ToFloat(AscendC::LocalTensor<float> dst,
+                                   AscendC::LocalTensor<T> src, uint32_t count)
+    {
+        if constexpr (std::is_same_v<T, float>) {
+            // UB-to-UB copies require a multiple of 32 bytes. Padding stays in UB.
+            AscendC::DataCopy(dst, src, (count + 7) / 8 * 8);
+        } else {
+            AscendC::Cast(dst, src, AscendC::RoundMode::CAST_NONE, count);
+        }
+    }
+
+    __aicore__ inline void Store(AscendC::LocalTensor<T> dst,
+                                 AscendC::LocalTensor<float> src, uint32_t count)
+    {
+        AscendC::PipeBarrier<PIPE_V>();
+        if constexpr (std::is_same_v<T, float>) {
+            AscendC::DataCopy(dst, src, (count + 7) / 8 * 8);
+        } else {
+            // Round to nearest, ties to even, matching PyTorch dtype conversion.
+            AscendC::Cast(dst, src, AscendC::RoundMode::CAST_RINT, count);
+        }
+        // The caller may reuse src immediately for the next result.
+        AscendC::PipeBarrier<PIPE_V>();
+    }
+
+    __aicore__ inline void Compute(uint32_t count)
+    {
+        auto input = inQueue_.DeQue<T>();  // MTE2 -> vector synchronization
+        auto output = outQueue_.AllocTensor<T>();
+        auto gate = work_.Get<float>();
+        auto up = gate[TILE_LENGTH];
+        auto grad = gate[2 * TILE_LENGTH];
+        auto sigmoid = gate[3 * TILE_LENGTH];
+        auto tmp = gate[4 * TILE_LENGTH];
+        ToFloat(gate, input, count);
+        ToFloat(up, input[TILE_LENGTH], count);
+        if constexpr (Backward) {
+            ToFloat(grad, input[2 * TILE_LENGTH], count);
+        }
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Muls(sigmoid, gate, -1.0f, count);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Exp(sigmoid, sigmoid, count);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Adds(sigmoid, sigmoid, 1.0f, count);
+        AscendC::Duplicate(tmp, 1.0f, count);
+        AscendC::PipeBarrier<PIPE_V>();
+        AscendC::Div(sigmoid, tmp, sigmoid, count);
+        AscendC::PipeBarrier<PIPE_V>();
+
+        AscendC::Mul(tmp, gate, sigmoid, count);
+        AscendC::PipeBarrier<PIPE_V>();
+        if constexpr (Backward) {
+            // d_up = grad * (gate * sigmoid(gate)).
+            AscendC::Mul(tmp, grad, tmp, count);
+            Store(output[TILE_LENGTH], tmp, count);
+
+            // d_gate = (grad * up) * (sigmoid * (1 + gate * (1 - sigmoid))).
+            AscendC::Muls(tmp, sigmoid, -1.0f, count);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Adds(tmp, tmp, 1.0f, count);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(tmp, gate, tmp, count);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Adds(tmp, tmp, 1.0f, count);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(tmp, sigmoid, tmp, count);
+            AscendC::Mul(up, grad, up, count);
+            AscendC::PipeBarrier<PIPE_V>();
+            AscendC::Mul(tmp, up, tmp, count);
+        } else {
+            AscendC::Mul(tmp, tmp, up, count);
+        }
+        Store(output, tmp, count);
+        outQueue_.EnQue(output);
+        inQueue_.FreeTensor(input);
+    }
+
+    __aicore__ inline void CopyOut(int64_t offset, uint32_t count)
+    {
+        auto output = outQueue_.DeQue<T>();  // vector -> MTE3 synchronization
+        AscendC::DataCopyExtParams params{
+            1, static_cast<uint32_t>(count * sizeof(T)), 0, 0, 0};
+        AscendC::DataCopyPad(outGm_[offset], output, params);
+        if constexpr (Backward) {
+            AscendC::DataCopyPad(dUpGm_[offset], output[TILE_LENGTH], params);
+        }
+        outQueue_.FreeTensor(output);
+    }
+
+    AscendC::GlobalTensor<T> gateGm_, upGm_, gradGm_, outGm_, dUpGm_;
+    AscendC::TQue<AscendC::TPosition::VECIN, 1> inQueue_;
+    AscendC::TQue<AscendC::TPosition::VECOUT, 1> outQueue_;
+    AscendC::TBuf<AscendC::TPosition::VECCALC> work_;
+    int64_t n_;
+};
+
+template <typename T, bool Backward>
+__global__ __vector__ void swiglu_ascend_kernel(
+    GM_ADDR gate, GM_ADDR up, GM_ADDR grad, GM_ADDR out, GM_ADDR dUp, int64_t n)
+{
+    AscendC::TPipe pipe;
+    KernelSwiGLU<T, Backward> op;
+    op.Init(&pipe, gate, up, grad, out, dUp, n);
+    op.Process();
+}
+
+void CheckInput(const torch::Tensor& tensor, const char* name)
+{
+    TORCH_CHECK(tensor.is_privateuseone(), name, " must be on an NPU device");
+    TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+    TORCH_CHECK(tensor.scalar_type() == at::kHalf || tensor.scalar_type() == at::kBFloat16 ||
+                tensor.scalar_type() == at::kFloat, name, " must be fp16, bf16, or fp32");
+}
+
+void CheckLike(const torch::Tensor& tensor, const torch::Tensor& gate, const char* name)
+{
+    CheckInput(tensor, name);
+    TORCH_CHECK(tensor.device() == gate.device(), name, " must be on the same NPU device as gate");
+    TORCH_CHECK(tensor.sizes() == gate.sizes(), name, " must share shape with gate");
+    TORCH_CHECK(tensor.scalar_type() == gate.scalar_type(), name, " must share dtype with gate");
+}
+
+template <bool Backward>
+void Launch(torch::Tensor gate, torch::Tensor up, torch::Tensor grad,
+            torch::Tensor out, torch::Tensor dUp)
+{
+    const int64_t n = gate.numel();
+    if (n == 0) {
+        return;
+    }
+    const uint32_t blocks = static_cast<uint32_t>(
+        std::min((n + TILE_LENGTH - 1) / TILE_LENGTH, MAX_BLOCKS));
+    // Flush torch_npu's task queue before launching directly on its current stream.
+    auto stream = c10_npu::getCurrentNPUStream().stream(true);
+    auto gatePtr = reinterpret_cast<uint8_t*>(gate.mutable_data_ptr());
+    auto upPtr = reinterpret_cast<uint8_t*>(up.mutable_data_ptr());
+    auto outPtr = reinterpret_cast<uint8_t*>(out.mutable_data_ptr());
+    uint8_t* gradPtr = nullptr;
+    uint8_t* dUpPtr = nullptr;
+    if constexpr (Backward) {
+        gradPtr = reinterpret_cast<uint8_t*>(grad.mutable_data_ptr());
+        dUpPtr = reinterpret_cast<uint8_t*>(dUp.mutable_data_ptr());
+    }
+    if (gate.scalar_type() == at::kHalf) {
+        swiglu_ascend_kernel<half, Backward><<<blocks, nullptr, stream>>>(
+            gatePtr, upPtr, gradPtr, outPtr, dUpPtr, n);
+    } else if (gate.scalar_type() == at::kBFloat16) {
+        swiglu_ascend_kernel<bfloat16_t, Backward><<<blocks, nullptr, stream>>>(
+            gatePtr, upPtr, gradPtr, outPtr, dUpPtr, n);
+    } else {
+        swiglu_ascend_kernel<float, Backward><<<blocks, nullptr, stream>>>(
+            gatePtr, upPtr, gradPtr, outPtr, dUpPtr, n);
+    }
+}
+
+}  // namespace
+
+torch::Tensor swiglu_ascend_forward(torch::Tensor gate, torch::Tensor up)
+{
+    CheckInput(gate, "gate");
+    CheckLike(up, gate, "up");
+    const c10::DeviceGuard guard(gate.device());
+    auto out = at::empty(gate.sizes(), gate.options());
+    Launch<false>(gate, up, {}, out, {});
+    return out;
+}
+
+std::vector<torch::Tensor> swiglu_ascend_backward(
+    torch::Tensor grad, torch::Tensor gate, torch::Tensor up)
+{
+    CheckInput(gate, "gate");
+    CheckLike(up, gate, "up");
+    CheckLike(grad, gate, "grad_out");
+    const c10::DeviceGuard guard(gate.device());
+    auto dGate = at::empty(gate.sizes(), gate.options());
+    auto dUp = at::empty(gate.sizes(), gate.options());
+    Launch<true>(gate, up, grad, dGate, dUp);
+    return {dGate, dUp};
+}

--- a/csrc/ascend/batch_invariant_logp_ascend.asc
+++ b/csrc/ascend/batch_invariant_logp_ascend.asc
@@ -308,5 +308,6 @@ std::vector<torch::Tensor> batch_invariant_logp_ascend_forward(torch::Tensor log
     return {logp, lse};
 }
 
+
 // The PYBIND11_MODULE for rl_engine._C_npu lives in npu_module.cpp so that
 // every Ascend op shares one compiled module.

--- a/csrc/ascend/bindings.asc
+++ b/csrc/ascend/bindings.asc
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+// One Python module initializer for all Ascend translation units: it lives in
+// npu_module.cpp, so keep this TU free of any PYBIND11_MODULE definition.

--- a/csrc/ascend/npu_module.cpp
+++ b/csrc/ascend/npu_module.cpp
@@ -42,6 +42,10 @@ torch::Tensor fused_linear_logp_ascend_forward(torch::Tensor hidden,
                                                torch::optional<torch::Tensor> bias,
                                                torch::Tensor target);
 
+torch::Tensor swiglu_ascend_forward(torch::Tensor gate, torch::Tensor up);
+std::vector<torch::Tensor> swiglu_ascend_backward(
+    torch::Tensor grad, torch::Tensor gate, torch::Tensor up);
+
 torch::Tensor rmsnorm_ascend_forward(torch::Tensor x,
                                      torch::Tensor weight,
                                      torch::Tensor rstd);
@@ -94,4 +98,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
     m.def("fused_linear_logp_ascend",
           &fused_linear_logp_ascend_forward,
           "Batch-invariant fused linear log-probability (Ascend C forward)");
+    m.def("swiglu_forward", &swiglu_ascend_forward, "SwiGLU forward (Ascend C)");
+    m.def("swiglu_backward", &swiglu_ascend_backward, "SwiGLU backward (Ascend C)");
 }

--- a/docs/operators/activation.md
+++ b/docs/operators/activation.md
@@ -2,7 +2,7 @@
 
 The activation operators are the element-wise core of the Qwen3/Llama gated MLP. They
 implement the WS1 dual-path contract (issue #108): pure-PyTorch fp32 ground truth, plus
-CUDA and Triton candidates that validate against it.
+CUDA, Triton and Ascend C candidates that validate against it.
 
 - **SiLU** (`NativeSiLUOp` / `SiLUCudaOp` / `TritonSiLUOp`): `silu(x) = x * sigmoid(x)` —
   the `hidden_act="silu"` gate.
@@ -44,6 +44,7 @@ All backends expose the WS1 dual-path contract:
 | PyTorch fallback | `NativeSiLUOp` / `NativeSwiGLUOp` | None | fp32 ground-truth reference; CPU and any GPU. |
 | CUDA | `SiLUCudaOp` / `SwiGLUCudaOp` | `_C.silu_*` / `_C.swiglu_*` | General CUDA (fp16/bf16/fp32); math in fp32. |
 | Triton | `TritonSiLUOp` / `TritonSwiGLUOp` | Triton JIT | Portable GPU baseline; same fp32 math contract. |
+| Ascend C | `SwiGLUAscendOp` | `_C_npu.swiglu_forward` / `swiglu_backward` | NPU SwiGLU forward and backward; fp16/bf16/fp32 inputs, FP32 math. |
 
 ## Tensor Contract
 
@@ -67,9 +68,57 @@ mutation, device/dtype follow the inputs.
 | `cuda` | CUDA → Triton → PyTorch native |
 | `rocm` | Triton → PyTorch native |
 | `cpu` | PyTorch native |
+| `npu` | SwiGLU: Ascend C → PyTorch native; SiLU: PyTorch native |
 
 If the CUDA extension is not built (or symbols are missing), the registry falls back to
 Triton, then to the native gold.
+
+On NPU, a missing Ascend extension or missing SwiGLU symbols causes the registry to
+select PyTorch native. Construct `SwiGLUAscendOp` directly when the Ascend C kernel
+is required; its constructor raises an error if either native symbol is missing.
+
+## Ascend C Build and Validation
+
+On a Linux Ascend host with matching PyTorch, `torch_npu` and CANN installed, source
+the CANN environment and build the existing NPU extension:
+
+```bash
+source /usr/local/Ascend/ascend-toolkit/set_env.sh
+KERNEL_ALIGN_FORCE_ASCEND=1 KERNEL_ALIGN_ASCEND_ARCH=dav-2201 \
+  python -m pip install --no-build-isolation -e .
+python -m pytest tests/test_swiglu.py -v
+python scripts/check_operator.py --op swiglu --candidate ascend --dtype bf16 --device npu --check-grad
+```
+
+The kernel uses the A2/A3 vector programming model (`dav-2201`). Other architectures
+require separate build and device validation. `setup.py` automatically includes all
+`csrc/ascend/*.asc` files; `bindings.asc` defines the shared `_C_npu` module entry.
+
+```python
+import torch
+import torch_npu
+from rl_engine.kernels.registry import kernel_registry
+
+swiglu = kernel_registry.get_op("swiglu", device="npu")
+gate = torch.randn(2, 12288, device="npu", dtype=torch.bfloat16, requires_grad=True)
+up = torch.randn_like(gate, requires_grad=True)
+out = swiglu(gate, up)
+out.float().sum().backward()
+```
+
+The wrapper accepts scalars, empty tensors and strided views. It makes inputs and
+upstream gradients contiguous before invoking the kernels. Both kernels use fixed
+2048-element tiles, bounded UB storage, FP32 intermediates and a single output cast.
+FP32-to-FP16/BF16 uses ties-to-even rounding (`CAST_RINT`), as specified by the
+[Ascend C Cast API](https://www.hiascend.com/document/detail/zh/CANNCommunityEdition/81RC1alpha002/apiref/ascendcopapi/atlasascendc_api_07_0073.html).
+`forward_fp32` returns FP32 while retaining gradients to the original inputs.
+Only first-order autograd is supported by this backend.
+
+The tests cover dtype accuracy, both input gradients, tails, multiple tiles,
+noncontiguous views, input validation, batch-position invariance, stream ordering
+and multiple devices. CPU runs check Python integration and skip hardware tests;
+on an NPU host a missing extension fails the hardware tests. Hardware compilation,
+numerical acceptance and performance must be validated on the target NPU.
 
 ## Accuracy
 
@@ -125,6 +174,9 @@ native forward+backward, registry dispatch, and the issue-#108 `OP_SPECS` harnes
 - `rl_engine/kernels/ops/pytorch/activation/swiglu.py` — gold
 - `rl_engine/kernels/ops/cuda/activation/swiglu.py` — CUDA wrappers
 - `rl_engine/kernels/ops/triton/activation/swiglu.py` — Triton kernels
+- `rl_engine/kernels/ops/ascend/activation/swiglu.py` — Ascend autograd wrapper
+- `csrc/ascend/activation.asc` — Ascend C forward/backward kernels
+- `csrc/ascend/bindings.asc` — shared NPU extension bindings
 - `csrc/cuda/activation.cu` — CUDA kernels
 - `rl_engine/kernels/registry.py`
 - `rl_engine/kernels/gtest/operator_specs.py`

--- a/rl_engine/_C_npu.pyi
+++ b/rl_engine/_C_npu.pyi
@@ -3,6 +3,10 @@
 # Built only when KERNEL_ALIGN_FORCE_ASCEND=1 on a machine with CANN + torch_npu.
 import torch
 
+def swiglu_forward(gate: torch.Tensor, up: torch.Tensor) -> torch.Tensor: ...
+def swiglu_backward(
+    grad_out: torch.Tensor, gate: torch.Tensor, up: torch.Tensor
+) -> list[torch.Tensor]: ...
 def batch_invariant_logp_ascend(
     logits: torch.Tensor,
     target: torch.Tensor,

--- a/rl_engine/kernels/gtest/operator_specs.py
+++ b/rl_engine/kernels/gtest/operator_specs.py
@@ -217,6 +217,7 @@ OP_SPECS = {
             "pytorch": "rl_engine.kernels.ops.pytorch.activation.swiglu.NativeSwiGLUOp",
             "triton": "rl_engine.kernels.ops.triton.activation.swiglu.TritonSwiGLUOp",
             "cuda": "rl_engine.kernels.ops.cuda.activation.swiglu.SwiGLUCudaOp",
+            "ascend": "rl_engine.kernels.ops.ascend.activation.swiglu.SwiGLUAscendOp",
         },
         grad_input_names=("gate", "up"),
     ),

--- a/rl_engine/kernels/ops/ascend/__init__.py
+++ b/rl_engine/kernels/ops/ascend/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
 
+from . import activation  # noqa: F401
 from . import linear  # noqa: F401
 from . import loss  # noqa: F401
 from . import norm  # noqa: F401

--- a/rl_engine/kernels/ops/ascend/activation/__init__.py
+++ b/rl_engine/kernels/ops/ascend/activation/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from .swiglu import SwiGLUAscendOp
+
+__all__ = ["SwiGLUAscendOp"]

--- a/rl_engine/kernels/ops/ascend/activation/swiglu.py
+++ b/rl_engine/kernels/ops/ascend/activation/swiglu.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+"""Ascend C SwiGLU, with FP32 math and fused forward/backward kernels."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+from torch import Tensor
+from torch.autograd.function import once_differentiable
+
+_C_npu: Any = None
+try:
+    from rl_engine import _C_npu
+except ImportError:  # pragma: no cover - extension requires CANN + torch_npu
+    pass
+
+_SUPPORTED_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+def _validate_inputs(gate: Tensor, up: Tensor) -> None:
+    if gate.device.type != "npu" or up.device.type != "npu":
+        raise RuntimeError("SwiGLUAscendOp requires NPU tensors.")
+    if gate.device != up.device:
+        raise RuntimeError("gate and up must be on the same NPU device.")
+    if gate.shape != up.shape:
+        raise ValueError("gate and up must share shape.")
+    for name, value in (("gate", gate), ("up", up)):
+        if value.dtype not in _SUPPORTED_DTYPES:
+            raise TypeError(f"{name} must have dtype fp16, bf16, or fp32, got {value.dtype}.")
+    if gate.dtype != up.dtype:
+        raise TypeError("gate and up must share dtype.")
+
+
+class _SwiGLUAscendFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, gate: Tensor, up: Tensor) -> Tensor:
+        gate_c, up_c = gate.contiguous(), up.contiguous()
+        result = _C_npu.swiglu_forward(gate_c, up_c)
+        ctx.save_for_backward(gate_c, up_c)
+        return result
+
+    @staticmethod
+    @once_differentiable
+    def backward(ctx, grad_out: Tensor):
+        gate, up = ctx.saved_tensors
+        d_gate = d_up = None
+        if any(ctx.needs_input_grad):
+            grads = _C_npu.swiglu_backward(grad_out.contiguous(), gate, up)
+            if ctx.needs_input_grad[0]:
+                d_gate = grads[0]
+            if ctx.needs_input_grad[1]:
+                d_up = grads[1]
+        return d_gate, d_up
+
+
+class SwiGLUAscendOp:
+    """``(gate * sigmoid(gate)) * up`` on NPU, with first-order autograd.
+
+    Inputs share shape, dtype and device. Arbitrary shapes, empty tensors and
+    strided views are supported; the native kernels receive contiguous tensors.
+    """
+
+    op_class = "elementwise"
+
+    def __init__(self) -> None:
+        if _C_npu is None or not all(
+            hasattr(_C_npu, name) for name in ("swiglu_forward", "swiglu_backward")
+        ):
+            raise RuntimeError(
+                "Ascend C SwiGLU kernels are not compiled into rl_engine._C_npu. "
+                "Rebuild on an Ascend host with CANN and torch_npu: "
+                "KERNEL_ALIGN_FORCE_ASCEND=1 pip install --no-build-isolation -e ."
+            )
+
+    def __call__(self, gate: Tensor, up: Tensor) -> Tensor:
+        return self.forward(gate, up)
+
+    def forward(self, gate: Tensor, up: Tensor) -> Tensor:
+        """Compute in FP32 and return the input dtype."""
+        _validate_inputs(gate, up)
+        return _SwiGLUAscendFunction.apply(gate, up)
+
+    def forward_fp32(self, gate: Tensor, up: Tensor) -> Tensor:
+        """Compute and return FP32, preserving gradients to the original inputs."""
+        _validate_inputs(gate, up)
+        return _SwiGLUAscendFunction.apply(gate.float(), up.float())

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -168,6 +168,7 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     PYTORCH_NATIVE_SWIGLU = "rl_engine.kernels.ops.pytorch.activation.swiglu.NativeSwiGLUOp"
     CUDA_SILU = "rl_engine.kernels.ops.cuda.activation.swiglu.SiLUCudaOp"
     CUDA_SWIGLU = "rl_engine.kernels.ops.cuda.activation.swiglu.SwiGLUCudaOp"
+    ASCEND_SWIGLU = "rl_engine.kernels.ops.ascend.activation.swiglu.SwiGLUAscendOp"
     TRITON_SILU = "rl_engine.kernels.ops.triton.activation.swiglu.TritonSiLUOp"
     TRITON_SWIGLU = "rl_engine.kernels.ops.triton.activation.swiglu.TritonSwiGLUOp"
 
@@ -743,6 +744,10 @@ class KernelRegistry:
         self._priority_map["npu"]["linear_logp"] = [
             OpBackend.ASCEND_FUSED_LINEAR_LOGP,
             OpBackend.PYTORCH_LINEAR_LOGP,
+        ]
+        self._priority_map["npu"]["swiglu"] = [
+            OpBackend.ASCEND_SWIGLU,
+            OpBackend.PYTORCH_NATIVE_SWIGLU,
         ]
         logger.info(f"KernelRegistry initialized for {device_ctx.device_type}")
         self._adjust_priority_for_hardware()

--- a/tests/test_swiglu.py
+++ b/tests/test_swiglu.py
@@ -1,30 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 RL-Kernel Contributors
 
-"""SiLU / SwiGLU tests: native gold + CUDA / Triton candidates vs ground truth.
+"""SiLU / SwiGLU tests: native gold + CUDA / Triton / Ascend C candidates.
 
 Covers:
 - Native correctness (fp32 formula, dtype path, shape guard)
 - Axis A batch invariance (slice + padding, forward + backward)
 - CUDA / Triton forward+backward vs NativeSiLUOp / NativeSwiGLUOp (issue #108 harness)
+- Ascend C SwiGLU integration, forward/backward accuracy and NPU acceptance
 - Registry dispatch + OP_SPECS candidate paths
 """
 
 from __future__ import annotations
 
 import argparse
+from types import SimpleNamespace
 
 import pytest
 import torch
 
 from rl_engine.kernels.gtest.op_checks import run_operator_suite
 from rl_engine.kernels.gtest.operator_specs import (
+    OP_SPECS,
     make_candidate,
     make_operator_case,
     operator_names,
 )
+from rl_engine.kernels.ops.ascend.activation import swiglu as ascend
 from rl_engine.kernels.ops.pytorch.activation.swiglu import NativeSiLUOp, NativeSwiGLUOp
-from rl_engine.kernels.registry import kernel_registry
+from rl_engine.kernels.registry import KernelRegistry, OpBackend, kernel_registry
+from rl_engine.platforms.device import _npu_available, device_ctx
 
 try:
     from rl_engine.kernels.ops.triton.activation.swiglu import TritonSiLUOp, TritonSwiGLUOp
@@ -49,6 +54,7 @@ except ImportError:  # pragma: no cover - extension may be missing in CPU-only b
 
 # Qwen3-8B SwiGLU intermediate dim (gate/up_proj output width).
 _INTERMEDIATE = 12288
+_ASCEND_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
 
 
 # Shared helper
@@ -70,6 +76,7 @@ def _dtype_tolerance(dtype: torch.dtype) -> tuple[float, float]:
 
 
 requires_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+requires_npu = pytest.mark.skipif(not _npu_available(), reason="Ascend NPU required")
 requires_cuda_activation = pytest.mark.skipif(
     not (torch.cuda.is_available() and _HAS_CUDA_ACTIVATION),
     reason="CUDA SiLU/SwiGLU extension is not available",
@@ -681,3 +688,233 @@ def test_silu_swiglu_cuda_triton_issue_108_harness(candidate, op_name, dtype):
         f"{op_name}/{candidate}/{dtype} failed against gold: "
         f"{report.candidates[0].cases[0].outputs}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Ascend C SwiGLU integration and on-device acceptance
+# ---------------------------------------------------------------------------
+# NPU tests skip only when no NPU is available. On NPU hosts, a missing
+# extension fails these tests instead of silently exercising PyTorch fallback.
+
+
+@pytest.mark.parametrize("symbols", [(), ("swiglu_forward",), ("swiglu_backward",)])
+def test_missing_extension_symbols_raise_actionable_error(monkeypatch, symbols):
+    monkeypatch.setattr(ascend, "_C_npu", SimpleNamespace(**dict.fromkeys(symbols)))
+    with pytest.raises(RuntimeError, match="KERNEL_ALIGN_FORCE_ASCEND=1"):
+        ascend.SwiGLUAscendOp()
+
+
+def test_npu_registry_selects_ascend_and_falls_back_without_extension(monkeypatch):
+    monkeypatch.setattr(device_ctx, "device_type", "npu")
+    symbols = SimpleNamespace(swiglu_forward=object(), swiglu_backward=object())
+    monkeypatch.setattr(ascend, "_C_npu", symbols)
+    assert isinstance(KernelRegistry().get_op("swiglu"), ascend.SwiGLUAscendOp)
+    assert isinstance(KernelRegistry().get_op("swiglu", device="cpu"), NativeSwiGLUOp)
+    monkeypatch.setattr(ascend, "_C_npu", None)
+    assert isinstance(KernelRegistry().get_op("swiglu"), NativeSwiGLUOp)
+
+
+def test_ascend_candidate_is_exposed_to_accuracy_harness():
+    assert OP_SPECS["swiglu"].candidate_paths["ascend"] == OpBackend.ASCEND_SWIGLU.value
+
+
+@pytest.mark.parametrize("method", ["forward", "forward_fp32"])
+def test_ascend_wrapper_rejects_cpu_inputs(monkeypatch, method):
+    monkeypatch.setattr(
+        ascend, "_C_npu", SimpleNamespace(swiglu_forward=object(), swiglu_backward=object())
+    )
+    with pytest.raises(RuntimeError, match="requires NPU tensors"):
+        getattr(ascend.SwiGLUAscendOp(), method)(torch.ones(3), torch.ones(3))
+
+
+@pytest.mark.parametrize("needs_grad", [(True, True), (True, False), (False, True)])
+@pytest.mark.parametrize("fp32_output", [False, True])
+def test_autograd_wrapper_contiguity_and_gradient_routing(monkeypatch, needs_grad, fp32_output):
+    """Exercise the Python autograd boundary; this does not emulate Ascend C."""
+    calls = []
+
+    def forward(gate, up):
+        assert gate.is_contiguous() and up.is_contiguous()
+        calls.append(("forward", gate.dtype))
+        return NativeSwiGLUOp()(gate, up)
+
+    def backward(grad_out, gate, up):
+        assert all(x.is_contiguous() for x in (grad_out, gate, up))
+        calls.append(("backward", grad_out.dtype))
+        g, u, dy = gate.float(), up.float(), grad_out.float()
+        s = torch.sigmoid(g)
+        return ((dy * u) * (s * (1 + g * (1 - s)))).to(gate.dtype), (dy * (g * s)).to(up.dtype)
+
+    monkeypatch.setattr(
+        ascend, "_C_npu", SimpleNamespace(swiglu_forward=forward, swiglu_backward=backward)
+    )
+    # CPU-only test of the wrapper; real device guards are tested separately.
+    monkeypatch.setattr(ascend, "_validate_inputs", lambda gate, up: None)
+    gate = torch.randn(7, 5, dtype=torch.bfloat16).t().requires_grad_(needs_grad[0])
+    up = torch.randn(7, 5, dtype=torch.bfloat16).t().requires_grad_(needs_grad[1])
+    grad_out = torch.randn(7, 5).t()
+    method = "forward_fp32" if fp32_output else "forward"
+    result = getattr(ascend.SwiGLUAscendOp(), method)(gate, up)
+    result.backward(grad_out.to(result.dtype))
+
+    ref_gate = gate.detach().clone().requires_grad_(needs_grad[0])
+    ref_up = up.detach().clone().requires_grad_(needs_grad[1])
+    ref = getattr(NativeSwiGLUOp(), method)(ref_gate, ref_up)
+    ref.backward(grad_out.to(ref.dtype))
+    torch.testing.assert_close(result, ref, rtol=0, atol=0)
+    for actual, expected in ((gate.grad, ref_gate.grad), (up.grad, ref_up.grad)):
+        if expected is None:
+            assert actual is None
+        else:
+            torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+    expected_dtype = torch.float32 if fp32_output else torch.bfloat16
+    assert calls == [("forward", expected_dtype), ("backward", expected_dtype)]
+
+
+@pytest.fixture
+def npu_op():
+    return ascend.SwiGLUAscendOp()
+
+
+def _ascend_dtype_tolerance(dtype):
+    return {
+        torch.float32: (1e-5, 1e-5),
+        torch.float16: (1e-3, 1e-3),
+        torch.bfloat16: (2e-2, 1.6e-2),
+    }[dtype]
+
+
+@requires_npu
+@pytest.mark.parametrize("dtype", _ASCEND_DTYPES)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (),
+        (0, 17),
+        (1,),
+        (7,),
+        (15,),
+        (31,),
+        (33,),
+        (2047,),
+        (2048,),
+        (2049,),
+        (2, 3, 65),
+        (2, 12288),
+        (65539,),
+    ],
+)
+def test_npu_forward_backward_and_fp32_path(npu_op, dtype, shape):
+    generator = torch.Generator().manual_seed(29)
+    gate_cpu = torch.randn(shape, generator=generator).to(dtype).requires_grad_()
+    up_cpu = torch.randn(shape, generator=generator).to(dtype).requires_grad_()
+    grad_cpu = torch.randn(shape, generator=generator)
+    gate = gate_cpu.detach().to("npu").requires_grad_()
+    up = up_cpu.detach().to("npu").requires_grad_()
+    for method in ("forward", "forward_fp32"):
+        gate.grad = up.grad = gate_cpu.grad = up_cpu.grad = None
+        out = getattr(npu_op, method)(gate, up)
+        ref = getattr(NativeSwiGLUOp(), method)(gate_cpu, up_cpu)
+        assert out.device == gate.device and out.shape == gate.shape
+        assert out.dtype == ref.dtype
+        out.backward(grad_cpu.to(device="npu", dtype=out.dtype))
+        ref.backward(grad_cpu.to(ref.dtype))
+        rtol, atol = _ascend_dtype_tolerance(out.dtype)
+        torch.testing.assert_close(out.cpu(), ref, rtol=rtol, atol=atol)
+        rtol, atol = _ascend_dtype_tolerance(dtype)
+        torch.testing.assert_close(gate.grad.cpu(), gate_cpu.grad, rtol=rtol, atol=atol)
+        torch.testing.assert_close(up.grad.cpu(), up_cpu.grad, rtol=rtol, atol=atol)
+    torch.testing.assert_close(gate.detach().cpu(), gate_cpu.detach(), rtol=0, atol=0)
+    torch.testing.assert_close(up.detach().cpu(), up_cpu.detach(), rtol=0, atol=0)
+
+
+@requires_npu
+@pytest.mark.parametrize("dtype", _ASCEND_DTYPES)
+def test_npu_strided_inputs_and_upstream_gradient(npu_op, dtype):
+    # Chunked gate/up projections and a transposed upstream gradient.
+    packed = torch.randn(5, 66, dtype=dtype, device="npu", requires_grad=True)
+    gate, up = packed.chunk(2, dim=-1)
+    assert not gate.is_contiguous() and not up.is_contiguous()
+    dy = torch.randn(33, 5, dtype=dtype, device="npu").t()
+    result = npu_op(gate, up)
+    result.backward(dy)
+    ref_packed = packed.detach().cpu().requires_grad_()
+    ref = NativeSwiGLUOp()(*ref_packed.chunk(2, dim=-1))
+    ref.backward(dy.cpu())
+    rtol, atol = _ascend_dtype_tolerance(dtype)
+    torch.testing.assert_close(result.cpu(), ref, rtol=rtol, atol=atol)
+    torch.testing.assert_close(packed.grad.cpu(), ref_packed.grad, rtol=rtol, atol=atol)
+
+
+@requires_npu
+@pytest.mark.parametrize("dtype", _ASCEND_DTYPES)
+def test_npu_batch_position_and_repeat_invariance(npu_op, dtype):
+    gate = torch.randn(33, dtype=dtype, device="npu")
+    up = torch.randn_like(gate)
+    dy = torch.randn_like(gate)
+
+    def evaluate(g, u, grad):
+        g = g.detach().requires_grad_()
+        u = u.detach().requires_grad_()
+        out = npu_op(g, u)
+        return (out.detach(), *torch.autograd.grad(out, (g, u), grad))
+
+    expected = evaluate(gate, up, dy)
+    for rows, position in ((1, 0), (7, 3), (65, 64), (65, 64)):
+        g = torch.randn(rows, 33, dtype=dtype, device="npu")
+        u, grad = torch.randn_like(g), torch.randn_like(g)
+        g[position], u[position], grad[position] = gate, up, dy
+        actual = evaluate(g, u, grad)
+        for a, e in zip(actual, expected):
+            assert torch.equal(a[position], e)
+
+
+@requires_npu
+def test_npu_input_validation_and_native_boundary(npu_op):
+    x = torch.ones(7, device="npu")
+    with pytest.raises(ValueError, match="share shape"):
+        npu_op(x, x[:3])
+    with pytest.raises(TypeError, match="share dtype"):
+        npu_op(x, x.half())
+    with pytest.raises(TypeError, match="fp16, bf16, or fp32"):
+        npu_op(x.int(), x.int())
+    with pytest.raises(RuntimeError, match="contiguous"):
+        ascend._C_npu.swiglu_forward(x[::2], x[::2])
+    with pytest.raises(RuntimeError, match="share shape"):
+        ascend._C_npu.swiglu_backward(x[:3], x, x)
+    with pytest.raises(RuntimeError, match="share dtype"):
+        ascend._C_npu.swiglu_backward(x.half(), x, x)
+
+
+@requires_npu
+def test_npu_current_stream_ordering(npu_op):
+    stream = torch.npu.Stream()
+    with torch.npu.stream(stream):
+        gate = torch.randn(4099, device="npu").mul_(2).requires_grad_()
+        up = torch.randn_like(gate).requires_grad_()
+        dy = torch.randn_like(gate)
+        actual = npu_op(gate, up)
+        grads = torch.autograd.grad(actual, (gate, up), dy)
+        expected = NativeSwiGLUOp()(gate, up)
+        ref_grads = torch.autograd.grad(expected, (gate, up), dy)
+    stream.synchronize()
+    for actual_tensor, expected_tensor in zip((actual, *grads), (expected, *ref_grads)):
+        torch.testing.assert_close(actual_tensor, expected_tensor, rtol=1e-5, atol=1e-5)
+
+
+@requires_npu
+def test_npu_device_guard_and_cross_device_rejection(npu_op):
+    if torch.npu.device_count() < 2:
+        pytest.skip("Two NPUs required")
+    with torch.npu.device(0):
+        gate = torch.randn(33, device="npu:1", requires_grad=True)
+        up = torch.randn_like(gate, requires_grad=True)
+        out = npu_op(gate, up)
+        out.sum().backward()
+        assert torch.npu.current_device() == 0
+        assert out.device == gate.device == gate.grad.device == up.grad.device
+        torch.testing.assert_close(out, NativeSwiGLUOp()(gate, up), rtol=1e-5, atol=1e-5)
+        with pytest.raises(RuntimeError, match="same NPU device"):
+            npu_op(gate, up.to("npu:0"))
+        with pytest.raises(RuntimeError, match="same NPU device"):
+            ascend._C_npu.swiglu_forward(gate, up.to("npu:0"))


### PR DESCRIPTION
## Summary
- Add fused SwiGLU (`gate * sigmoid(gate) * up`) forward and backward kernels written in Ascend C (`csrc/ascend/activation.asc`), computing in FP32 and returning the input dtype (fp16 / bf16 / fp32)
- Register the kernels on the NPU extension via a new `csrc/ascend/bindings.asc` module initializer (`swiglu_forward` / `swiglu_backward`) with `.pyi` stubs
- Add `SwiGLUAscendOp` Python wrapper with autograd support (`once_differentiable`), input validation, arbitrary shapes / empty tensors / strided-view handling, and an FP32-output variant
- Wire `ASCEND_SWIGLU` into `KernelRegistry` NPU dispatch priority (ascend -> pytorch fallback) and update gtest operator specs
- Extend `tests/test_swiglu.py` (precision vs reference, dtype/shape/strided/empty coverage, autograd checks) and update `docs/operators/activation.md`

