### PR TITLE
feat(musa): add native deterministic gemm kernel

### DIFF
--- a/csrc/musa/det_gemm.mu
+++ b/csrc/musa/det_gemm.mu
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+
+#include <musa_runtime.h>
+#include <torch/extension.h>
+#include <torch_musa/csrc/aten/musa/Exceptions.h>
+#include <torch_musa/csrc/aten/musa/MUSAContext.h>
+
+namespace {
+
+constexpr int kBlockSize = 256;
+
+template <
+    typename input_t,
+    typename output_t,
+    bool TransposeA,
+    bool TransposeB,
+    bool TransposeOutput>
+__global__ void det_gemm_kernel(
+    const input_t* a,
+    const input_t* b,
+    output_t* c,
+    int m,
+    int n,
+    int k) {
+    const int index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= m * n) {
+        return;
+    }
+    const int row = index / n;
+    const int column = index % n;
+    float accumulator = 0.0f;
+    for (int inner = 0; inner < k; ++inner) {
+        const int a_index = TransposeA ? inner * m + row : row * k + inner;
+        const int b_index = TransposeB ? column * k + inner : inner * n + column;
+        accumulator +=
+            static_cast<float>(a[a_index]) * static_cast<float>(b[b_index]);
+    }
+    const int output_index = TransposeOutput ? column * m + row : index;
+    c[output_index] = static_cast<output_t>(accumulator);
+}
+
+template <typename input_t, typename output_t>
+void launch(
+    torch::Tensor a,
+    torch::Tensor b,
+    torch::Tensor output,
+    int m,
+    int n,
+    int k,
+    bool transpose_a,
+    bool transpose_b,
+    bool transpose_output) {
+    const int blocks = (m * n + kBlockSize - 1) / kBlockSize;
+    auto stream = at::musa::getCurrentMUSAStream();
+    if (transpose_a) {
+        if (transpose_output) {
+            det_gemm_kernel<input_t, output_t, true, false, true>
+                <<<blocks, kBlockSize, 0, stream>>>(
+                    a.data_ptr<input_t>(),
+                    b.data_ptr<input_t>(),
+                    output.data_ptr<output_t>(),
+                    m,
+                    n,
+                    k);
+        } else {
+            det_gemm_kernel<input_t, output_t, true, false, false>
+                <<<blocks, kBlockSize, 0, stream>>>(
+                    a.data_ptr<input_t>(),
+                    b.data_ptr<input_t>(),
+                    output.data_ptr<output_t>(),
+                    m,
+                    n,
+                    k);
+        }
+    } else if (transpose_b) {
+        det_gemm_kernel<input_t, output_t, false, true, false>
+            <<<blocks, kBlockSize, 0, stream>>>(
+                a.data_ptr<input_t>(),
+                b.data_ptr<input_t>(),
+                output.data_ptr<output_t>(),
+                m,
+                n,
+                k);
+    } else {
+        det_gemm_kernel<input_t, output_t, false, false, false>
+            <<<blocks, kBlockSize, 0, stream>>>(
+                a.data_ptr<input_t>(),
+                b.data_ptr<input_t>(),
+                output.data_ptr<output_t>(),
+                m,
+                n,
+                k);
+    }
+}
+
+void check_inputs(torch::Tensor a, torch::Tensor b) {
+    TORCH_CHECK(
+        a.device().type() == c10::kPrivateUse1 &&
+            b.device().type() == c10::kPrivateUse1,
+        "det_gemm requires MUSA tensors");
+    TORCH_CHECK(a.device() == b.device(), "det_gemm tensors must share a device");
+    TORCH_CHECK(a.dim() == 2 && b.dim() == 2, "det_gemm expects 2-D tensors");
+    TORCH_CHECK(a.scalar_type() == b.scalar_type(), "det_gemm dtypes must match");
+    TORCH_CHECK(
+        a.scalar_type() == at::ScalarType::BFloat16,
+        "MUSA det_gemm currently supports bfloat16 inputs");
+}
+
+torch::Tensor dispatch(
+    torch::Tensor a,
+    torch::Tensor b,
+    int m,
+    int n,
+    int k,
+    bool transpose_a,
+    bool transpose_b,
+    bool transpose_output,
+    bool output_fp32) {
+    a = a.contiguous();
+    b = b.contiguous();
+    auto options = output_fp32 ? a.options().dtype(torch::kFloat) : a.options();
+    auto output = torch::empty(
+        transpose_output ? std::vector<int64_t>{n, m}
+                         : std::vector<int64_t>{m, n},
+        options);
+    if (m == 0 || n == 0) {
+        return output;
+    }
+    if (output_fp32) {
+        launch<c10::BFloat16, float>(
+            a, b, output, m, n, k, transpose_a, transpose_b, transpose_output);
+    } else {
+        launch<c10::BFloat16, c10::BFloat16>(
+            a, b, output, m, n, k, transpose_a, transpose_b, transpose_output);
+    }
+    C10_MUSA_KERNEL_LAUNCH_CHECK();
+    return output;
+}
+
+}  // namespace
+
+torch::Tensor det_gemm_fwd(torch::Tensor a, torch::Tensor b) {
+    check_inputs(a, b);
+    TORCH_CHECK(b.size(0) == a.size(1), "det_gemm_fwd: K mismatch");
+    return dispatch(a, b, a.size(0), b.size(1), a.size(1), false, false, false, false);
+}
+
+torch::Tensor det_gemm_fwd_fp32(torch::Tensor a, torch::Tensor b) {
+    check_inputs(a, b);
+    TORCH_CHECK(b.size(0) == a.size(1), "det_gemm_fwd_fp32: K mismatch");
+    return dispatch(a, b, a.size(0), b.size(1), a.size(1), false, false, false, true);
+}
+
+torch::Tensor det_gemm_fwd_rhs_transposed(torch::Tensor a, torch::Tensor bt) {
+    check_inputs(a, bt);
+    TORCH_CHECK(bt.size(1) == a.size(1), "det_gemm_fwd_rhs_transposed: K mismatch");
+    return dispatch(a, bt, a.size(0), bt.size(0), a.size(1), false, true, false, false);
+}
+
+torch::Tensor det_gemm_da(torch::Tensor dc, torch::Tensor b) {
+    check_inputs(dc, b);
+    TORCH_CHECK(b.size(1) == dc.size(1), "det_gemm_da: N mismatch");
+    return dispatch(dc, b, dc.size(0), b.size(0), dc.size(1), false, true, false, false);
+}
+
+torch::Tensor det_gemm_db(torch::Tensor a, torch::Tensor dc) {
+    check_inputs(a, dc);
+    TORCH_CHECK(a.size(0) == dc.size(0), "det_gemm_db: M mismatch");
+    return dispatch(a, dc, a.size(1), dc.size(1), a.size(0), true, false, false, false);
+}
+
+torch::Tensor det_gemm_db_transposed(torch::Tensor a, torch::Tensor dc) {
+    check_inputs(a, dc);
+    TORCH_CHECK(a.size(0) == dc.size(0), "det_gemm_db_transposed: M mismatch");
+    return dispatch(a, dc, a.size(1), dc.size(1), a.size(0), true, false, true, false);
+}

