### PR TITLE
[CI] Fix black formatting on main and pin line-length in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,13 @@ dev = ["pytest", "black", "isort", "ruff", "mypy", "pre-commit"]
 where = ["."]
 include = ["rl_engine*"]
 
+[tool.black]
+line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100
+
 [tool.ruff]
 line-length = 100
 

--- a/rl_engine/integrations/vllm_runtime.py
+++ b/rl_engine/integrations/vllm_runtime.py
@@ -475,11 +475,7 @@ def _patch_qwen3_strict_model(
                 )[instance.tp_rank].contiguous()
 
             assert instance.quant_method is not None
-            bias_ = (
-                None
-                if (instance.tp_rank > 0 or instance.skip_bias_add)
-                else instance.bias
-            )
+            bias_ = None if (instance.tp_rank > 0 or instance.skip_bias_add) else instance.bias
             output_parallel = instance.quant_method.apply(instance, input_parallel, bias_)
 
             if instance.reduce_results and instance.tp_size > 1:

--- a/rl_engine/kernels/ops/cuda/attention/flash_attn.py
+++ b/rl_engine/kernels/ops/cuda/attention/flash_attn.py
@@ -130,9 +130,7 @@ class StrictFlashAttention4Core:
         tensors, RNG state, or distributed collectives.
         """
         if torch.version.hip is not None:
-            raise StrictFlashAttentionUnavailable(
-                "FA4 CUDA precompile is unavailable on ROCm"
-            )
+            raise StrictFlashAttentionUnavailable("FA4 CUDA precompile is unavailable on ROCm")
         if not torch.cuda.is_available():
             raise StrictFlashAttentionUnavailable(
                 "FA4 CUDA precompile requires an available CUDA device"
@@ -144,11 +142,7 @@ class StrictFlashAttention4Core:
         if head_dim <= 0 or sequence_length <= 0:
             raise ValueError("head_dim and sequence_length must be positive")
 
-        target = (
-            torch.device("cuda", torch.cuda.current_device())
-            if device is None
-            else device
-        )
+        target = torch.device("cuda", torch.cuda.current_device()) if device is None else device
         if target.type != "cuda":
             raise ValueError("strict FA4 training precompile requires a CUDA device")
 


### PR DESCRIPTION
Closes #382

## Summary

`pre-commit run --all-files` fails on `main` because two files were committed with black's default 88-column wrapping instead of the repo's 100. Every PR rebased onto `main` inherits the red `linting` check.

## Changes

- Reformat `rl_engine/integrations/vllm_runtime.py` and `rl_engine/kernels/ops/cuda/attention/flash_attn.py`. Pure formatting, no logic change.
- Add `[tool.black]` and `[tool.isort]` with line-length 100 to `pyproject.toml`, mirroring the existing pre-commit args, so editor plugins and direct CLI runs use the same width. No change to CI behavior.

## Verification

`pre-commit run --all-files` on this branch:

```text
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check for added large files..............................................Passed
black....................................................................Passed
isort....................................................................Passed
flake8...................................................................Passed
```

black and isort invoked directly with the pinned versions and no pre-commit args, confirming the new `pyproject.toml` sections are picked up:

```text
$ black --check .       # black 24.4.2
320 files would be left unchanged.

$ isort --check-only .  # isort 5.13.2
(no output, exit 0)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project packaging and configuration, including runtime and optional development dependencies.
  * Added support for configurable CUDA, ROCm, vLLM, viewer, and development environments.
  * Added standardized project tooling and test configuration.

* **Style**
  * Improved code formatting without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->