### PR TITLE
[P5-2] Add deterministic clamp_swiglu_weighted CUDA kernel

### DIFF
--- a/csrc/cuda/activation.cu
+++ b/csrc/cuda/activation.cu
@@ -93,6 +93,164 @@ __global__ void swiglu_backward_kernel(
   d_gate[idx] = static_cast<scalar_t>(dyv * uv * silu_grad_f32(gv));
 }
 
+__device__ __forceinline__ float sigmoid_f32_strict(float x) { // new
+  const float denominator = __fadd_rn(1.0f, expf(-x));
+  return 1.0f / denominator;
+}
+
+__global__ void clamp_swiglu_weighted_forward_kernel(
+    const float* __restrict__ gate,
+    const float* __restrict__ up,
+    const float* __restrict__ p_s,
+    at::BFloat16* __restrict__ h,
+    float* __restrict__ g_saved,
+    float* __restrict__ u_saved,
+    float* __restrict__ sig_saved,
+    float* __restrict__ silu_saved,
+    const int64_t n,
+    const int64_t width,
+    const bool weighted) {
+  const int64_t idx =
+      blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x;
+
+  if (idx >= n) {
+    return;
+  }
+
+  const float gate_value = gate[idx];
+  const float up_value = up[idx];
+
+  float g = gate_value;
+  float u = up_value;
+
+  if (weighted) {
+    if (g > 10.0f) {
+      g = 10.0f;
+    }
+
+    if (u < -10.0f) {
+      u = -10.0f;
+    } else if (u > 10.0f) {
+      u = 10.0f;
+    }
+  }
+
+  const float sig = sigmoid_f32_strict(g);
+  const float silu = __fmul_rn(g, sig);
+  const float product = __fmul_rn(silu, u);
+
+  const float h32 =
+      weighted
+          ? __fmul_rn(product, p_s[idx / width])
+          : product;
+
+  h[idx] = static_cast<at::BFloat16>(h32);
+
+  g_saved[idx] = g;
+  u_saved[idx] = u;
+  sig_saved[idx] = sig;
+  silu_saved[idx] = silu;
+}
+
+template <typename scalar_t>
+__global__ void clamp_swiglu_weighted_backward_kernel(
+    const scalar_t* __restrict__ dh,
+    const float* __restrict__ gate,
+    const float* __restrict__ up,
+    const float* __restrict__ g,
+    const float* __restrict__ u,
+    const float* __restrict__ sig,
+    const float* __restrict__ silu,
+    const float* __restrict__ p_s,
+    float* __restrict__ d_gate,
+    float* __restrict__ d_up,
+    const int64_t n,
+    const int64_t width,
+    const bool weighted) {
+  const int64_t idx =
+      blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x;
+
+  if (idx >= n) {
+    return;
+  }
+
+  const float dh32 = static_cast<float>(dh[idx]);
+
+  const float weighted_dh =
+      weighted
+          ? __fmul_rn(dh32, p_s[idx / width])
+          : dh32;
+
+  const float one_minus_sig =
+      __fadd_rn(1.0f, -sig[idx]);
+
+  const float derivative_inner =
+      __fadd_rn(
+          1.0f,
+          __fmul_rn(g[idx], one_minus_sig));
+
+  const float d_silu =
+      __fmul_rn(sig[idx], derivative_inner);
+
+  const float gate_mask =
+      (!weighted || gate[idx] < 10.0f)
+          ? 1.0f
+          : 0.0f;
+
+  const float up_mask =
+      (!weighted ||
+       (up[idx] > -10.0f && up[idx] < 10.0f))
+          ? 1.0f
+          : 0.0f;
+
+  d_gate[idx] =
+      __fmul_rn(
+          __fmul_rn(
+              __fmul_rn(weighted_dh, u[idx]),
+              d_silu),
+          gate_mask);
+
+  d_up[idx] =
+      __fmul_rn(
+          __fmul_rn(weighted_dh, silu[idx]),
+          up_mask);
+}
+
+template <typename scalar_t>
+__global__ void clamp_swiglu_weighted_dp_s_kernel(
+    const scalar_t* __restrict__ dh,
+    const float* __restrict__ silu,
+    const float* __restrict__ u,
+    float* __restrict__ dp_s,
+    const int64_t rows,
+    const int64_t width) {
+  const int64_t row =
+      blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x;
+
+  if (row >= rows) {
+    return;
+  }
+
+  float acc = 0.0f;
+  const int64_t row_offset = row * width;
+
+#pragma unroll 1
+  for (int64_t column = 0; column < width; ++column) {
+    const int64_t idx = row_offset + column;
+
+    const float term =
+        __fmul_rn(
+            __fmul_rn(
+                static_cast<float>(dh[idx]),
+                silu[idx]),
+            u[idx]);
+
+    acc = __fadd_rn(acc, term);
+  }
+
+  dp_s[row] = acc;
+}
+
 template <typename scalar_t>
 __global__ void swiglu_packed_forward_kernel(
     const scalar_t* __restrict__ gate_up,
@@ -168,6 +326,67 @@ static void check_same_device(
       lhs.device(),
       " and ",
       rhs.device());
+}
+
+static void check_cuda_contig_fp32( // new
+    const torch::Tensor& t,
+    const char* name) {
+  TORCH_CHECK(
+      t.is_cuda(),
+      name,
+      " must be a CUDA tensor");
+
+  TORCH_CHECK(
+      t.is_contiguous(),
+      name,
+      " must be contiguous");
+
+  TORCH_CHECK(
+      t.scalar_type() == at::kFloat,
+      name,
+      " must be float32");
+}
+
+static void check_same_shape_2d(
+    const torch::Tensor& lhs,
+    const torch::Tensor& rhs,
+    const char* lhs_name,
+    const char* rhs_name) {
+  TORCH_CHECK(
+      lhs.dim() == 2,
+      lhs_name,
+      " must be 2D [rows, width]");
+
+  TORCH_CHECK(
+      rhs.dim() == 2,
+      rhs_name,
+      " must be 2D [rows, width]");
+
+  TORCH_CHECK(
+      lhs.sizes() == rhs.sizes(),
+      lhs_name,
+      " and ",
+      rhs_name,
+      " must share shape");
+}
+
+static void check_route_weights(
+    const torch::optional<torch::Tensor>& p_s,
+    const torch::Tensor& reference) {
+  if (!p_s.has_value()) {
+    return;
+  }
+
+  check_cuda_contig_fp32(*p_s, "p_s");
+  check_same_device(*p_s, reference, "p_s", "gate");
+
+  TORCH_CHECK(
+      p_s->dim() == 1,
+      "p_s must be 1D [rows]");
+
+  TORCH_CHECK(
+      p_s->size(0) == reference.size(0),
+      "p_s must have shape [rows]");
 }
 
 }  // namespace
@@ -363,4 +582,169 @@ std::vector<torch::Tensor> swiglu_packed_backward_cuda(
       });
   C10_CUDA_KERNEL_LAUNCH_CHECK();
   return {d_gate, d_up};