--- a/csrc/musa/ops.cpp
+++ b/csrc/musa/ops.cpp
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+
+#include <torch/extension.h>
+
+torch::Tensor det_gemm_fwd(torch::Tensor a, torch::Tensor b);
+torch::Tensor det_gemm_fwd_fp32(torch::Tensor a, torch::Tensor b);
+torch::Tensor det_gemm_fwd_rhs_transposed(torch::Tensor a, torch::Tensor bt);
+torch::Tensor det_gemm_da(torch::Tensor dc, torch::Tensor b);
+torch::Tensor det_gemm_db(torch::Tensor a, torch::Tensor dc);
+torch::Tensor det_gemm_db_transposed(torch::Tensor a, torch::Tensor dc);
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("det_gemm_fwd", &det_gemm_fwd);
+    m.def("det_gemm_fwd_fp32", &det_gemm_fwd_fp32);
+    m.def("det_gemm_fwd_rhs_transposed", &det_gemm_fwd_rhs_transposed);
+    m.def("det_gemm_da", &det_gemm_da);
+    m.def("det_gemm_db", &det_gemm_db);
+    m.def("det_gemm_db_transposed", &det_gemm_db_transposed);
+}

--- a/rl_engine/kernels/ops/musa/__init__.py
+++ b/rl_engine/kernels/ops/musa/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/rl_engine/kernels/ops/musa/matmul/__init__.py
+++ b/rl_engine/kernels/ops/musa/matmul/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from .det_gemm import MusaDetGemmOp
+
+__all__ = ["MusaDetGemmOp"]

--- a/rl_engine/kernels/ops/musa/matmul/det_gemm.py
+++ b/rl_engine/kernels/ops/musa/matmul/det_gemm.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 RL-Kernel Contributors
+
+from __future__ import annotations
+
+import torch
+
+from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
+
+
+class _MusaDetGemmFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, a: torch.Tensor, b: torch.Tensor, output_fp32: bool):
+        ctx.save_for_backward(a, b)
+        ctx.output_fp32 = bool(output_fp32)
+        if ctx.output_fp32:
+            return _C.det_gemm_fwd_fp32(a, b)
+        return _C.det_gemm_fwd(a, b)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        a, b = ctx.saved_tensors
+        grad_a = _C.det_gemm_da(grad_output, b) if ctx.needs_input_grad[0] else None
+        grad_b = _C.det_gemm_db(a, grad_output) if ctx.needs_input_grad[1] else None
+        return grad_a, grad_b, None
+
+
+class _MusaDetLinearFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, a: torch.Tensor, weight: torch.Tensor):
+        ctx.save_for_backward(a, weight)
+        return _C.det_gemm_fwd_rhs_transposed(a, weight)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        a, weight = ctx.saved_tensors
+        grad_a = _C.det_gemm_fwd(grad_output, weight) if ctx.needs_input_grad[0] else None
+        grad_weight = _C.det_gemm_db_transposed(a, grad_output) if ctx.needs_input_grad[1] else None
+        return grad_a, grad_weight
+
+
+class MusaDetGemmOp:
+    """Deterministic fixed-order GEMM for MUSA BF16 tensors."""
+
+    def __init__(self) -> None:
+        if not _EXT_AVAILABLE or _C is None:
+            raise RuntimeError("MUSA det_gemm requires the compiled extension")
+        required = (
+            "det_gemm_fwd",
+            "det_gemm_fwd_fp32",
+            "det_gemm_fwd_rhs_transposed",
+            "det_gemm_da",
+            "det_gemm_db",
+            "det_gemm_db_transposed",
+        )
+        missing = [name for name in required if not hasattr(_C, name)]
+        if missing:
+            raise RuntimeError(f"MUSA det_gemm extension is missing: {', '.join(missing)}")
+
+    @staticmethod
+    def _check(a: torch.Tensor, b: torch.Tensor) -> None:
+        if a.device.type != "musa" or b.device.type != "musa":
+            raise ValueError("MUSA det_gemm requires MUSA tensors")
+        if a.dtype != torch.bfloat16 or b.dtype != torch.bfloat16:
+            raise TypeError("MUSA det_gemm currently supports BF16 tensors")
+
+    def __call__(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        self._check(a, b)
+        if a.ndim != 2 or b.ndim != 2 or a.size(1) != b.size(0):
+            raise ValueError("det_gemm expects A[M,K] and B[K,N]")
+        return _MusaDetGemmFunction.apply(a.contiguous(), b.contiguous(), False)
+
+    def forward_fp32(self, a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+        self._check(a, b)
+        if a.ndim != 2 or b.ndim != 2 or a.size(1) != b.size(0):
+            raise ValueError("det_gemm expects A[M,K] and B[K,N]")
+        return _MusaDetGemmFunction.apply(a.contiguous(), b.contiguous(), True)
+
+    forward_accum_fp32 = forward_fp32
+
+    def linear(self, a: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+        self._check(a, weight)
+        if a.ndim != 2 or weight.ndim != 2 or a.size(1) != weight.size(1):
+            raise ValueError("linear expects A[M,K] and weight[N,K]")
+        return _MusaDetLinearFunction.apply(a.contiguous(), weight.contiguous())
+
+
+def deterministic_gemm(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    return MusaDetGemmOp()(a, b)

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -90,6 +90,7 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     PYTORCH_PACK = "rl_engine.kernels.ops.pytorch.packing.pack.NativePackOp"
     # Batch-invariant deterministic GEMM (WS1 #146)
     CUDA_DET_GEMM = "rl_engine.kernels.ops.cuda.matmul.det_gemm.DetGemmOp"
+    MUSA_DET_GEMM = "rl_engine.kernels.ops.musa.matmul.det_gemm.MusaDetGemmOp"
     TRITON_DET_GEMM = "rl_engine.kernels.ops.triton.matmul.det_gemm.TritonDetGemmOp"
     # NON-deterministic reference (torch.matmul); reference/benchmark ONLY,
     # intentionally excluded from det_gemm dispatch (cuBLAS breaks invariance).
@@ -578,7 +579,7 @@ class KernelRegistry:
                 "linear_logp": [OpBackend.PYTORCH_LINEAR_LOGP],
                 "ratio_kl": [OpBackend.PYTORCH_RATIO_KL],
                 "pack": [OpBackend.PYTORCH_PACK],
-                "det_gemm": [],
+                "det_gemm": [OpBackend.MUSA_DET_GEMM],
                 "batch_invariant_logp": [OpBackend.PYTORCH_BATCH_INVARIANT_LOGP],
                 "matmul": [OpBackend.PYTORCH_NATIVE_MATMUL],
                 "rms_norm": [OpBackend.PYTORCH_NATIVE_RMS_NORM],

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,17 @@ def _load_envs_module():
 envs = _load_envs_module()
 
 
+def _musa_build_available(torch) -> bool:
+    try:
+        import torch_musa  # noqa: F401
+    except ImportError:
+        return False
+    return bool(
+        hasattr(torch, "musa")
+        and (torch.musa.is_available() or bool(os.environ.get("TORCH_MUSA_ARCH_LIST", "").strip()))
+    )
+
+
 def _load_torch_extension_tools():
     try:
         import torch
@@ -30,6 +41,10 @@ def _load_torch_extension_tools():
             raise
         return None, None, None
 
+    if _musa_build_available(torch):
+        from torch_musa.utils.musa_extension import BuildExtension, MUSAExtension
+
+        return torch, BuildExtension, MUSAExtension
     from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
     # CUDAExtension is also the supported extension entry point for ROCm
@@ -45,6 +60,8 @@ def _native_extension_required() -> bool:
         or bool(os.environ.get("PYTORCH_ROCM_ARCH", "").strip())
         or bool(os.environ.get("TORCH_CUDA_ARCH_LIST", "").strip())
         or envs.env_flag("FORCE_CUDA")
+        or bool(os.environ.get("TORCH_MUSA_ARCH_LIST", "").strip())
+        or envs.env_flag("FORCE_MUSA")
     )
 
 
@@ -93,7 +110,7 @@ def _filter_rocm_incompatible_nvcc_flags(flags: list[str]) -> list[str]:
 
 
 def get_extensions():
-    torch, _, CUDAExtension = _load_torch_extension_tools()
+    torch, _, Extension = _load_torch_extension_tools()
     if torch is None:
         message = (
             "PyTorch is unavailable, so rl_engine._C cannot be built. Install a matching "
@@ -116,6 +133,24 @@ def get_extensions():
     if os.environ.get("KERNEL_ALIGN_DEV_RPATH") == "1":
         torch_rpath.append(f"-Wl,-rpath,{torch_lib_dir}")
     is_rocm = getattr(torch.version, "hip", None) is not None
+
+    if _musa_build_available(torch):
+        extensions.append(
+            Extension(
+                name="rl_engine._C",
+                sources=[
+                    "csrc/musa/ops.cpp",
+                    "csrc/musa/det_gemm.mu",
+                ],
+                include_dirs=[],
+                extra_compile_args={
+                    "cxx": ["-O3", "-std=c++17", "-DKERNEL_ALIGN_WITH_MUSA"],
+                    "mcc": ["-O3", "-std=c++17", "-DKERNEL_ALIGN_WITH_MUSA"],
+                },
+                extra_link_args=list(torch_rpath),
+            )
+        )
+        return extensions
 
     # CUDAExtension is intentionally used for both CUDA and ROCm. On ROCm,
     # PyTorch's BuildExtension hipifies CUDA sources and invokes hipcc; it also
@@ -254,7 +289,7 @@ def get_extensions():
             nvcc_flags = _filter_rocm_incompatible_nvcc_flags(nvcc_flags)
 
         extensions.append(
-            CUDAExtension(
+            Extension(
                 name="rl_engine._C",
                 sources=cuda_sources,
                 include_dirs=[],

--- a/tests/test_musa_det_gemm.py
+++ b/tests/test_musa_det_gemm.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+
+from rl_engine.kernels.ops.musa.matmul.det_gemm import MusaDetGemmOp
+from rl_engine.kernels.registry import KernelRegistry
+
+
+def _musa_available() -> bool:
+    return hasattr(torch, "musa") and torch.musa.is_available()
+
+
+def _reference(a, b):
+    return (a.float() @ b.float()).to(a.dtype)
+
+
+@pytest.mark.skipif(not _musa_available(), reason="requires a MUSA device")
+@pytest.mark.parametrize("shape", [(1, 7, 5), (31, 70, 65), (128, 128, 128)])
+def test_musa_det_gemm_forward_matches_reference(shape):
+    m, k, n = shape
+    torch.manual_seed(2026)
+    a = torch.randn(m, k, device="musa", dtype=torch.bfloat16)
+    b = torch.randn(k, n, device="musa", dtype=torch.bfloat16)
+    op = MusaDetGemmOp()
+    actual = op(a, b)
+    expected = _reference(a, b)
+    assert torch.allclose(actual.float(), expected.float(), atol=0.25, rtol=0.02)
+
+
+@pytest.mark.skipif(not _musa_available(), reason="requires a MUSA device")
+def test_musa_det_gemm_is_batch_invariant():
+    torch.manual_seed(2027)
+    a = torch.randn(128, 64, device="musa", dtype=torch.bfloat16)
+    b = torch.randn(64, 96, device="musa", dtype=torch.bfloat16)
+    op = MusaDetGemmOp()
+    full = op(a, b)
+    chunks = torch.cat((op(a[:31], b), op(a[31:], b)), dim=0)
+    assert torch.equal(full, chunks)
+
+
+@pytest.mark.skipif(not _musa_available(), reason="requires a MUSA device")
+def test_musa_det_gemm_backward_matches_reference():
+    torch.manual_seed(2028)
+    a = torch.randn(8, 32, device="musa", dtype=torch.bfloat16, requires_grad=True)
+    b = torch.randn(32, 24, device="musa", dtype=torch.bfloat16, requires_grad=True)
+    grad = torch.randn(8, 24, device="musa", dtype=torch.bfloat16)
+    MusaDetGemmOp()(a, b).backward(grad)
+    grad_a, grad_b = a.grad.float(), b.grad.float()
+
+    ar = a.detach().float().requires_grad_(True)
+    br = b.detach().float().requires_grad_(True)
+    (_reference(ar, br).float()).backward(grad.float())
+    assert torch.allclose(grad_a, ar.grad, atol=2e-2, rtol=2e-2)
+    assert torch.allclose(grad_b, br.grad, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.skipif(not _musa_available(), reason="requires a MUSA device")
+def test_musa_det_gemm_linear_weight_layout_and_registry():
+    torch.manual_seed(2029)
+    a = torch.randn(4, 16, device="musa", dtype=torch.bfloat16)
+    weight = torch.randn(9, 16, device="musa", dtype=torch.bfloat16)
+    actual = MusaDetGemmOp().linear(a, weight)
+    expected = (a.float() @ weight.float().t()).to(a.dtype)
+    assert torch.equal(actual, expected)
+    assert KernelRegistry().get_op("det_gemm", device="musa").__class__.__name__ == "MusaDetGemmOp"


### PR DESCRIPTION
# [MUSA][kernels] Add native MUSA deterministic GEMM

## Summary

Adds a native MUSA implementation for the deterministic `det_gemm` kernel.

The MUSA implementation uses a fixed ascending K-order reduction with FP32
accumulation and supports the forward and backward GEMM layouts required by
`MusaDetGemmOp`. It provides MUSA-native forward, transposed-RHS forward, dA,
dB, and canonical transposed dB paths while preserving the existing CUDA, ROCm,
and CPU backends.

| Path | Status |
| --- | --- |
| MUSA forward (`csrc/musa/det_gemm.mu`) | Fixed-order GEMM with FP32 accumulation. New. |
| MUSA transposed-RHS forward | Supports `[M, K] @ [N, K]^T` without materializing the RHS transpose. New. |
| MUSA backward dA | Supports `dA = dC @ B^T`. New. |
| MUSA backward dB | Supports `dB = A^T @ dC`. New. |
| MUSA canonical transposed dB | Returns contiguous `[N, K]` weight gradients. New. |
| Python backend | Adds `MusaDetGemmOp` with autograd support. New. |
| Registry | MUSA `det_gemm` selects `MusaDetGemmOp`. New. |
| CUDA / ROCm / CPU behavior | Preserved. |
| Tests | Added MUSA correctness, invariance, backward, layout, and registry coverage. |

## Implementation

- Added `csrc/musa/det_gemm.mu`.
  - Uses one output thread per matrix element.
  - Accumulates the K dimension in a fixed ascending order.
  - Uses FP32 accumulation and casts to BF16 for standard output.
  - Supports regular GEMM, transposed-RHS GEMM, transposed-LHS gradients, and transposed output layout.
  - Provides an FP32-output forward entry point.
- Added `csrc/musa/ops.cpp`.
  - Exposes the MUSA `det_gemm` entry points through PyBind11.
  - Provides input device, dimensionality, dtype, and shape validation.
- Updated `setup.py`.
  - Detects an available MUSA build environment.
  - Uses `MUSAExtension` for MUSA builds.
  - Compiles only the MUSA `det_gemm` sources in the MUSA path.
  - Preserves the existing CUDA and ROCm extension paths.
- Added `rl_engine/kernels/ops/musa/matmul/det_gemm.py`.
  - Implements `MusaDetGemmOp`.
  - Adds autograd support for dA and dB.
  - Supports the `linear(A, weight[N, K])` layout.
  - Provides `forward_fp32` and `forward_accum_fp32`.
- Updated `rl_engine/kernels/registry.py`.
  - Adds the `MUSA_DET_GEMM` backend.
  - Routes MUSA `det_gemm` requests to `MusaDetGemmOp`.
- Added `tests/test_musa_det_gemm.py`.
  - Covers forward correctness.
  - Covers batch and chunk invariance.
  - Covers backward dA and dB.
  - Covers transposed weight-gradient layout.
  - Covers MUSA registry dispatch.

## Validation environment

| Item | Value |
| --- | --- |
| GPU | Moore Threads MTT S5000 |
| GPU count | 8 |
| Test devices | 1 |
| MUSA runtime | 40305 |
| Driver | 3.3.5-server |
| PyTorch | 2.7.1 |
| torch_musa | 2.7.1+5f0ecd1 |
| Host compiler | mcc 5.2.0 |
| MUSA architecture | `mp_31` |
| Python | 3.10 |

## Correctness / Tests

### Build

```text
RL_KERNEL_REQUIRE_EXT=1 \
python3 -m pip install --no-build-isolation --no-deps -e .

Result: successfully built and installed RL-Kernel
```

### MUSA-specific tests

```text
python3 -m pytest tests/test_musa_det_gemm.py -q

Result: 6 passed
```

The MUSA-specific tests cover:

- BF16 forward GEMM against the PyTorch reference.
- Unaligned and non-square matrix shapes.
- Bitwise batch invariance.
- Bitwise chunked execution invariance.
- Backward dA and dB correctness.
- Canonical contiguous `[N, K]` weight-gradient layout.
- `linear(A, weight[N, K])` behavior.
- MUSA registry selection.

The forward reference comparison uses FP32 PyTorch matmul followed by BF16 conversion with a tolerance appropriate for the MUSA reference reduction path. Batch and chunk invariance are checked independently using exact tensor equality.

### Registry tests

```text
python3 -m pytest tests/test_kernel_registry.py -q

Result: 12 passed
```

### Python validation

```text
python3 -m py_compile \
  setup.py \
  rl_engine/kernels/registry.py \
  rl_engine/kernels/ops/musa/matmul/det_gemm.py \
  tests/test_musa_det_gemm.py

Result: passed
```

## Benchmarks

Single MTT S5000, one GPU, BF16 inputs, 3 warmup iterations and 10 measured iterations for forward, 2 warmup iterations and 5 measured iterations for forward + backward. The native and reference implementations both run on the same MUSA device. The reference uses FP32 `torch.mm` followed by BF16 output conversion.

### Forward

| Shape (`M x K x N`) | Dtype | Native MUSA (ms) | PyTorch reference (ms) | Native / reference | Native peak VRAM | Reference peak VRAM | Max abs diff |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `128 x 128 x 128` | `bfloat16` | 0.054 | 0.051 | 0.94x | 0.00009 GB | 0.00024 GB | 4.88e-4 |
| `256 x 512 x 512` | `bfloat16` | 0.326 | 0.051 | 0.16x | 0.00107 GB | 0.00278 GB | 2.50e-1 |
| `512 x 1024 x 1024` | `bfloat16` | 1.784 | 0.052 | 0.03x | 0.00464 GB | 0.01147 GB | 5.00e-1 |

### Forward + Backward

The native path uses `MusaDetGemmOp` for forward and native MUSA dA/dB kernels for backward.

| Shape (`M x K x N`) | Dtype | Native fwd+bwd (ms) | PyTorch reference fwd+bwd (ms) | Native / reference | Native peak VRAM | Reference peak VRAM |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| `128 x 128 x 128` | `bfloat16` | 0.212 | 0.249 | 1.18x | 0.00031 GB | 0.00046 GB |
| `256 x 512 x 512` | `bfloat16` | 1.021 | 0.242 | 0.24x | 0.00317 GB | 0.00488 GB |
| `512 x 1024 x 1024` | `bfloat16` | 5.858 | 0.251 | 0.04x | 0.01270 GB | 0.01953 GB |

The fixed-order native path is intended to establish the deterministic MUSA execution contract. Its current one-thread-per-output implementation is slower than the optimized MUSA matrix-multiplication reference for medium and large shapes; tiled and hardware-specific optimization is future work.

## Files

- `csrc/musa/det_gemm.mu`
- `csrc/musa/ops.cpp`
- `setup.py`
- `rl_engine/kernels/ops/musa/__init__.py`
- `rl_engine/kernels/ops/musa/matmul/__init__.py`
- `rl_engine/kernels/ops/musa/matmul/det_gemm.py`
- `rl_engine/kernels/registry.py`
- `tests/test_musa_det_gemm.py`

## Limitations

- The current MUSA implementation supports BF16 inputs.
- The kernel is a correctness-oriented fixed-order implementation and is not yet optimized for large GEMM shapes.
- FP32-output mode still uses BF16 inputs with FP32 accumulation.
- Tensor-parallel collective integration is not included in this change.
- CUDA, ROCm, and CPU paths continue to use their existing backends.
- Further optimization can add tiled MUSA GEMM implementations while preserving the current API and reduction contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deterministic BF16 matrix multiplication support for MUSA GPUs.
  * Added forward, FP32-accumulation, transposed-weight, and gradient operations.
  * Added automatic MUSA backend registration and Python-accessible GEMM operations.
  * Added MUSA build support when a compatible environment is available.

* **Tests**
  * Added MUSA coverage for forward results, batching, gradients, linear operations, and backend registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->