+}
+
+std::vector<torch::Tensor> clamp_swiglu_weighted_forward_cuda( // new
+    torch::Tensor gate,
+    torch::Tensor up,
+    torch::optional<torch::Tensor> p_s) {
+  check_cuda_contig_fp32(gate, "gate");
+  check_cuda_contig_fp32(up, "up");
+  check_same_device(gate, up, "gate", "up");
+  check_same_shape_2d(gate, up, "gate", "up");
+  check_route_weights(p_s, gate);
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(gate));
+
+  auto h =
+      torch::empty(
+          gate.sizes(),
+          gate.options().dtype(torch::kBFloat16));
+
+  auto g = torch::empty_like(gate);
+  auto u = torch::empty_like(up);
+  auto sig = torch::empty_like(gate);
+  auto silu = torch::empty_like(gate);
+
+  const int64_t n = gate.numel();
+
+  if (n == 0) {
+    return {h, g, u, sig, silu};
+  }
+
+  int threads = 0;
+  int64_t blocks = 0;
+
+  launch_1d(n, threads, blocks);
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  clamp_swiglu_weighted_forward_kernel
+      <<<blocks, threads, 0, stream>>>(
+          gate.data_ptr<float>(),
+          up.data_ptr<float>(),
+          p_s.has_value()
+              ? p_s->data_ptr<float>()
+              : nullptr,
+          h.data_ptr<at::BFloat16>(),
+          g.data_ptr<float>(),
+          u.data_ptr<float>(),
+          sig.data_ptr<float>(),
+          silu.data_ptr<float>(),
+          n,
+          gate.size(1),
+          p_s.has_value());
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return {h, g, u, sig, silu};
+}
+
+std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
+    torch::Tensor dh,
+    torch::Tensor gate,
+    torch::Tensor up,
+    torch::Tensor g,
+    torch::Tensor u,
+    torch::Tensor sig,
+    torch::Tensor silu,
+    torch::optional<torch::Tensor> p_s) {
+  check_cuda_contig(dh, "dh");
+  check_cuda_contig_fp32(gate, "gate");
+  check_cuda_contig_fp32(up, "up");
+  check_cuda_contig_fp32(g, "g");
+  check_cuda_contig_fp32(u, "u");
+  check_cuda_contig_fp32(sig, "sig");
+  check_cuda_contig_fp32(silu, "silu");
+
+  check_same_device(dh, gate, "dh", "gate");
+  check_same_device(gate, up, "gate", "up");
+  check_same_device(gate, g, "gate", "g");
+  check_same_device(gate, u, "gate", "u");
+  check_same_device(gate, sig, "gate", "sig");
+  check_same_device(gate, silu, "gate", "silu");
+
+  check_same_shape_2d(gate, up, "gate", "up");
+  check_same_shape_2d(gate, dh, "gate", "dh");
+  check_same_shape_2d(gate, g, "gate", "g");
+  check_same_shape_2d(gate, u, "gate", "u");
+  check_same_shape_2d(gate, sig, "gate", "sig");
+  check_same_shape_2d(gate, silu, "gate", "silu");
+
+  check_route_weights(p_s, gate);
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(gate));
+
+  auto d_gate = torch::empty_like(gate);
+  auto d_up = torch::empty_like(up);
+
+  auto dp_s =
+      p_s.has_value()
+          ? torch::zeros(
+                {gate.size(0)},
+                gate.options())
+          : torch::empty(
+                {0},
+                gate.options());
+
+  const int64_t n = gate.numel();
+
+  if (n == 0) {
+    return {d_gate, d_up, dp_s};
+  }
+
+  int threads = 0;
+  int64_t blocks = 0;
+
+  launch_1d(n, threads, blocks);
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      dh.scalar_type(),
+      "clamp_swiglu_weighted_backward_cuda",
+      [&] {
+        clamp_swiglu_weighted_backward_kernel<scalar_t>
+            <<<blocks, threads, 0, stream>>>(
+                dh.data_ptr<scalar_t>(),
+                gate.data_ptr<float>(),
+                up.data_ptr<float>(),
+                g.data_ptr<float>(),
+                u.data_ptr<float>(),
+                sig.data_ptr<float>(),
+                silu.data_ptr<float>(),
+                p_s.has_value()
+                    ? p_s->data_ptr<float>()
+                    : nullptr,
+                d_gate.data_ptr<float>(),
+                d_up.data_ptr<float>(),
+                n,
+                gate.size(1),
+                p_s.has_value());
+
+        if (p_s.has_value()) {
+          int dp_threads = 0;
+          int64_t dp_blocks = 0;
+
+          launch_1d(
+              gate.size(0),
+              dp_threads,
+              dp_blocks);
+
+          clamp_swiglu_weighted_dp_s_kernel<scalar_t>
+              <<<dp_blocks, dp_threads, 0, stream>>>(
+                  dh.data_ptr<scalar_t>(),
+                  silu.data_ptr<float>(),
+                  u.data_ptr<float>(),
+                  dp_s.data_ptr<float>(),
+                  gate.size(0),
+                  gate.size(1));
+        }
+      });
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return {d_gate, d_up, dp_s};
 }

--- a/csrc/cuda/activation.cu
+++ b/csrc/cuda/activation.cu
@@ -93,7 +93,7 @@ __global__ void swiglu_backward_kernel(
   d_gate[idx] = static_cast<scalar_t>(dyv * uv * silu_grad_f32(gv));
 }
 
-__device__ __forceinline__ float sigmoid_f32_strict(float x) { // new
+__device__ __forceinline__ float sigmoid_f32_strict(float x) {
   const float denominator = __fadd_rn(1.0f, expf(-x));
   return 1.0f / denominator;
 }
@@ -103,10 +103,6 @@ __global__ void clamp_swiglu_weighted_forward_kernel(
     const float* __restrict__ up,
     const float* __restrict__ p_s,
     at::BFloat16* __restrict__ h,
-    float* __restrict__ g_saved,
-    float* __restrict__ u_saved,
-    float* __restrict__ sig_saved,
-    float* __restrict__ silu_saved,
     const int64_t n,
     const int64_t width,
     const bool weighted) {
@@ -145,11 +141,6 @@ __global__ void clamp_swiglu_weighted_forward_kernel(
           : product;
 
   h[idx] = static_cast<at::BFloat16>(h32);
-
-  g_saved[idx] = g;
-  u_saved[idx] = u;
-  sig_saved[idx] = sig;
-  silu_saved[idx] = silu;
 }
 
 template <typename scalar_t>
@@ -157,10 +148,6 @@ __global__ void clamp_swiglu_weighted_backward_kernel(
     const scalar_t* __restrict__ dh,
     const float* __restrict__ gate,
     const float* __restrict__ up,
-    const float* __restrict__ g,
-    const float* __restrict__ u,
-    const float* __restrict__ sig,
-    const float* __restrict__ silu,
     const float* __restrict__ p_s,
     float* __restrict__ d_gate,
     float* __restrict__ d_up,
@@ -174,6 +161,27 @@ __global__ void clamp_swiglu_weighted_backward_kernel(
     return;
   }
 
+  const float gate_value = gate[idx];
+  const float up_value = up[idx];
+
+  float g = gate_value;
+  float u = up_value;
+
+  if (weighted) {
+    if (g > 10.0f) {
+      g = 10.0f;
+    }
+
+    if (u < -10.0f) {
+      u = -10.0f;
+    } else if (u > 10.0f) {
+      u = 10.0f;
+    }
+  }
+
+  const float sig = sigmoid_f32_strict(g);
+  const float silu = __fmul_rn(g, sig);
+
   const float dh32 = static_cast<float>(dh[idx]);
 
   const float weighted_dh =
@@ -182,45 +190,45 @@ __global__ void clamp_swiglu_weighted_backward_kernel(
           : dh32;
 
   const float one_minus_sig =
-      __fadd_rn(1.0f, -sig[idx]);
+      __fadd_rn(1.0f, -sig);
 
   const float derivative_inner =
       __fadd_rn(
           1.0f,
-          __fmul_rn(g[idx], one_minus_sig));
+          __fmul_rn(g, one_minus_sig));
 
   const float d_silu =
-      __fmul_rn(sig[idx], derivative_inner);
+      __fmul_rn(sig, derivative_inner);
 
   const float gate_mask =
-      (!weighted || gate[idx] < 10.0f)
+      (!weighted || gate_value < 10.0f)
           ? 1.0f
           : 0.0f;
 
   const float up_mask =
       (!weighted ||
-       (up[idx] > -10.0f && up[idx] < 10.0f))
+       (up_value > -10.0f && up_value < 10.0f))
           ? 1.0f
           : 0.0f;
 
   d_gate[idx] =
       __fmul_rn(
           __fmul_rn(
-              __fmul_rn(weighted_dh, u[idx]),
+              __fmul_rn(weighted_dh, u),
               d_silu),
           gate_mask);
 
   d_up[idx] =
       __fmul_rn(
-          __fmul_rn(weighted_dh, silu[idx]),
+          __fmul_rn(weighted_dh, silu),
           up_mask);
 }
 
 template <typename scalar_t>
 __global__ void clamp_swiglu_weighted_dp_s_kernel(
     const scalar_t* __restrict__ dh,
-    const float* __restrict__ silu,
-    const float* __restrict__ u,
+    const float* __restrict__ gate,
+    const float* __restrict__ up,
     float* __restrict__ dp_s,
     const int64_t rows,
     const int64_t width) {
@@ -238,12 +246,28 @@ __global__ void clamp_swiglu_weighted_dp_s_kernel(
   for (int64_t column = 0; column < width; ++column) {
     const int64_t idx = row_offset + column;
 
+    float g = gate[idx];
+    float u = up[idx];
+
+    if (g > 10.0f) {
+      g = 10.0f;
+    }
+
+    if (u < -10.0f) {
+      u = -10.0f;
+    } else if (u > 10.0f) {
+      u = 10.0f;
+    }
+
+    const float sig = sigmoid_f32_strict(g);
+    const float silu = __fmul_rn(g, sig);
+
     const float term =
         __fmul_rn(
             __fmul_rn(
                 static_cast<float>(dh[idx]),
-                silu[idx]),
-            u[idx]);
+                silu),
+            u);
 
     acc = __fadd_rn(acc, term);
   }
@@ -328,7 +352,7 @@ static void check_same_device(
       rhs.device());
 }
 
-static void check_cuda_contig_fp32( // new
+static void check_cuda_contig_fp32(
     const torch::Tensor& t,
     const char* name) {
   TORCH_CHECK(
@@ -584,7 +608,7 @@ std::vector<torch::Tensor> swiglu_packed_backward_cuda(
   return {d_gate, d_up};
 }
 
-std::vector<torch::Tensor> clamp_swiglu_weighted_forward_cuda( // new
+std::vector<torch::Tensor> clamp_swiglu_weighted_forward_cuda(
     torch::Tensor gate,
     torch::Tensor up,
     torch::optional<torch::Tensor> p_s) {
@@ -601,15 +625,10 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_forward_cuda( // new
           gate.sizes(),
           gate.options().dtype(torch::kBFloat16));
 
-  auto g = torch::empty_like(gate);
-  auto u = torch::empty_like(up);
-  auto sig = torch::empty_like(gate);
-  auto silu = torch::empty_like(gate);
-
   const int64_t n = gate.numel();
 
   if (n == 0) {
-    return {h, g, u, sig, silu};
+    return {h};
   }
 
   int threads = 0;
@@ -627,49 +646,29 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_forward_cuda( // new
               ? p_s->data_ptr<float>()
               : nullptr,
           h.data_ptr<at::BFloat16>(),
-          g.data_ptr<float>(),
-          u.data_ptr<float>(),
-          sig.data_ptr<float>(),
-          silu.data_ptr<float>(),
           n,
           gate.size(1),
           p_s.has_value());
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
 
-  return {h, g, u, sig, silu};
+  return {h};
 }
 
 std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
     torch::Tensor dh,
     torch::Tensor gate,
     torch::Tensor up,
-    torch::Tensor g,
-    torch::Tensor u,
-    torch::Tensor sig,
-    torch::Tensor silu,
     torch::optional<torch::Tensor> p_s) {
   check_cuda_contig(dh, "dh");
   check_cuda_contig_fp32(gate, "gate");
   check_cuda_contig_fp32(up, "up");
-  check_cuda_contig_fp32(g, "g");
-  check_cuda_contig_fp32(u, "u");
-  check_cuda_contig_fp32(sig, "sig");
-  check_cuda_contig_fp32(silu, "silu");
 
   check_same_device(dh, gate, "dh", "gate");
   check_same_device(gate, up, "gate", "up");
-  check_same_device(gate, g, "gate", "g");
-  check_same_device(gate, u, "gate", "u");
-  check_same_device(gate, sig, "gate", "sig");
-  check_same_device(gate, silu, "gate", "silu");
 
   check_same_shape_2d(gate, up, "gate", "up");
   check_same_shape_2d(gate, dh, "gate", "dh");
-  check_same_shape_2d(gate, g, "gate", "g");
-  check_same_shape_2d(gate, u, "gate", "u");
-  check_same_shape_2d(gate, sig, "gate", "sig");
-  check_same_shape_2d(gate, silu, "gate", "silu");
 
   check_route_weights(p_s, gate);
 
@@ -711,10 +710,6 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
                 dh.data_ptr<scalar_t>(),
                 gate.data_ptr<float>(),
                 up.data_ptr<float>(),
-                g.data_ptr<float>(),
-                u.data_ptr<float>(),
-                sig.data_ptr<float>(),
-                silu.data_ptr<float>(),
                 p_s.has_value()
                     ? p_s->data_ptr<float>()
                     : nullptr,
@@ -736,8 +731,8 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
           clamp_swiglu_weighted_dp_s_kernel<scalar_t>
               <<<dp_blocks, dp_threads, 0, stream>>>(
                   dh.data_ptr<scalar_t>(),
-                  silu.data_ptr<float>(),
-                  u.data_ptr<float>(),
+                  gate.data_ptr<float>(),
+                  up.data_ptr<float>(),
                   dp_s.data_ptr<float>(),
                   gate.size(0),
                   gate.size(1));

--- a/csrc/cuda/activation.cu
+++ b/csrc/cuda/activation.cu
@@ -93,6 +93,10 @@ __global__ void swiglu_backward_kernel(
   d_gate[idx] = static_cast<scalar_t>(dyv * uv * silu_grad_f32(gv));
 }
 
+#if defined(__USE_FAST_MATH__)
+#error "P5 clamp_swiglu_weighted requires precise FP32 math; disable --use_fast_math"
+#endif
+
 __device__ __forceinline__ float sigmoid_f32_strict(float x) {
   const float denominator = __fadd_rn(1.0f, expf(-x));
   return 1.0f / denominator;
@@ -105,6 +109,7 @@ __global__ void clamp_swiglu_weighted_forward_kernel(
     at::BFloat16* __restrict__ h,
     const int64_t n,
     const int64_t width,
+    const int64_t input_stride,
     const bool weighted) {
   const int64_t idx =
       blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x;
@@ -113,8 +118,12 @@ __global__ void clamp_swiglu_weighted_forward_kernel(
     return;
   }
 
-  const float gate_value = gate[idx];
-  const float up_value = up[idx];
+      const int64_t row = idx / width;
+      const int64_t column = idx - row * width;
+      const int64_t input_offset = row * input_stride + column;
+
+      const float gate_value = gate[input_offset];
+      const float up_value = up[input_offset];
 
   float g = gate_value;
   float u = up_value;
@@ -137,7 +146,7 @@ __global__ void clamp_swiglu_weighted_forward_kernel(
 
   const float h32 =
       weighted
-          ? __fmul_rn(product, p_s[idx / width])
+          ? __fmul_rn(product, p_s[row])
           : product;
 
   h[idx] = static_cast<at::BFloat16>(h32);
@@ -153,6 +162,7 @@ __global__ void clamp_swiglu_weighted_backward_kernel(
     float* __restrict__ d_up,
     const int64_t n,
     const int64_t width,
+    const int64_t input_stride,
     const bool weighted) {
   const int64_t idx =
       blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x;
@@ -161,8 +171,12 @@ __global__ void clamp_swiglu_weighted_backward_kernel(
     return;
   }
 
-  const float gate_value = gate[idx];
-  const float up_value = up[idx];
+    const int64_t row = idx / width;
+    const int64_t column = idx - row * width;
+    const int64_t input_offset = row * input_stride + column;
+
+    const float gate_value = gate[input_offset];
+    const float up_value = up[input_offset];
 
   float g = gate_value;
   float u = up_value;
@@ -186,7 +200,7 @@ __global__ void clamp_swiglu_weighted_backward_kernel(
 
   const float weighted_dh =
       weighted
-          ? __fmul_rn(dh32, p_s[idx / width])
+          ? __fmul_rn(dh32, p_s[row])
           : dh32;
 
   const float one_minus_sig =
@@ -231,7 +245,8 @@ __global__ void clamp_swiglu_weighted_dp_s_kernel(
     const float* __restrict__ up,
     float* __restrict__ dp_s,
     const int64_t rows,
-    const int64_t width) {
+    const int64_t width,
+    const int64_t input_stride) {
   const int64_t row =
       blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x;
 
@@ -240,14 +255,17 @@ __global__ void clamp_swiglu_weighted_dp_s_kernel(
   }
 
   float acc = 0.0f;
-  const int64_t row_offset = row * width;
+
+  const int64_t input_row_offset = row * input_stride;
+  const int64_t output_row_offset = row * width;
 
 #pragma unroll 1
   for (int64_t column = 0; column < width; ++column) {
-    const int64_t idx = row_offset + column;
+    const int64_t input_idx = input_row_offset + column;
+    const int64_t output_idx = output_row_offset + column;
 
-    float g = gate[idx];
-    float u = up[idx];
+    float g = gate[input_idx];
+    float u = up[input_idx];
 
     if (g > 10.0f) {
       g = 10.0f;
@@ -265,7 +283,7 @@ __global__ void clamp_swiglu_weighted_dp_s_kernel(
     const float term =
         __fmul_rn(
             __fmul_rn(
-                static_cast<float>(dh[idx]),
+                static_cast<float>(dh[output_idx]),
                 silu),
             u);
 
@@ -648,6 +666,7 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_forward_cuda(
           h.data_ptr<at::BFloat16>(),
           n,
           gate.size(1),
+          gate.size(1),
           p_s.has_value());
 
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -717,6 +736,7 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
                 d_up.data_ptr<float>(),
                 n,
                 gate.size(1),
+                gate.size(1),
                 p_s.has_value());
 
         if (p_s.has_value()) {
@@ -735,7 +755,165 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
                   up.data_ptr<float>(),
                   dp_s.data_ptr<float>(),
                   gate.size(0),
+                  gate.size(1),
                   gate.size(1));
+        }
+      });
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return {d_gate, d_up, dp_s};
+}
+
+std::vector<torch::Tensor> clamp_swiglu_weighted_packed_forward_cuda(
+    torch::Tensor gate_up,
+    torch::optional<torch::Tensor> p_s) {
+  check_cuda_contig_fp32(gate_up, "gate_up");
+
+  TORCH_CHECK(
+      gate_up.dim() == 2,
+      "gate_up must be 2D [rows, 2 * width]");
+
+  TORCH_CHECK(
+      gate_up.size(1) % 2 == 0,
+      "gate_up width must be even");
+
+  check_route_weights(p_s, gate_up);
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(gate_up));
+
+  const int64_t rows = gate_up.size(0);
+  const int64_t width = gate_up.size(1) / 2;
+
+  auto h = torch::empty(
+      {rows, width},
+      gate_up.options().dtype(torch::kBFloat16));
+
+  const int64_t n = h.numel();
+
+  if (n == 0) {
+    return {h};
+  }
+
+  int threads = 0;
+  int64_t blocks = 0;
+  launch_1d(n, threads, blocks);
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  const float* gate_ptr = gate_up.data_ptr<float>();
+  const float* up_ptr = gate_ptr + width;
+
+  clamp_swiglu_weighted_forward_kernel
+      <<<blocks, threads, 0, stream>>>(
+          gate_ptr,
+          up_ptr,
+          p_s.has_value()
+              ? p_s->data_ptr<float>()
+              : nullptr,
+          h.data_ptr<at::BFloat16>(),
+          n,
+          width,
+          2 * width,
+          p_s.has_value());
+
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  return {h};
+}
+
+std::vector<torch::Tensor> clamp_swiglu_weighted_packed_backward_cuda(
+    torch::Tensor dh,
+    torch::Tensor gate_up,
+    torch::optional<torch::Tensor> p_s) {
+  check_cuda_contig(dh, "dh");
+  check_cuda_contig_fp32(gate_up, "gate_up");
+  check_same_device(dh, gate_up, "dh", "gate_up");
+
+  TORCH_CHECK(
+      gate_up.dim() == 2,
+      "gate_up must be 2D [rows, 2 * width]");
+
+  TORCH_CHECK(
+      gate_up.size(1) % 2 == 0,
+      "gate_up width must be even");
+
+  const int64_t rows = gate_up.size(0);
+  const int64_t width = gate_up.size(1) / 2;
+
+  TORCH_CHECK(
+      dh.dim() == 2 &&
+          dh.size(0) == rows &&
+          dh.size(1) == width,
+      "dh must have shape [rows, width]");
+
+  check_route_weights(p_s, gate_up);
+
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(gate_up));
+
+  auto d_gate = torch::empty(
+      {rows, width},
+      gate_up.options());
+
+  auto d_up = torch::empty(
+      {rows, width},
+      gate_up.options());
+
+  auto dp_s =
+      p_s.has_value()
+          ? torch::zeros({rows}, gate_up.options())
+          : torch::empty({0}, gate_up.options());
+
+  const int64_t n = dh.numel();
+
+  if (n == 0) {
+    return {d_gate, d_up, dp_s};
+  }
+
+  int threads = 0;
+  int64_t blocks = 0;
+  launch_1d(n, threads, blocks);
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+
+  const float* gate_ptr = gate_up.data_ptr<float>();
+  const float* up_ptr = gate_ptr + width;
+
+  AT_DISPATCH_FLOATING_TYPES_AND2(
+      at::ScalarType::Half,
+      at::ScalarType::BFloat16,
+      dh.scalar_type(),
+      "clamp_swiglu_weighted_packed_backward_cuda",
+      [&] {
+        clamp_swiglu_weighted_backward_kernel<scalar_t>
+            <<<blocks, threads, 0, stream>>>(
+                dh.data_ptr<scalar_t>(),
+                gate_ptr,
+                up_ptr,
+                p_s.has_value()
+                    ? p_s->data_ptr<float>()
+                    : nullptr,
+                d_gate.data_ptr<float>(),
+                d_up.data_ptr<float>(),
+                n,
+                width,
+                2 * width,
+                p_s.has_value());
+
+        if (p_s.has_value()) {
+          int dp_threads = 0;
+          int64_t dp_blocks = 0;
+          launch_1d(rows, dp_threads, dp_blocks);
+
+          clamp_swiglu_weighted_dp_s_kernel<scalar_t>
+              <<<dp_blocks, dp_threads, 0, stream>>>(
+                  dh.data_ptr<scalar_t>(),
+                  gate_ptr,
+                  up_ptr,
+                  dp_s.data_ptr<float>(),
+                  rows,
+                  width,
+                  2 * width);
         }
       });
 

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -546,9 +546,17 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("swiglu_packed_backward", &swiglu_packed_backward,
           "Batch-invariant SwiGLU backward for [rows, 2 * intermediate]");
     m.def(
-        "clamp_swiglu_weighted_forward",
-        &clamp_swiglu_weighted_forward,
-        "P5 clamp_swiglu_weighted forward CUDA");
+      "clamp_swiglu_weighted_backward",
+      &clamp_swiglu_weighted_backward,
+      py::arg("dh"),
+      py::arg("gate"),
+      py::arg("up"),
+      py::arg("g"),
+      py::arg("u"),
+      py::arg("sig"),
+      py::arg("silu"),
+      py::arg("p_s") = py::none(),
+      "P5 clamp_swiglu_weighted backward CUDA");
 
     m.def(
         "clamp_swiglu_weighted_backward",

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -141,6 +141,14 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
     torch::Tensor gate,
     torch::Tensor up,
     torch::optional<torch::Tensor> p_s);
+  std::vector<torch::Tensor> clamp_swiglu_weighted_packed_forward_cuda(
+    torch::Tensor gate_up,
+    torch::optional<torch::Tensor> p_s);
+
+std::vector<torch::Tensor> clamp_swiglu_weighted_packed_backward_cuda(
+    torch::Tensor dh,
+    torch::Tensor gate_up,
+    torch::optional<torch::Tensor> p_s);
 // RMSNorm Declarations & Wrappers
 
 void rmsnorm_forward_cuda(
@@ -322,6 +330,23 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_backward(
       dh,
       gate,
       up,
+      p_s);
+}
+std::vector<torch::Tensor> clamp_swiglu_weighted_packed_forward(
+    torch::Tensor gate_up,
+    torch::optional<torch::Tensor> p_s) {
+  return clamp_swiglu_weighted_packed_forward_cuda(
+      gate_up,
+      p_s);
+}
+
+std::vector<torch::Tensor> clamp_swiglu_weighted_packed_backward(
+    torch::Tensor dh,
+    torch::Tensor gate_up,
+    torch::optional<torch::Tensor> p_s) {
+  return clamp_swiglu_weighted_packed_backward_cuda(
+      dh,
+      gate_up,
       p_s);
 }
 // Deterministic standard-softmax attention (issue #147)
@@ -549,6 +574,20 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
       py::arg("up"),
       py::arg("p_s") = py::none(),
       "P5 clamp_swiglu_weighted backward CUDA");
+    m.def(
+        "clamp_swiglu_weighted_packed_forward",
+        &clamp_swiglu_weighted_packed_forward,
+        py::arg("gate_up"),
+        py::arg("p_s") = py::none(),
+        "P5 packed clamp_swiglu_weighted forward CUDA");
+
+    m.def(
+        "clamp_swiglu_weighted_packed_backward",
+        &clamp_swiglu_weighted_packed_backward,
+        py::arg("dh"),
+        py::arg("gate_up"),
+        py::arg("p_s") = py::none(),
+        "P5 packed clamp_swiglu_weighted backward CUDA");
     // Deterministic standard-softmax attention (issue #147)
     m.def(
         "deterministic_attention_forward",

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -140,10 +140,6 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
     torch::Tensor dh,
     torch::Tensor gate,
     torch::Tensor up,
-    torch::Tensor g,
-    torch::Tensor u,
-    torch::Tensor sig,
-    torch::Tensor silu,
     torch::optional<torch::Tensor> p_s);
 // RMSNorm Declarations & Wrappers
 
@@ -321,19 +317,11 @@ std::vector<torch::Tensor> clamp_swiglu_weighted_backward(
     torch::Tensor dh,
     torch::Tensor gate,
     torch::Tensor up,
-    torch::Tensor g,
-    torch::Tensor u,
-    torch::Tensor sig,
-    torch::Tensor silu,
     torch::optional<torch::Tensor> p_s) {
   return clamp_swiglu_weighted_backward_cuda(
       dh,
       gate,
       up,
-      g,
-      u,
-      sig,
-      silu,
       p_s);
 }
 // Deterministic standard-softmax attention (issue #147)
@@ -554,17 +542,13 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "P5 clamp_swiglu_weighted forward CUDA");
 
     m.def(
-        "clamp_swiglu_weighted_backward",
-        &clamp_swiglu_weighted_backward,
-        py::arg("dh"),
-        py::arg("gate"),
-        py::arg("up"),
-        py::arg("g"),
-        py::arg("u"),
-        py::arg("sig"),
-        py::arg("silu"),
-        py::arg("p_s") = py::none(),
-        "P5 clamp_swiglu_weighted backward CUDA");
+      "clamp_swiglu_weighted_backward",
+      &clamp_swiglu_weighted_backward,
+      py::arg("dh"),
+      py::arg("gate"),
+      py::arg("up"),
+      py::arg("p_s") = py::none(),
+      "P5 clamp_swiglu_weighted backward CUDA");
     // Deterministic standard-softmax attention (issue #147)
     m.def(
         "deterministic_attention_forward",

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -546,21 +546,24 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("swiglu_packed_backward", &swiglu_packed_backward,
           "Batch-invariant SwiGLU backward for [rows, 2 * intermediate]");
     m.def(
-      "clamp_swiglu_weighted_backward",
-      &clamp_swiglu_weighted_backward,
-      py::arg("dh"),
-      py::arg("gate"),
-      py::arg("up"),
-      py::arg("g"),
-      py::arg("u"),
-      py::arg("sig"),
-      py::arg("silu"),
-      py::arg("p_s") = py::none(),
-      "P5 clamp_swiglu_weighted backward CUDA");
+        "clamp_swiglu_weighted_forward",
+        &clamp_swiglu_weighted_forward,
+        py::arg("gate"),
+        py::arg("up"),
+        py::arg("p_s") = py::none(),
+        "P5 clamp_swiglu_weighted forward CUDA");
 
     m.def(
         "clamp_swiglu_weighted_backward",
         &clamp_swiglu_weighted_backward,
+        py::arg("dh"),
+        py::arg("gate"),
+        py::arg("up"),
+        py::arg("g"),
+        py::arg("u"),
+        py::arg("sig"),
+        py::arg("silu"),
+        py::arg("p_s") = py::none(),
         "P5 clamp_swiglu_weighted backward CUDA");
     // Deterministic standard-softmax attention (issue #147)
     m.def(

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -130,7 +130,21 @@ torch::Tensor swiglu_packed_forward_cuda(torch::Tensor gate_up);
 std::vector<torch::Tensor> swiglu_packed_backward_cuda(
     torch::Tensor dy,
     torch::Tensor gate_up);
+// P5-2 ClampSwiGLU weighted declarations
+std::vector<torch::Tensor> clamp_swiglu_weighted_forward_cuda(
+    torch::Tensor gate,
+    torch::Tensor up,
+    torch::optional<torch::Tensor> p_s);
 
+std::vector<torch::Tensor> clamp_swiglu_weighted_backward_cuda(
+    torch::Tensor dh,
+    torch::Tensor gate,
+    torch::Tensor up,
+    torch::Tensor g,
+    torch::Tensor u,
+    torch::Tensor sig,
+    torch::Tensor silu,
+    torch::optional<torch::Tensor> p_s);
 // RMSNorm Declarations & Wrappers
 
 void rmsnorm_forward_cuda(
@@ -293,6 +307,35 @@ std::vector<torch::Tensor> swiglu_packed_backward(
   return swiglu_packed_backward_cuda(dy, gate_up);
 }
 
+std::vector<torch::Tensor> clamp_swiglu_weighted_forward(
+    torch::Tensor gate,
+    torch::Tensor up,
+    torch::optional<torch::Tensor> p_s) {
+  return clamp_swiglu_weighted_forward_cuda(
+      gate,
+      up,
+      p_s);
+}
+
+std::vector<torch::Tensor> clamp_swiglu_weighted_backward(
+    torch::Tensor dh,
+    torch::Tensor gate,
+    torch::Tensor up,
+    torch::Tensor g,
+    torch::Tensor u,
+    torch::Tensor sig,
+    torch::Tensor silu,
+    torch::optional<torch::Tensor> p_s) {
+  return clamp_swiglu_weighted_backward_cuda(
+      dh,
+      gate,
+      up,
+      g,
+      u,
+      sig,
+      silu,
+      p_s);
+}
 // Deterministic standard-softmax attention (issue #147)
 std::vector<torch::Tensor> deterministic_attention_forward(
     torch::Tensor q,
@@ -502,7 +545,15 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
           "Batch-invariant SwiGLU forward for [rows, 2 * intermediate]");
     m.def("swiglu_packed_backward", &swiglu_packed_backward,
           "Batch-invariant SwiGLU backward for [rows, 2 * intermediate]");
+    m.def(
+        "clamp_swiglu_weighted_forward",
+        &clamp_swiglu_weighted_forward,
+        "P5 clamp_swiglu_weighted forward CUDA");
 
+    m.def(
+        "clamp_swiglu_weighted_backward",
+        &clamp_swiglu_weighted_backward,
+        "P5 clamp_swiglu_weighted backward CUDA");
     // Deterministic standard-softmax attention (issue #147)
     m.def(
         "deterministic_attention_forward",

--- a/rl_engine/moe/cuda_provider.py
+++ b/rl_engine/moe/cuda_provider.py
@@ -24,10 +24,6 @@ _SUPPORTED_DTYPES = (
 _SAVED_KEYS = (
     "gate32",
     "up32",
-    "g",
-    "u",
-    "sig",
-    "silu",
 )
 
 
@@ -121,7 +117,7 @@ class ClampSwiGLUWeightedCudaProvider(ReferenceProvider):
         up32 = up.float().contiguous()
         p_s32 = None if p_s is None else p_s.contiguous()
 
-        h, g, u, sig, silu = getattr(
+        (h,) = getattr(
             _C,
             _FORWARD_SYMBOL,
         )(
@@ -133,10 +129,6 @@ class ClampSwiGLUWeightedCudaProvider(ReferenceProvider):
         saved = {
             "gate32": gate32,
             "up32": up32,
-            "g": g,
-            "u": u,
-            "sig": sig,
-            "silu": silu,
         }
 
         if p_s32 is not None:
@@ -182,10 +174,6 @@ class ClampSwiGLUWeightedCudaProvider(ReferenceProvider):
             dh.contiguous(),
             gate32,
             saved["up32"],
-            saved["g"],
-            saved["u"],
-            saved["sig"],
-            saved["silu"],
             p_s,
         )
 

--- a/rl_engine/moe/cuda_provider.py
+++ b/rl_engine/moe/cuda_provider.py
@@ -14,6 +14,8 @@ from rl_engine.moe.provider import ReferenceProvider
 
 _FORWARD_SYMBOL = "clamp_swiglu_weighted_forward"
 _BACKWARD_SYMBOL = "clamp_swiglu_weighted_backward"
+_PACKED_FORWARD_SYMBOL = "clamp_swiglu_weighted_packed_forward"
+_PACKED_BACKWARD_SYMBOL = "clamp_swiglu_weighted_packed_backward"
 
 _SUPPORTED_DTYPES = (
     torch.float16,
@@ -33,7 +35,14 @@ def _require_cuda_extension() -> None:
             "ClampSwiGLUWeightedCudaProvider requires the compiled " "rl_engine._C extension."
         )
 
-    missing = [name for name in (_FORWARD_SYMBOL, _BACKWARD_SYMBOL) if not hasattr(_C, name)]
+    required_symbols = (
+        _FORWARD_SYMBOL,
+        _BACKWARD_SYMBOL,
+        _PACKED_FORWARD_SYMBOL,
+        _PACKED_BACKWARD_SYMBOL,
+    )
+
+    missing = [name for name in required_symbols if not hasattr(_C, name)]
 
     if missing:
         raise RuntimeError(
@@ -57,6 +66,20 @@ def _validate_matrix(
         raise TypeError(f"{name} must have dtype fp16, bf16, or fp32, " f"got {x.dtype}.")
 
 
+def _validate_packed_matrix(
+    gate_up: torch.Tensor,
+) -> None:
+    _validate_matrix(
+        gate_up,
+        "gate_up",
+    )
+
+    if gate_up.shape[1] % 2 != 0:
+        raise ValueError(
+            "gate_up must have shape [rows, 2 * width], " f"got shape {tuple(gate_up.shape)}."
+        )
+
+
 class ClampSwiGLUWeightedCudaProvider(ReferenceProvider):
     """P5-2 CUDA provider with deterministic FP32 computation."""
 
@@ -71,6 +94,7 @@ class ClampSwiGLUWeightedCudaProvider(ReferenceProvider):
             "backend": "cuda",
             "delivered_ops": ["clamp_swiglu_weighted"],
             "geometry": ["one-row", "packed"],
+            "layouts": ["separate", "gate-up-packed"],
             "devices": ["cuda"],
         }
 
@@ -174,6 +198,92 @@ class ClampSwiGLUWeightedCudaProvider(ReferenceProvider):
             dh.contiguous(),
             gate32,
             saved["up32"],
+            p_s,
+        )
+
+        return (
+            dgate,
+            dup,
+            dp_s if p_s is not None else None,
+        )
+
+    def clamp_swiglu_weighted_packed_fwd(
+        self,
+        gate_up: torch.Tensor,
+        p_s: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        _validate_packed_matrix(gate_up)
+
+        if p_s is not None:
+            if p_s.device != gate_up.device:
+                raise RuntimeError(
+                    "p_s and gate_up must share a CUDA device, "
+                    f"got {p_s.device} and {gate_up.device}."
+                )
+
+            if p_s.dtype != torch.float32:
+                raise TypeError(f"p_s must have dtype fp32, got {p_s.dtype}.")
+
+            if p_s.shape != (gate_up.shape[0],):
+                raise ValueError(
+                    f"p_s must have shape ({gate_up.shape[0]},), " f"got {tuple(p_s.shape)}."
+                )
+
+        gate_up32 = gate_up.float().contiguous()
+        p_s32 = None if p_s is None else p_s.contiguous()
+
+        (h,) = getattr(
+            _C,
+            _PACKED_FORWARD_SYMBOL,
+        )(
+            gate_up32,
+            p_s32,
+        )
+
+        saved = {
+            "gate_up32": gate_up32,
+        }
+
+        if p_s32 is not None:
+            saved["p_s"] = p_s32
+
+        return h, saved
+
+    def clamp_swiglu_weighted_packed_bwd(
+        self,
+        dh: torch.Tensor,
+        saved: dict[str, torch.Tensor],
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        if "gate_up32" not in saved:
+            raise KeyError("saved state is missing: gate_up32")
+
+        _validate_matrix(dh, "dh")
+
+        gate_up32 = saved["gate_up32"]
+        rows = gate_up32.shape[0]
+        width = gate_up32.shape[1] // 2
+
+        if dh.device != gate_up32.device:
+            raise RuntimeError(
+                "dh and gate_up32 must share a CUDA device, "
+                f"got {dh.device} and {gate_up32.device}."
+            )
+
+        if dh.shape != (rows, width):
+            raise ValueError(f"dh must have shape ({rows}, {width}), " f"got {tuple(dh.shape)}.")
+
+        p_s = saved.get("p_s")
+
+        dgate, dup, dp_s = getattr(
+            _C,
+            _PACKED_BACKWARD_SYMBOL,
+        )(
+            dh.contiguous(),
+            gate_up32,
             p_s,
         )
 

--- a/rl_engine/moe/cuda_provider.py
+++ b/rl_engine/moe/cuda_provider.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+"""CUDA provider for P5-2 clamp_swiglu_weighted."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
+from rl_engine.moe.contract import ORACLE_PROFILE
+from rl_engine.moe.provider import ReferenceProvider
+
+_FORWARD_SYMBOL = "clamp_swiglu_weighted_forward"
+_BACKWARD_SYMBOL = "clamp_swiglu_weighted_backward"
+
+_SUPPORTED_DTYPES = (
+    torch.float16,
+    torch.bfloat16,
+    torch.float32,
+)
+
+_SAVED_KEYS = (
+    "gate32",
+    "up32",
+    "g",
+    "u",
+    "sig",
+    "silu",
+)
+
+
+def _require_cuda_extension() -> None:
+    if not _EXT_AVAILABLE or _C is None:
+        raise RuntimeError(
+            "ClampSwiGLUWeightedCudaProvider requires the compiled " "rl_engine._C extension."
+        )
+
+    missing = [name for name in (_FORWARD_SYMBOL, _BACKWARD_SYMBOL) if not hasattr(_C, name)]
+
+    if missing:
+        raise RuntimeError(
+            "P5-2 CUDA symbols are unavailable: "
+            f"{', '.join(missing)}. "
+            "Rebuild rl_engine._C from this branch."
+        )
+
+
+def _validate_matrix(
+    x: torch.Tensor,
+    name: str,
+) -> None:
+    if x.device.type != "cuda":
+        raise RuntimeError(f"{name} must be a CUDA tensor, got {x.device}.")
+
+    if x.dim() != 2:
+        raise ValueError(f"{name} must be 2D [rows, width], " f"got shape {tuple(x.shape)}.")
+
+    if x.dtype not in _SUPPORTED_DTYPES:
+        raise TypeError(f"{name} must have dtype fp16, bf16, or fp32, " f"got {x.dtype}.")
+
+
+class ClampSwiGLUWeightedCudaProvider(ReferenceProvider):
+    """P5-2 CUDA provider with deterministic FP32 computation."""
+
+    name = "cuda-clamp-swiglu-weighted"
+    numeric_profile = ORACLE_PROFILE
+
+    def __init__(self) -> None:
+        _require_cuda_extension()
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "backend": "cuda",
+            "delivered_ops": ["clamp_swiglu_weighted"],
+            "geometry": ["one-row", "packed"],
+            "devices": ["cuda"],
+        }
+
+    def provenance(self) -> dict[str, Any]:
+        return {
+            "requested_backend": self.name,
+            "actual_backend": self.name,
+            "numeric_profile": self.numeric_profile,
+            "torch_version": torch.__version__,
+        }
+
+    def clamp_swiglu_weighted_fwd(
+        self,
+        gate: torch.Tensor,
+        up: torch.Tensor,
+        p_s: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
+        _validate_matrix(gate, "gate")
+        _validate_matrix(up, "up")
+
+        if gate.device != up.device:
+            raise RuntimeError(
+                "gate and up must share a CUDA device, " f"got {gate.device} and {up.device}."
+            )
+
+        if gate.shape != up.shape:
+            raise ValueError("gate and up must share shape, " f"got {gate.shape} and {up.shape}.")
+
+        if p_s is not None:
+            if p_s.device != gate.device:
+                raise RuntimeError(
+                    "p_s and gate must share a CUDA device, " f"got {p_s.device} and {gate.device}."
+                )
+
+            if p_s.dtype != torch.float32:
+                raise TypeError(f"p_s must have dtype fp32, got {p_s.dtype}.")
+
+            if p_s.shape != (gate.shape[0],):
+                raise ValueError(
+                    f"p_s must have shape ({gate.shape[0]},), " f"got {tuple(p_s.shape)}."
+                )
+
+        gate32 = gate.float().contiguous()
+        up32 = up.float().contiguous()
+        p_s32 = None if p_s is None else p_s.contiguous()
+
+        h, g, u, sig, silu = getattr(
+            _C,
+            _FORWARD_SYMBOL,
+        )(
+            gate32,
+            up32,
+            p_s32,
+        )
+
+        saved = {
+            "gate32": gate32,
+            "up32": up32,
+            "g": g,
+            "u": u,
+            "sig": sig,
+            "silu": silu,
+        }
+
+        if p_s32 is not None:
+            saved["p_s"] = p_s32
+
+        return h, saved
+
+    def clamp_swiglu_weighted_bwd(
+        self,
+        dh: torch.Tensor,
+        saved: dict[str, torch.Tensor],
+    ) -> tuple[
+        torch.Tensor,
+        torch.Tensor,
+        torch.Tensor | None,
+    ]:
+        missing = [key for key in _SAVED_KEYS if key not in saved]
+
+        if missing:
+            raise KeyError(f"saved state is missing: {', '.join(missing)}")
+
+        _validate_matrix(dh, "dh")
+
+        gate32 = saved["gate32"]
+
+        if dh.device != gate32.device:
+            raise RuntimeError(
+                "dh and saved tensors must share a CUDA device, "
+                f"got {dh.device} and {gate32.device}."
+            )
+
+        if dh.shape != gate32.shape:
+            raise ValueError(
+                "dh and saved tensors must share shape, " f"got {dh.shape} and {gate32.shape}."
+            )
+
+        p_s = saved.get("p_s")
+
+        dgate, dup, dp_s = getattr(
+            _C,
+            _BACKWARD_SYMBOL,
+        )(
+            dh.contiguous(),
+            gate32,
+            saved["up32"],
+            saved["g"],
+            saved["u"],
+            saved["sig"],
+            saved["silu"],
+            p_s,
+        )
+
+        return (
+            dgate,
+            dup,
+            dp_s if p_s is not None else None,
+        )

--- a/tests/test_p5_clamp_swiglu_weighted_cuda.py
+++ b/tests/test_p5_clamp_swiglu_weighted_cuda.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+"""CUDA tests for P5-2 clamp_swiglu_weighted."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
+from rl_engine.moe import fixtures, oracle
+from rl_engine.moe.cuda_provider import (
+    ClampSwiGLUWeightedCudaProvider,
+)
+
+_HAS_P5_CUDA = bool(
+    torch.cuda.is_available()
+    and _EXT_AVAILABLE
+    and _C is not None
+    and hasattr(_C, "clamp_swiglu_weighted_forward")
+    and hasattr(_C, "clamp_swiglu_weighted_backward")
+)
+
+requires_p5_cuda = pytest.mark.skipif(
+    not _HAS_P5_CUDA,
+    reason="P5-2 CUDA extension unavailable",
+)
+
+
+def _assert_exact(
+    got: torch.Tensor,
+    want: torch.Tensor,
+) -> None:
+    assert got.dtype == want.dtype
+    assert got.shape == want.shape
+    assert torch.equal(got, want)
+
+
+@requires_p5_cuda
+def test_boundary_fixture_is_byte_exact() -> None:
+    provider = ClampSwiGLUWeightedCudaProvider()
+
+    gate, up, p_s = (tensor.cuda() for tensor in fixtures.make_swiglu_boundary_inputs())
+
+    dh = fixtures.make_grad_output(
+        "swiglu_boundary",
+        tuple(gate.shape),
+    ).cuda()
+
+    h_ref, saved_ref = oracle.clamp_swiglu_weighted_fwd(
+        gate,
+        up,
+        p_s,
+    )
+
+    grads_ref = oracle.clamp_swiglu_weighted_bwd(
+        dh,
+        saved_ref,
+    )
+
+    h_got, saved_got = provider.clamp_swiglu_weighted_fwd(
+        gate,
+        up,
+        p_s,
+    )
+
+    grads_got = provider.clamp_swiglu_weighted_bwd(
+        dh,
+        saved_got,
+    )
+
+    _assert_exact(h_got, h_ref)
+
+    for key in ("g", "u", "sig", "silu"):
+        _assert_exact(
+            saved_got[key],
+            saved_ref[key],
+        )
+
+    for got, want in zip(
+        grads_got,
+        grads_ref,
+        strict=True,
+    ):
+        assert got is not None
+        assert want is not None
+        _assert_exact(got, want)
+
+
+@requires_p5_cuda
+def test_shared_variant_has_no_weight_no_clamp_and_no_dp_s() -> None:
+    provider = ClampSwiGLUWeightedCudaProvider()
+
+    gate = torch.tensor(
+        [[12.0, -12.0, 10.0, -10.0]],
+        device="cuda",
+    )
+
+    up = torch.tensor(
+        [[12.0, -12.0, 10.0, -10.0]],
+        device="cuda",
+    )
+
+    dh = torch.tensor(
+        [[1.0, -0.5, 0.25, -2.0]],
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+
+    h_ref, saved_ref = oracle.clamp_swiglu_weighted_fwd(
+        gate,
+        up,
+        None,
+    )
+
+    dgate_ref, dup_ref, dp_ref = oracle.clamp_swiglu_weighted_bwd(
+        dh,
+        saved_ref,
+    )
+
+    h_got, saved_got = provider.clamp_swiglu_weighted_fwd(
+        gate,
+        up,
+        None,
+    )
+
+    dgate_got, dup_got, dp_got = provider.clamp_swiglu_weighted_bwd(
+        dh,
+        saved_got,
+    )
+
+    _assert_exact(h_got, h_ref)
+    _assert_exact(saved_got["g"], gate)
+    _assert_exact(saved_got["u"], up)
+    _assert_exact(dgate_got, dgate_ref)
+    _assert_exact(dup_got, dup_ref)
+
+    assert dp_got is None
+    assert dp_ref is None
+
+
+@requires_p5_cuda
+def test_repeated_runs_are_byte_exact() -> None:
+    provider = ClampSwiGLUWeightedCudaProvider()
+
+    generator = torch.Generator().manual_seed(63)
+
+    gate = (
+        torch.randn(
+            7,
+            257,
+            generator=generator,
+        )
+        * 12.0
+    ).cuda()
+
+    up = (
+        torch.randn(
+            7,
+            257,
+            generator=generator,
+        )
+        * 12.0
+    ).cuda()
+
+    p_s = torch.rand(
+        7,
+        generator=generator,
+    ).cuda()
+
+    dh = (
+        torch.randn(
+            7,
+            257,
+            generator=generator,
+        )
+        .to(torch.bfloat16)
+        .cuda()
+    )
+
+    h_first, saved_first = provider.clamp_swiglu_weighted_fwd(
+        gate,
+        up,
+        p_s,
+    )
+
+    grads_first = provider.clamp_swiglu_weighted_bwd(
+        dh,
+        saved_first,
+    )
+
+    for _ in range(4):
+        h_repeat, saved_repeat = provider.clamp_swiglu_weighted_fwd(
+            gate,
+            up,
+            p_s,
+        )
+
+        grads_repeat = provider.clamp_swiglu_weighted_bwd(
+            dh,
+            saved_repeat,
+        )
+
+        _assert_exact(h_repeat, h_first)
+
+        for got, want in zip(
+            grads_repeat,
+            grads_first,
+            strict=True,
+        ):
+            assert got is not None
+            assert want is not None
+            _assert_exact(got, want)
+
+
+@requires_p5_cuda
+def test_empty_batch_and_fail_closed_validation() -> None:
+    provider = ClampSwiGLUWeightedCudaProvider()
+
+    empty = torch.empty(
+        0,
+        32,
+        device="cuda",
+    )
+
+    p_s = torch.empty(
+        0,
+        device="cuda",
+    )
+
+    dh = torch.empty(
+        0,
+        32,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+
+    h, saved = provider.clamp_swiglu_weighted_fwd(
+        empty,
+        empty,
+        p_s,
+    )
+
+    dgate, dup, dp_s = provider.clamp_swiglu_weighted_bwd(
+        dh,
+        saved,
+    )
+
+    assert h.shape == (0, 32)
+    assert h.dtype == torch.bfloat16
+    assert dgate.shape == (0, 32)
+    assert dup.shape == (0, 32)
+    assert dp_s is not None
+    assert dp_s.shape == (0,)
+
+    with pytest.raises(
+        RuntimeError,
+        match="CUDA tensor",
+    ):
+        provider.clamp_swiglu_weighted_fwd(
+            empty.cpu(),
+            empty.cpu(),
+            p_s.cpu(),
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="share shape",
+    ):
+        provider.clamp_swiglu_weighted_fwd(
+            empty,
+            torch.empty(
+                0,
+                16,
+                device="cuda",
+            ),
+            p_s,
+        )
+
+    with pytest.raises(
+        TypeError,
+        match="p_s must have dtype fp32",
+    ):
+        provider.clamp_swiglu_weighted_fwd(
+            empty,
+            empty,
+            p_s.to(torch.bfloat16),
+        )

--- a/tests/test_p5_clamp_swiglu_weighted_cuda.py
+++ b/tests/test_p5_clamp_swiglu_weighted_cuda.py
@@ -36,6 +36,39 @@ def _assert_exact(
     assert torch.equal(got, want)
 
 
+def _assert_saved_state(
+    saved: dict[str, torch.Tensor],
+    gate: torch.Tensor,
+    up: torch.Tensor,
+    p_s: torch.Tensor | None,
+) -> None:
+    expected_keys = {
+        "gate32",
+        "up32",
+    }
+
+    if p_s is not None:
+        expected_keys.add("p_s")
+
+    assert set(saved) == expected_keys
+
+    _assert_exact(
+        saved["gate32"],
+        gate.float().contiguous(),
+    )
+
+    _assert_exact(
+        saved["up32"],
+        up.float().contiguous(),
+    )
+
+    if p_s is not None:
+        _assert_exact(
+            saved["p_s"],
+            p_s.contiguous(),
+        )
+
+
 @requires_p5_cuda
 def test_boundary_fixture_is_byte_exact() -> None:
     provider = ClampSwiGLUWeightedCudaProvider()
@@ -71,11 +104,12 @@ def test_boundary_fixture_is_byte_exact() -> None:
 
     _assert_exact(h_got, h_ref)
 
-    for key in ("g", "u", "sig", "silu"):
-        _assert_exact(
-            saved_got[key],
-            saved_ref[key],
-        )
+    _assert_saved_state(
+        saved_got,
+        gate,
+        up,
+        p_s,
+    )
 
     for got, want in zip(
         grads_got,
@@ -130,8 +164,14 @@ def test_shared_variant_has_no_weight_no_clamp_and_no_dp_s() -> None:
     )
 
     _assert_exact(h_got, h_ref)
-    _assert_exact(saved_got["g"], gate)
-    _assert_exact(saved_got["u"], up)
+
+    _assert_saved_state(
+        saved_got,
+        gate,
+        up,
+        None,
+    )
+
     _assert_exact(dgate_got, dgate_ref)
     _assert_exact(dup_got, dup_ref)
 
@@ -189,6 +229,13 @@ def test_repeated_runs_are_byte_exact() -> None:
         saved_first,
     )
 
+    _assert_saved_state(
+        saved_first,
+        gate,
+        up,
+        p_s,
+    )
+
     for _ in range(4):
         h_repeat, saved_repeat = provider.clamp_swiglu_weighted_fwd(
             gate,
@@ -202,6 +249,13 @@ def test_repeated_runs_are_byte_exact() -> None:
         )
 
         _assert_exact(h_repeat, h_first)
+
+        _assert_saved_state(
+            saved_repeat,
+            gate,
+            up,
+            p_s,
+        )
 
         for got, want in zip(
             grads_repeat,
@@ -244,6 +298,13 @@ def test_empty_batch_and_fail_closed_validation() -> None:
     dgate, dup, dp_s = provider.clamp_swiglu_weighted_bwd(
         dh,
         saved,
+    )
+
+    _assert_saved_state(
+        saved,
+        empty,
+        empty,
+        p_s,
     )
 
     assert h.shape == (0, 32)

--- a/tests/test_p5_clamp_swiglu_weighted_cuda.py
+++ b/tests/test_p5_clamp_swiglu_weighted_cuda.py
@@ -179,6 +179,89 @@ def test_shared_variant_has_no_weight_no_clamp_and_no_dp_s() -> None:
     assert dp_ref is None
 
 
+@pytest.mark.parametrize(
+    "weighted",
+    [
+        False,
+        True,
+    ],
+)
+@requires_p5_cuda
+def test_packed_layout_is_byte_exact_and_zero_copy(
+    weighted: bool,
+) -> None:
+    provider = ClampSwiGLUWeightedCudaProvider()
+
+    gate, up, p_s = (tensor.cuda() for tensor in fixtures.make_swiglu_boundary_inputs())
+
+    gate_up = torch.cat(
+        (
+            gate,
+            up,
+        ),
+        dim=1,
+    ).contiguous()
+
+    route_weights = p_s if weighted else None
+
+    dh = fixtures.make_grad_output(
+        "swiglu_boundary",
+        tuple(gate.shape),
+    ).cuda()
+
+    h_ref, saved_ref = oracle.clamp_swiglu_weighted_fwd(
+        gate,
+        up,
+        route_weights,
+    )
+
+    grads_ref = oracle.clamp_swiglu_weighted_bwd(
+        dh,
+        saved_ref,
+    )
+
+    h_got, saved_got = provider.clamp_swiglu_weighted_packed_fwd(
+        gate_up,
+        route_weights,
+    )
+
+    grads_got = provider.clamp_swiglu_weighted_packed_bwd(
+        dh,
+        saved_got,
+    )
+
+    _assert_exact(
+        h_got,
+        h_ref,
+    )
+
+    expected_saved_keys = {
+        "gate_up32",
+    }
+
+    if route_weights is not None:
+        expected_saved_keys.add("p_s")
+
+    assert set(saved_got) == expected_saved_keys
+
+    assert gate_up.dtype == torch.float32
+    assert saved_got["gate_up32"].data_ptr() == gate_up.data_ptr()
+
+    for got, want in zip(
+        grads_got,
+        grads_ref,
+        strict=True,
+    ):
+        if want is None:
+            assert got is None
+        else:
+            assert got is not None
+            _assert_exact(
+                got,
+                want,
+            )
+
+
 @requires_p5_cuda
 def test_repeated_runs_are_byte_exact() -> None:
     provider = ClampSwiGLUWeightedCudaProvider()


### PR DESCRIPTION
## Summary

Implement P5-2 `clamp_swiglu_weighted` with deterministic CUDA forward and backward kernels.

## Changes

* Added FP32 CUDA forward computation with:

  * `gate` upper clamp at `10`
  * `up` clamp to `[-10, 10]`
  * optional routing weight `p_s`
  * one final BF16 cast
* Added backward kernels for `d_gate`, `d_up`, and deterministic serial `dp_s` reduction.
* Added strict clamp-boundary subgradient behavior.
* Added C++/PyBind bindings in `csrc/ops.cpp`.
* Added `ClampSwiGLUWeightedCudaProvider`.
* Added CUDA tests for boundary cases, shared expert mode, repeated runs, and validation errors.

## Validation

* Black: passed
* Ruff: passed
* CPU provider tests: `3 passed`
* CPU P5 acceptance:

  * `base_only_one_row`: passed
  * `shared_t1`: passed
* CUDA tests: skipped locally because this environment has no NVIDIA GPU.

The golden-manifest anchor test was not used as a local gate because the committed manifest is CPU-x86 specific, while local validation uses Apple Silicon with PyTorch 2.14.0. The manifest was not regenerated or modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added weighted, clamped SwiGLU activation support with forward and backward operations, including optional route weights and CUDA acceleration.
  - Added a Mixture-of-Experts framework with validated expert data contracts, provider selection, shared and routed expert pipelines, LoRA support, and trace comparison utilities.
  - Added exact MXFP8/MXFP4 quantization and dequantization support.
  - Added deterministic fixtures, golden outputs, and an acceptance-check command for validating provider implementations.

- **Documentation**
  - Added the P5 Expert Start Kit design and numeric compatibility contract.

- **Tests**
  - Added comprehensive coverage for CUDA activation behavior, quantization, contracts, providers, oracle calculations, determinism, validation, and boundary cases.

- **Style**
  - Standardized formatting configuration and reformatted several statements without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->