### PR TITLE
[DSv4][P5-4] MXFP8×MXFP4 Routed Expert grouped GEMM: strict CUDA kernel

### DIFF
--- a/P5_4.md
+++ b/P5_4.md
@@ -1,0 +1,75 @@
+> **父 Issue**：#8 [DSV4][P5/7] MXFP4 Routed Expert、LoRA 与 Shared Expert
+> **开发序号**：P5-4 · **阶段**:WS1（单卡算子闭环） · **交付**：1 个 PR / 每后端
+> **前置**：`P5-S0` start kit 已合入（`rl_engine/moe/`，含 oracle、golden fixture 与验收命令）
+
+## 1. 这个 PR 要写什么
+
+Routed Expert 的 fc1 / fc2 frozen base GEMM：**MXFP8 activation × MXFP4 frozen weight**。
+
+**BWD 只写 `dX`，不写 `dW`**——base weight 全部冻结（#1 §2.5 第 1 条）。
+
+⚠️ **SM90 硬件事实（决定实现策略）**：
+1. WGMMA **没有 FP4 操作数**。B 必须在 kernel 内（register/smem）把 nibble 解成 E4M3 再进 MMA；FP4→FP8 是精确转换。**禁止把 dequant 后的 B 写回 global memory**（等于 unpack base weight，违反 #62 合同）。
+2. H100 的 fp8 WGMMA **内部累加是降精度的（≈fp22）**，无法与 oracle 的纯 FP32 串行累加逐位一致。因此：
+   - **strict path**：用 FFMA（`__fmul_rn` / `__fadd_rn`，禁 FMA 融合）复现 oracle 的 `oracle-fp32-serial-v1` profile，与 golden byte-equal；
+   - **WGMMA path**：作为性能路径实现，登记独立 numeric profile + 与 oracle 的实测 diff，**不得静默顶替 strict path**。
+
+## 2. 接口（与 `P5-S0` 已发布签名一致）
+
+```python
+# rl_engine/moe/oracle.py 为语义参考；kernel 按同一签名注册进 provider
+mxfp8_mxfp4_grouped_gemm_fwd(a: MXTensor, w: MXTensor, expert_offsets) -> Y   # FP32 [M, N]
+mxfp8_mxfp4_grouped_gemm_bwd(dy, w: MXTensor, expert_offsets) -> dX          # FP32 [M, K]；无 saved、无 dW
+```
+
+### 输入输出契约（bytes 级，不得偏离）
+
+| Tensor | dtype | shape | layout / 要求 |
+| --- | --- | --- | --- |
+| `a.codes` | uint8 (E4M3) | `[M, K]` | row-major，K 连续；来自 P5-1 (#60) 输出 |
+| `a.scales` | uint8 (E8M0) | `[M, K/32]` | 与 codes 同行对齐 |
+| `w.codes` | uint8 (E2M1 ×2) | `[E, N, K/2]` | K 连续；每 byte 两个 nibble，**低 nibble = 偶数 k** |
+| `w.scales` | uint8 (E8M0) | `[E, N, K/32]` | |
+| `expert_offsets` | int32 | `[E+1]` | 单调不减，首 0 尾 M；rows 已按 expert 排序；**允许空 group** |
+| `Y` | **FP32** | `[M, N]` | 不提前 round BF16（下游与 LoRA 在 FP32 相加） |
+| `dy` | BF16 | `[M, N]` | |
+| `dX` | **FP32** | `[M, K]` | W dequant→**BF16**（精确），串行升序 n，FP32 累加 |
+
+两个调用点：**fc1** `K=hidden, N=2*ffn`（N 前 ffn 行 = gate，后 ffn 行 = up）；**fc2** `K=ffn, N=hidden`。约束 `K % 32 == 0`；M 任意（含 1）。
+
+## 3. 固定数学（不得改写成数学等价但关联方式不同的形式）
+
+每 `K = 32` 一段（j 升序）：
+
+```
+partial_j = Σ_{k∈j} â_k · ŵ_k        # 解码后元素，FP32，k 升序，mul 与 add 分开 round
+acc      += (partial_j × scale_a_j) × scale_w_j     # 括号顺序固定
+```
+
+Backward：`dX = dY · W`（BF16 操作数，FP32 accumulator，n 升序）。
+
+## 4. 必须写死的东西
+
+- strict path = one-row unpadded launch geometry，与 Miles decode 一致。
+- base weight 保持 packed；dequant 只发生在 register/smem。
+- split-K / atomic merge / workspace / tile 配置必须进 provenance——**改算法即改加法顺序**。
+- `expert_tensor_parallel_size = 1`（不切 TP，见 P5-7 #66）。
+- 通用数值合同见 #8（MXFP8×MXFP4、LoRA 独立 BF16 路径、BF16 backward + FP32 reduction、无 dW、禁 silent fallback）。
+
+## 5. 参考实现
+
+- **语义 golden**：`rl_engine/moe/oracle.py::mxfp8_mxfp4_grouped_gemm_{fwd,bwd}`（profile `oracle-fp32-serial-v1`）。
+- 仓库内 SM90 模板：`csrc/cuda/gemm/det_gemm_kernel.cu`（WGMMA/TMA、batch-invariant）。
+- OCP MXFP4 标准；Megatron Experts grouped linear。TE/CUTLASS 可复用，但须先通过 strict matrix。
+
+## 6. 验收条件
+
+- [ ] `python scripts/check_p5.py --provider <你的Provider> --device cuda` 全部 PASS（含 `uneven_experts` 空 group case）。
+- [ ] **geometry 门禁**：对全部 fixture 行满足 `fwd(packed)[r] == fwd(one-row)` byte-equal；做不到则 strict path 明确降级 one-row，packed 路径单独 benchmark。
+- [ ] backward `dX` 与 oracle byte-equal；确认无 `dW`（base 参数无 grad 且 packed bytes 前后 hash 不变）。
+- [ ] WGMMA 性能路径（如交付）登记独立 numeric profile，附与 oracle 的 max-diff 报告;`provenance()` 记录 requested/actual backend、kernel/build fingerprint、tile/split-K 配置。
+- [ ] 未通过 strict matrix 的外部 core（TE/CUTLASS）必须经 provider hook 切到 RL Kernel，**禁止 silent fallback**。
+
+## 7. 依赖
+
+只依赖 `P5-S0`（已合入），与本包其他 sub-issue 无依赖，可立即开工。

--- a/P5_4_plan.md
+++ b/P5_4_plan.md
@@ -1,0 +1,255 @@
+# 补齐 P5-4 grouped-GEMM 的 device 侧 prep 环节
+
+## Context（为什么改）
+
+文件 `RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu` 里 P5-4 的 grouped GEMM 目前是**半吊子**：
+
+- strict 内核 `moe_grouped_gemm_fwd_strict` / `moe_grouped_gemm_bwd_strict` 的数值逻辑已经正确（K 升序串行、`__fmul_rn`/`__fadd_rn`、FP32 输出、bwd 只回 dX），且它们本身**能跑在 GPU 上**。
+- 但 `moe_prepare_experts`（[225-264](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L225-L264)）是** host 侧**函数：它调用 `moe_copy_offsets` 把 `expert_offsets` 拷回 CPU，再生成一个 host 内存里的 `std::vector<MoeGroupedGemmExpert>`。这个 vector **没有任何下游消费**（发射函数收的是原始指针），而且这条"拷回 CPU 再算"的路径被文件自己的注释（[201-203](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L201-L203)）明确禁止作为数值实现。
+
+目标：把 prep 从 host 挪到 **device**——用一个 prep kernel 在 GPU 上把每个 expert 的分组指针算好、写进 device 内存，并接入 fwd/bwd 发射链，让 strict grouped GEMM 全程 device 化。**P5-1 激活量化不在本次范围**（输入是已量化的 codes/scales）。
+
+## 契约（保持不变，必须 bit 级不变）
+
+| 张量 | dtype | shape | 备注 |
+|---|---|---|---|
+| `a.codes` | uint8 E4M3 | `[M, K]` | row-major，K 连续；来自 P5-1 |
+| `a.scales` | uint8 E8M0 | `[M, K/32]` | 与 codes 同行对齐 |
+| `w.codes` | uint8 E2M1×2 | `[E, N, K/2]` | 低 nibble = 偶数 k |
+| `w.scales` | uint8 E8M0 | `[E, N, K/32]` | |
+| `expert_offsets` | int32 | `[E+1]` | 单调不减、首 0 尾 M；允许空 group |
+| `Y`（fwd 出） | **FP32** | `[M, N]` | 不提前 round BF16 |
+| `dy`（bwd 入） | BF16 | `[M, N]` | |
+| `dX`（bwd 出） | **FP32** | `[M, K]` | W dequant→BF16，串行升序 n，FP32 累加 |
+
+### 公开接口（MXTensor，保持不变）
+
+```python
+# provider.py 的 CudaP5GemmProvider 方法（与 oracle.py 签名一致）：
+mxfp8_mxfp4_grouped_gemm_fwd(a: MXTensor, w: MXTensor, expert_offsets) -> Y   # FP32 [M, N]
+mxfp8_mxfp4_grouped_gemm_bwd(dy, w: MXTensor, expert_offsets) -> dX          # FP32 [M, K]；无 saved、无 dW
+```
+
+- MXTensor 拆包（`a.codes/a.scales`、`w.codes/w.scales`）发生在 **Python 层 provider.py 的 `CudaP5GemmProvider`**（现状不变，[provider.py:275-287](RL_KERNEL/rl_engine/moe/provider.py#L275-L287)）。
+- C++ 函数 `moe_mxfp8_mxfp4_grouped_gemm_forward(codes, scales, w_codes, w_scales, offsets)` 与 `_backward(dy, w_codes, w_scales, offsets)` 的**外部签名保持不变**（仍收 codes/scales 张量）。
+- 本次改动主体在 C++ 内部（prep kernel + 内核消费描述符 + 发射链），不触碰 MXTensor 接口；唯一 Python 侧改动是 `CudaP5GemmProvider.provenance()`（见下方「P5_4 §4/§6 落地检查」）。
+
+**数值路径一字不改**：只改"指针/路由怎么准备与传递"，不改逐元素累加、舍入、scale 应用顺序。
+
+## 改动设计
+
+### 1. 新增 device prep kernel（fwd + bwd 各一个，或一个模板）
+
+仿 vLLM 的 `__get_group_gemm_starts`（`references/vllm/.../nvfp4_blockwise_moe_kernel.cu:54-118`），但适配 P5 契约（无 alpha、无 cute layout、无 128B TMA 断言）。
+
+**fwd prep**（`__global__ void moe_prepare_experts_fwd_device`）：
+- 入参：`MoeGroupedGemmExpert* experts`（device 输出数组 `[E]`）、`a_codes/a_scales/w_codes/w_scales/out` 基址、`expert_offsets`（device，直接读，不拷 CPU）、`M, N, K, E`。
+- 每线程 `e = blockIdx.x*blockDim.x + threadIdx.x`，`e < E` 时：
+  - `row_begin = expert_offsets[e]`，`row_count = expert_offsets[e+1] - row_begin`；
+  - 写一个 `MoeGroupedGemmExpert` 到 `experts[e]`，指针字段（行/专家索引先 `(int64_t)` 提升，避免 32-bit 溢出）：
+    - `experts[e].activation_codes_ptr  = a_codes  + (int64_t)row_begin * K;`
+    - `experts[e].activation_scales_ptr = a_scales + (int64_t)row_begin * (K >> 5);`
+    - `experts[e].packed_weight_codes_ptr = w_codes  + (int64_t)e * N * (K >> 1);`
+    - `experts[e].weight_scales_ptr       = w_scales + (int64_t)e * N * (K >> 5);`
+    - `experts[e].output_ptr = out + (int64_t)row_begin * N;`
+  - stride 字段（int64_t）填常量，同样 `(int64_t)` 提升：`activation_row_stride=(int64_t)K`、`activation_scale_row_stride=(int64_t)(K>>5)`、`weight_expert_stride=(int64_t)N*(K>>1)`、`weight_scale_expert_stride=(int64_t)N*(K>>5)`、`output_row_stride=(int64_t)N`。
+- 网格：`<<<ceil(E/128), 128>>>`。
+
+**bwd prep**（`__global__ void moe_prepare_experts_bwd_device`）：结构同 fwd，但产出新 struct `MoeGroupedGemmBwdExpert`，字段为 `dy_ptr = dy + (int64_t)row_begin * N`、`dx_ptr = dx + (int64_t)row_begin * K`、`packed_weight_codes_ptr = w_codes + (int64_t)e * N * (K >> 1)`、`weight_scales_ptr = w_scales + (int64_t)e * N * (K >> 5)`、row/stride 元数据（同 fwd 的 `(int64_t)` 提升）。
+
+> `MoeGroupedGemmExpert` 已是 POD（纯字段、无方法），可直接在 device 上聚合赋值 `experts[e] = {...}`，无需改 struct。新增的 bwd 描述符同样定义为 POD。
+
+### 2. 新增 bwd 描述符 struct
+
+紧邻现有 `MoeGroupedGemmExpert`（[143-160](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L143-L160)）新增：
+
+```cpp
+struct MoeGroupedGemmBwdExpert {
+  int expert_id, row_begin, row_count, output_n, input_k, block_count;
+  const __nv_bfloat16* dy_ptr;
+  const std::uint8_t* packed_weight_codes_ptr;
+  const std::uint8_t* weight_scales_ptr;
+  float* dx_ptr;
+  int64_t dy_row_stride, dx_row_stride,
+          weight_expert_stride, weight_scale_expert_stride;
+};
+```
+
+### 3. 新增 host launcher（类似 vLLM 的 `run_get_group_gemm_starts`）
+
+仿 vLLM `references/vllm/.../nvfp4_blockwise_moe_kernel.cu:150-200` 的 `run_get_group_gemm_starts`，新增两个 host 函数（fwd/bwd 各一）作为 prep 的 host 入口，集中负责**确定设备型号/索引 + device_guard + 取 stream + 发射 prep kernel**：
+
+```cpp
+void moe_run_prepare_experts_fwd(
+    MoeGroupedGemmExpert* experts,            // device 描述符缓冲（已分配）
+    const torch::Tensor& activation_codes,    // 仅用于取 device 与基址
+    const torch::Tensor& activation_scales,
+    const torch::Tensor& packed_weight_codes,
+    const torch::Tensor& weight_scales,
+    torch::Tensor& output,
+    const torch::Tensor& expert_offsets,
+    int M, int N, int K, int E) {
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(activation_codes)); // 设备确定 + guard
+  auto stream = at::cuda::getCurrentCUDAStream();                                // 当前 stream
+  moe_prepare_experts_fwd_device<<<ceil(E/128), 128, 0, stream>>>(
+      experts, activation_codes.data_ptr<uint8_t>(), activation_scales.data_ptr<uint8_t>(),
+      packed_weight_codes.data_ptr<uint8_t>(), weight_scales.data_ptr<uint8_t>(),
+      output.data_ptr<float>(), expert_offsets.data_ptr<int32_t>(), M, N, K, E);
+}
+```
+
+- fwd/bwd wrapper 各自：分配输出 `output`/`dx` → 分配 `experts_buf`（`torch::empty({(int64_t)E * sizeof(MoeGroupedGemmExpert)}, options.dtype(kByte))`，`reinterpret_cast` 为描述符指针；bwd 用 `sizeof(MoeGroupedGemmBwdExpert)`）→ 调用对应 `moe_run_prepare_experts_*` → 再把 `experts`（+ `expert_offsets`）传给 strict 内核。
+- device_guard / stream 逻辑集中在 launcher 内，与 vLLM `run_get_group_gemm_starts` 的结构对齐，wrapper 不再各自散落。
+- 保留现有 wrapper 顶部的 `moe_copy_offsets` 校验（front=0/back=M/非递减）——仅 wrapper validation，非数值路径；数值 prep 已不依赖它。
+
+### 4. strict 内核改为消费 device 描述符
+
+**fwd** `moe_grouped_gemm_fwd_strict`（[321-360](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L321-L360)）签名改为：
+
+```cpp
+(const MoeGroupedGemmExpert* __restrict__ experts,
+ const int32_t* __restrict__ expert_offsets, int M, int N, int K, int E)
+```
+
+线程内：
+- `m = idx/N; n = idx%N; e = moe_find_expert(m, expert_offsets, E)`（路由仍用紧凑 offsets 二分，不变）；
+- 取 `const auto& ex = experts[e];`，行内偏移 `dr = m - ex.row_begin`；
+- `a_row  = ex.activation_codes_ptr  + dr*ex.activation_row_stride;`
+- `a_srow = ex.activation_scales_ptr + dr*ex.activation_scale_row_stride;`
+- `w_row  = ex.packed_weight_codes_ptr + n*(K>>1);`
+- `w_srow = ex.weight_scales_ptr       + n*ex.block_count;`
+- 写出 `out = ex.output_ptr + dr*ex.output_row_stride + n;`
+- 块内 32 点积、`(partial*sa)*sw`、`__fmul_rn/__fadd_rn` **逐行保持不变**。
+
+**bwd** `moe_grouped_gemm_bwd_strict`（[364-400](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L364-L400)）同理改为消费 `MoeGroupedGemmBwdExpert*`，`dy_row = ex.dy_ptr + dr*ex.dy_row_stride`，`dx = ex.dx_ptr + dr*ex.dx_row_stride + k`，w 指针用 `ex.packed_weight_codes_ptr`/`ex.weight_scales_ptr`，dequant→BF16 的串行 n 累加逻辑不变。
+
+### 5. 更新发射函数 + 删除死代码
+
+- `moe_launch_grouped_gemm_fwd_strict` / `_bwd_strict`（[404-425](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L404-L425)）参数改为收 `experts`（+ offsets），不再收 4 个平铺基址指针。
+- 删除 host `moe_prepare_experts`（[225-264](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L225-L264)）；偏移计算逻辑已搬进 device prep kernel。
+- **删除未使用的 `MoeGroupedGemmArgs`（[162-174](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L162-L174)）与 `MoeGroupedGemmBackwardArgs`（[176-187](RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu#L176-L187)）结构体**。
+- `MoeQuantizeArgs`（P5-1 用）与 `moe_check_h100_sm90` 本次不动（P5-1 不在范围）。
+
+## P5_4 §4/§6 落地检查（本次改动必须满足）
+
+### strict one-row unpadded geometry（§4）
+
+本次 strict 路径的 launch geometry 保持并**显式明确**为 one-row unpadded：
+
+- **fwd** `moe_grouped_gemm_fwd_strict`：flat 1D grid `ceil(M*N / kMoeStrictBlock)` 块 × `kMoeStrictBlock` 线程，每线程算一个输出元素 `(m,n)`，K 方向 `j` 升序、块内 `k` 升序**串行**归约；`moe_find_expert` 按 `expert_offsets` 二分路由。
+- **bwd** `moe_grouped_gemm_bwd_strict`：同构，每线程算 `(m,k)`，`n` 升序串行归约。
+
+无 split-K、无 atomic merge、无 workspace、无 M/N/K tile、无 padding；scale 括号顺序 `(partial*sa)*sw` 固定；`__fmul_rn`/`__fadd_rn` 禁 FMA。这与 `CudaP5GemmProvider.capabilities()["geometry"]=["one-row"]`（[provider.py:256-265](RL_KERNEL/rl_engine/moe/provider.py#L256-L265)）及文件顶部 `strict: one-row/unpadded` 注释一致，即 "one-row" 参考几何；解码语义与 oracle 逐位一致（`与 Miles decode 一致`）。
+
+> 术语澄清：此处 "one-row" = 每个输出元素完全在单线程内串行归约、不跨线程/跨行做归约（区别于 "packed" 的 M-tile / split-K / batch 几何），而非字面 "一个线程算一整行"。本次不引入 packed（WGMMA）路径，strict 即 one-row 参考。
+
+### geometry byte-equal gate（§6）
+
+门禁 `fwd(packed)[r] == fwd(one-row)` 针对 "packed"（WGMMA/tiled/batched）路径与 "one-row" 参考的比较。**本次 PR 不交付 packed 路径**，故门禁**平凡满足**（strict 本身即 one-row 参考，无 packed 可比较）。若后续交付 WGMMA 路径，必须：独立 numeric profile + 与 oracle 的 max-diff 报告，且不得静默顶替 strict path——该约束写入下方「备注」。
+
+### provenance（§6）
+
+`CudaP5GemmProvider.provenance()`（[provider.py:267-273](RL_KERNEL/rl_engine/moe/provider.py#L267-L273)）目前缺 tile/split-K 配置与 kernel/build fingerprint，需扩展为：
+
+```python
+def provenance(self) -> dict[str, Any]:
+    return {
+        "requested_backend": self.name,
+        "actual_backend": "cuda-strict",
+        "numeric_profile": self.numeric_profile,       # "p5-strict-ffma-v1"
+        "geometry": "one-row-unpadded",
+        "tile": None,          # 无 tiling
+        "split_k": 1,          # 无 split-K
+        "kernel_fingerprint": "mxfp8-mxfp4-grouped-gemm-strict-v1",
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+    }
+```
+
+`capabilities()`（[provider.py:256-265](RL_KERNEL/rl_engine/moe/provider.py#L256-L265)）已声明 `geometry ["one-row"]`、`implemented [fwd,bwd]`，无需改。`kernel_fingerprint` 字符串与 `.cu` 内新增的 `constexpr const char* kMoeGroupedGemmKernelFingerprint` 保持一字一致（单一事实源，人工同步）。
+
+### 无 dW / base weight packed bytes 不变（§6）
+
+- bwd 只回 `dX`，签名无 `dW`、无 `saved`（wrapper 不分配任何 weight grad）。
+- base weight 全程 packed：`w.codes`/`w.scales` 只读，dequant 仅在 kernel register 内进行，**不写回 global**。Step 4 对拍时断言 `w.codes`/`w.scales` 的 sha256 前后不变。
+
+## 函数上下游关系（text 图）
+
+约定：★ = host 函数（需自动化正确性测试）；▽ = device 内核（不单独测，手动 debug）。
+
+```text
+依赖方向：上游（顶层）→ 下游（底层）。箭头 = 调用 / 产出。
+
+FWD 链路
+─────────────────────────────────────────────────────────────────────────────
+[Python] provider.py mxfp8_mxfp4_grouped_gemm_fwd(a:MXTensor, w:MXTensor, offsets)
+      │  拆包 a.codes/a.scales、w.codes/w.scales（不改）
+      ▼
+★ [Host] moe_mxfp8_mxfp4_grouped_gemm_forward(codes, scales, w_codes, w_scales, offsets)
+      │  ①校验 ②分配 Y ③分配 experts_buf ④调 prep launcher ⑤调 GEMM launch
+      ├──────────────────────────────┬─────────────────────────────────┐
+      ▼                              ▼                                 ▼
+★ [Host] moe_run_prepare_experts_fwd      ★ [Host] moe_launch_grouped_gemm_fwd_strict
+      │  device_guard + stream           │  grid/block
+      ▼                                  ▼
+▽ [Dev] moe_prepare_experts_fwd_device    ▽ [Dev] moe_grouped_gemm_fwd_strict(experts,...)
+      │  写 experts[e]={row,ptr,stride}   │  moe_find_expert + 解码(e4m3/e2m1/e8m0)
+      ▼                                  │  读 experts[e] → 累加 → 写 Y[m,n]
+   experts[]（device 描述符数组 [E]）─────┘
+                                 ▼
+                            Y（FP32 [M,N]）
+
+BWD 链路（同构，dy + w → dX，无 dW）
+★ [Host] moe_mxfp8_mxfp4_grouped_gemm_backward(dy, w_codes, w_scales, offsets)
+      ├─► ★ moe_run_prepare_experts_bwd → ▽ moe_prepare_experts_bwd_device → experts_bwd[]
+      └─► ★ moe_launch_grouped_gemm_bwd_strict → ▽ moe_grouped_gemm_bwd_strict → dX（FP32 [M,K]）
+```
+
+## 关键文件
+
+- `RL_KERNEL/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu` —— 主要改动文件（新增 2 个 prep kernel + 1 个 bwd 描述符 + 1 个 `constexpr` 指纹，改 2 个 strict 内核签名 + 2 个 wrapper + 2 个 launch，删 1 个 host 函数）。
+- `RL_KERNEL/rl_engine/moe/provider.py` —— 仅改 `CudaP5GemmProvider.provenance()`（补 geometry/tile/split_k/kernel_fingerprint/cuda_version 字段），其余不动。
+- 参考（只读）：`references/vllm/csrc/libtorch_stable/quantization/fp4/nvfp4_blockwise_moe_kernel.cu:54-118`（prep kernel 范式）；`scripts/check_p5.py`（端到端验收入口）。
+
+## 实现顺序与测试（自底向上，每个 host 函数完成即测）
+
+> 约定：★ host 函数需自动化正确性测试；▽ device 内核不单独测（手动 debug）。
+> 每步都先 `python setup.py build_ext --inplace` 编译通过，再跑对应测试，通过后才进入下一步。
+
+**Step 0 —— 结构清理（无测试，编译通过即可）**
+- 删 `MoeGroupedGemmArgs`、`MoeGroupedGemmBackwardArgs`；新增 `MoeGroupedGemmBwdExpert`。
+
+**Step 1 —— prep（▽ prep kernel + ★ launcher）**
+- 实现 `moe_prepare_experts_fwd_device` / `_bwd_device`；实现 ★ `moe_run_prepare_experts_fwd` / `_bwd`（device_guard + stream + 发射 prep）。
+- 【测 ★ launcher】跑 launcher 后把 `experts_buf` 拷回 CPU，逐项断言：
+  - `experts[e].row_begin == offsets[e]`
+  - `experts[e].row_count == offsets[e+1] - offsets[e]`
+  - `(experts[e].activation_codes_ptr - a_codes_base) == row_begin * K`（及 w/scale/out 指针偏移、各 stride 一致）
+  - 覆盖：多 expert + 空 group（`row_count==0`）。
+
+**Step 2 —— GEMM 消费描述符（▽ strict 内核 + ★ GEMM launch）**
+- 改 `moe_grouped_gemm_fwd_strict` / `_bwd_strict` 签名收 `experts`；改 ★ `moe_launch_grouped_gemm_fwd_strict` / `_bwd_strict`。
+- 【测】通过 wrapper 半成品（或临时入口）跑 fwd/bwd，对拍 oracle（`rtol=0,atol=0`）。
+- 覆盖：`M=1` 单行、空 group、`K%32==0`、多 expert。
+
+**Step 3 —— wire ★ 两个顶层 wrapper**
+- wrapper 分配 `experts_buf` + 调 launcher + 调 GEMM launch。
+- 【测】端到端：`_C.moe_mxfp8_mxfp4_grouped_gemm_forward/backward` 对拍 oracle，bit 级一致。
+- 顺带断言：数值路径无 `moe_copy_offsets` / `.to(kCPU)` host sync（仅 wrapper 校验保留）。
+
+**Step 4 —— provenance + 指纹 + 无 dW 断言（★ Python）**
+- `.cu` 内加 `constexpr const char* kMoeGroupedGemmKernelFingerprint = "mxfp8-mxfp4-grouped-gemm-strict-v1"`。
+- 改 `CudaP5GemmProvider.provenance()`：补 `geometry/tile/split_k/kernel_fingerprint/cuda_version`（`kernel_fingerprint` 与 `.cu` 常量一致）。
+- 【测】`resolve_provider("cuda").provenance()` 返回上述字段；`capabilities()["geometry"]==["one-row"]` 且 `implemented` 含 fwd/bwd。
+
+**Step 5 —— 端到端验收（★ 全链路）**
+- 跑 `python scripts/check_p5.py --provider cuda --device cuda`：所有 e2e case（含 `uneven_experts` 空 group）PASS，`y/dx` 与 oracle 逐字节一致（sha256 相等）。
+- 顺带断言：base weight 无 dW（`w.codes`/`w.scales` sha256 前后不变）；bwd 只回 `dX`。
+
+对拍输入构造（复用 oracle）：`a = mx_quantize(x, "e4m3")` 造 a.codes/a.scales；造 `w`（E2M1 codes/scales）与 `expert_offsets`；`y_native` 与 `oracle.mxfp8_mxfp4_grouped_gemm_fwd(a, w, offsets)` 逐字节比较；bwd 同理对 `oracle.mxfp8_mxfp4_grouped_gemm_bwd`。
+
+## 备注（非本次范围）
+
+- P5-1 激活量化（`moe_mxfp8_act_quant_forward` 仍 fail-closed）**不改**。
+- WGMMA / CUTLASS ptr-array 性能路径仍保持独立、不引入；本次只是把 strict 路径的 prep 设备化。
+- 若后续交付 WGMMA（packed）路径：必须通过 `fwd(packed)[r] == fwd(one-row)` geometry 门禁；做不到则 strict path 明确降级 one-row、packed 单独 benchmark，并登记独立 numeric profile + 与 oracle 的 max-diff 报告，**禁止静默顶替 strict path**。`expert_tensor_parallel_size = 1`（不切 TP，单卡），本内核不涉及。

--- a/P5_4_triton_plan.md
+++ b/P5_4_triton_plan.md
@@ -1,0 +1,144 @@
+# P5-4 Triton 版本实现计划（mxfp8×mxfp4 grouped GEMM，bit-exact strict）
+
+## 背景（Context）
+
+P5-4 grouped GEMM 现有两条链路：FP32 oracle（`oracle.py`，黄金字节）与 CUDA strict（`csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu`，H100/SM90 专用，`__fmul_rn`/`__fadd_rn` 逐位一致）。CUDA strict 在 prep kernel 启动前经 `moe_check_h100_sm90` 强制 SM90（非 SM90 设备 fail-closed）。
+
+本次新增一条 **Triton 后端**：实现 `mxfp8_mxfp4_grouped_gemm_fwd/bwd`，数值语义与 oracle **逐位一致（bit-exact strict）**，从而能通过 `scripts/check_p5.py` 的 sha256 门禁。同样**仅适配 SM90（H100）**，不追求非 H100 / ROCm 可移植性。代码结构镜像 CUDA 文件（prep kernel / 传参 struct / 计算层），统一英文 banner 注释。
+
+**已确认的两个决策**：
+- Scope：**仅 P5-4 grouped GEMM**（fwd+bwd），其余算子（P5-1/2/3/5）留在 oracle 上。
+- 数值：**bit-exact strict**（逐元素 mul/add 无 FMA，串行升序归约），不用 `tl.dot`。
+
+## 范围与接入
+
+- 新增文件 `rl_engine/moe/triton_grouped_gemm.py`（含 Triton 内核 + `TritonP5GemmProvider`）。
+- 改 `rl_engine/moe/provider.py`：`resolve_provider` 的 `aliases` 增加 `"triton": "rl_engine.moe.triton_grouped_gemm:TritonP5GemmProvider"`（与 `"cuda"` 并列）。
+- **不改**：`ops.cpp`、`MXTensor`、`oracle.py`、`mx_format.py`、`check_p5.py`、`.cu`。
+- fail-closed：triton 未安装时 `TritonP5GemmProvider` 构造/调用必须 raise，禁止静默回退 oracle；与 `CudaP5GemmProvider` 对齐（独立 numeric profile，不顶替 strict path）。
+
+## 数值契约（bit-exact，逐位对齐 oracle）
+
+Triton 内核必须**精确复现** oracle 的归约顺序与舍入；任何一处 FMA 融合都会导致 sha256 失配。
+
+### fwd（对齐 `oracle.mxfp8_mxfp4_grouped_gemm_fwd` + `_block_scaled_dot`）
+
+对每个输出元素 `(m, n)`，按以下冻结顺序：
+
+```
+acc = 0
+for j in 0 .. K/32-1:                      # 块升序
+    partial = 0
+    for kk in j*32 .. (j+1)*32-1:          # 块内升序 k
+        partial = fadd_rn(partial, fmul_rn(a_elems[m,kk], w_elems[n,kk]))
+    acc = fadd_rn(acc, fmul_rn(fmul_rn(partial, sa[m,j]), sw[n,j]))   # (partial*sa)*sw
+```
+
+- decode 全精确（e4m3/e2m1/e8m0 → fp32 无舍入）。
+- 关键：块内 partial 先算完 32 次 mul/add，**再**乘 `sa`、`sw`，最后累加进 `acc`；括号顺序 `(partial*sa)*sw` 冻结。
+
+### bwd（对齐 `oracle.mxfp8_mxfp4_grouped_gemm_bwd` + `_serial_dot`）
+
+```
+# 先 dequant W 到 BF16（每 expert，寄存器内，不写回 global）
+w_full[n,k] = e2m1_decode(w_codes[n,k]) * e8m0_decode(w_scales[n, k//32])   # fp32, block-32 scale 折叠
+w_bf16[n,k] = round_bf16(w_full[n,k])                                       # fp32 -> BF16 RNE
+
+# 再归约（升序 n，无 block-scale 在归约中）
+dx[m,k] = 0
+for n in 0 .. N-1:                          # 升序 n
+    dx = fadd_rn(dx, fmul_rn(to_fp32(dy_bf16[m,n]), to_fp32(w_bf16[n,k])))
+```
+
+- **注意**：bwd 与 fwd 归约语义不同 —— bwd 先把 scale 折进 W 并 round 到 BF16，归约只在 N 上做，无 per-32-block 结构。dy 输入为 BF16。
+
+### 舍入手段
+
+- 禁用 `tl.dot`（张量核 FFMA，非逐位）。用逐元素 `fmul_rn`/`fadd_rn`（Triton libdevice `__nv_fmul_rn`/`__nv_fadd_rn`，对应 CUDA 的 `__fmul_rn`/`__fadd_rn`）。
+- 若 Triton 版本无显式 `fmul_rn`，退化为 `*`/`+` 并**关闭 FMA 收缩**；以 `check_p5.py` 的 sha256 为最终判定（一旦失配即视为收缩未被关闭）。
+- decode 用 **算术解码**（位运算 + 指数缩放，无查表）：e4m3/e2m1/e8m0 → fp32 全精确无舍入，镜像 `.cu` 的 `moe_e4m3_to_f32`/`moe_e2m1_nibble_to_f32`/`moe_e8m0_to_f32`（`ldexp`/`2**k` 语义，避免 `powf` 引入误差）。e2m1 的 8 个幅值 {0,0.5,1,1.5,2,3,4,6} 在 fp32 全精确。
+- BF16 舍入**必须用 `tl.cast(x, tl.bfloat16)`（RNE）**，对齐 `torch.Tensor.to(bfloat16)` 与 CUDA `__float2bfloat16`，禁止 RTZ（截断）；以 `check_p5.py` 的 sha256 为最终判定。
+
+## 文件结构
+
+```
+rl_engine/moe/triton_grouped_gemm.py
+├── module docstring（SPDX + 用途 + numeric profile + fail-closed 说明）
+├── triton availability guard（try import triton / tl；失败置 _TRITON_AVAILABLE=False）
+├── 常量：_KERNEL_FINGERPRINT（`"mxfp8-mxfp4-grouped-gemm-strict-triton-v1"`，与 CUDA 指纹不同，by design）、pinned BM/BN、block=32
+├── launch descriptor struct（dataclass 镜像 C struct）
+├── decode helpers（lookup table 生成 + @triton.jit decode）
+├── prep kernel（@triton.jit）
+├── fwd and bwd strict compute kernel（@triton.jit ×2）
+├── host launcher（python：分配 descriptor buffer + launch prep + launch compute）
+└── provider（TritonP5GemmProvider）
+```
+
+## 注释风格规范（统一，本次核心要求）
+
+采用单行 banner，英文小写 section 名，镜像 `.cu` 的 `/* ************ section ************ */` 形式：
+
+```python
+# ********************** launch descriptor struct **********************
+```
+
+规则：
+1. 每个功能段顶部一个 banner；`# ` 前缀，section 名两侧各 ≥22 个 `*`，左右对称。
+2. section 名英文小写，与 `.cu` 对应段同名（见下方分节）。
+3. 行内注释统一英文、祈使/陈述语气一致（与 `.cu` 现有注释一致）。
+4. 保留字段（`weight_expert_stride`/`weight_scale_expert_stride`）照抄 `.cu` 的反删除注释。
+
+## 分节结构（每节一个 banner）
+
+1. **launch descriptor struct**
+   - 定义 `MoeGroupedGemmExpert`（fwd，16 字段）与 `MoeGroupedGemmBwdExpert`（bwd，14 字段）两个 dataclass，字段名/顺序镜像 `.cu` 同名 struct。
+   - Triton 无 C struct：descriptor 用 int64 tensor `[E, n_fields]` 表达，`n_fields`=字段数；「指针」→ int64 字节偏移，「stride」→ int64 常量列。每列即一个字段。
+   - 保留 `weight_expert_stride`/`weight_scale_expert_stride` 两列 + 反删除注释（future WGMMA per-expert grouped GEMM，strict one-row 不读）。
+
+2. **decode helpers**
+   - `@triton.jit` 侧（算术解码，无 host 查表）：`decode_e4m3(code)` / `decode_e2m1(nibble)` / `decode_e8m0(scale)`，纯位运算 + 指数缩放，无舍入；镜像 `.cu` 的三个 codec。
+   - BF16 舍入：`round_bf16(fp32)` 用 `tl.cast(_, tl.bfloat16)`（RNE），对齐 `torch.Tensor.to(bfloat16)` / CUDA `__float2bfloat16`，禁止 RTZ。
+
+3. **prep kernel**
+   - 镜像 CUDA 的 device-side prep：`@triton.jit`，grid `(E,)`，每个 program 读 `expert_offsets[e]`、`expert_offsets[e+1]`，计算 `row_begin/row_count` 及派生偏移，写入 descriptor tensor `[E, n_fields]`。
+   - `expert_offsets` 直接从 device 读，**不 copy 到 host**（与 CUDA prep 一致，避免 host sync）。
+
+4. **fwd and bwd strict compute kernel**
+   - fwd：grid `(cdiv(M,BM), cdiv(N,BN))`；每个 program 算一个 BM×BN 输出 tile，每元素寄存器内按「fwd 数值契约」串行升序 k（含 32-block 结构）归约。
+   - bwd：grid `(cdiv(M,BM), cdiv(K,BK))`；每元素按「bwd 数值契约」先 dequant W 到 BF16（寄存器内），再串行升序 n 归约。
+   - 专家路由：`find_expert(m)` 用**固定 `ceil(log2 E)` 次展开的二分**（E 为 kernel 常量，迭代次数确定），避免数据依赖循环；空 group 天然被跳过（无 m 落进）。
+   - BM/BN/BK pinned（如 16/16/16），**无 autotune**（保证确定性，对齐 det_gemm.py 的「autotune disabled」惯例）。
+   - 空 group（`row_count==0`）直接跳过，不写输出。
+
+5. **host launcher**
+   - python 侧：`triton_grouped_gemm_fwd(a, w, expert_offsets)` / `_bwd(...)`。
+   - 分配 descriptor buffer（`torch.empty([E, n_fields], int64, device)`）→ launch prep → launch compute，返回 `[M,N]` / `[M,K]` fp32。
+   - 入参校验：`a/w` 为 `MXTensor`（e4m3/e2m1）、tensor is_cuda/contiguous、`expert_offsets` int32 且首 0 末 M 非递减（复用 `contract` 校验，不引入新逻辑）。
+
+6. **provider**
+   - `TritonP5GemmProvider(ReferenceProvider)`：只 override `mxfp8_mxfp4_grouped_gemm_fwd/bwd`，其余留在 oracle。
+   - `name="triton-p5-gemm"`，`numeric_profile="p5-strict-triton-v1"`。
+   - `capabilities()`：`backend="triton-p5-strict"`、`geometry=["one-row"]`、`devices=["cuda-sm90"]`、`implemented=["mxfp8_mxfp4_grouped_gemm_fwd", "mxfp8_mxfp4_grouped_gemm_bwd"]`。
+   - `provenance()`：补 `geometry/tile/split_k/kernel_fingerprint/triton_version/cuda_version`；`kernel_fingerprint` 与模块内 `_KERNEL_FINGERPRINT` 常量逐字一致（单一事实源，人工同步），`_KERNEL_FINGERPRINT = "mxfp8-mxfp4-grouped-gemm-strict-triton-v1"`。
+   - ⚠️ **此 Triton 指纹与 CUDA 指纹（`"mxfp8-mxfp4-grouped-gemm-strict-v1"`）不同，且这是有意为之（by design）**——两者是不同的后端 / numeric profile，绝不能复用同一指纹。
+   - fail-closed：`_TRITON_AVAILABLE` 为假时 raise；设备非 SM90 时 raise（镜像 `moe_check_h100_sm90`，仅适配 SM90）。
+
+## 验证
+
+在有 GPU（CUDA/ROCm）的机器上：
+
+```
+python scripts/check_p5.py --provider triton --device cuda
+```
+
+- 所有 e2e case（含 `uneven_experts` 空 group）PASS，`y/dx` 与 oracle 逐字节一致（sha256 相等）。
+- 顺带断言：base weight 无 dW（`w.codes`/`w.scales` sha256 前后不变）；bwd 只回 `dX`。
+- 断言 `resolve_provider("triton").provenance()` 含上述字段；`capabilities()["geometry"]==["one-row"]`。
+
+对拍输入复用 oracle/fixtures：`a=mx_quantize(x,"e4m3")`、`w`（e2m1 codes/scales）、`expert_offsets`；`y_triton` vs `oracle.mxfp8_mxfp4_grouped_gemm_fwd(a,w,offsets)` 逐位；bwd 同理。
+
+## 备注（非本次范围）
+
+- P5-1/2/3/5 不动；P5-1 激活量化仍 fail-closed。
+- `tl.dot`（WGMMA/tensor-core）性能路径 = 独立 numeric profile + 与 oracle 的 max-diff 报告，本次不交付；不得静默顶替 strict path（与 `P5_4_plan.md` 备注一致）。
+- 本次 Triton strict 为可移植参考实现（慢于 tuned GEMM，符合 one-row 参考定位）。

--- a/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu
+++ b/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu
@@ -1,0 +1,625 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+//
+// P5 CUDA interface skeleton (P5-1 / P5-4).
+//
+// Implementation steps (strict path):
+//   1. Quantize each input row in independent 32-element blocks and write
+//      separate E4M3 code bytes and E8M0 scale bytes.
+//   2. Keep W packed as E2M1 nibbles; decode only in registers/shared memory.
+//   3. Route contiguous row ranges using expert_offsets and skip empty groups.
+//   4. Accumulate each 32-wide partial in ascending K order with explicit
+//      FP32 multiply/add, then apply (partial * scale_a) * scale_w.
+//   5. Implement FC1 and FC2 through the same aligned [M,K] x [E,N,K]
+//      contract; backward writes only FP32 dX and never dW.
+//
+// The strict P5-4 grouped-GEMM kernels (forward + dX-only backward) are
+// implemented below. The P5-1 activation-quantization entry point is still
+// fail-closed, so a provider cannot silently claim full P5 support.
+//
+// ABI and address contract:
+//   P5-1 input_ptr:              BF16/FP32 [M,K], row-major, K contiguous.
+//   P5-1 activation_codes_ptr:   uint8 E4M3 [M,K], row-major, K contiguous.
+//   P5-1 activation_scales_ptr:  uint8 E8M0 [M,K/32].
+//       activation_scales_ptr[m*(K/32) + (k/32)] scales
+//       activation_codes_ptr[m*K + k].
+//   P5-4 packed_weight_codes_ptr: uint8 E2M1 [E,N,K/2], K contiguous;
+//       low nibble is even k and high nibble is odd k.
+//   P5-4 weight_scales_ptr:      uint8 E8M0 [E,N,K/32].
+//   P5-4 expert_offsets_ptr:     int32 [E+1], non-decreasing, first 0, last M.
+//   codes_ptr and scales_ptr are separate allocations/pointers. Never derive
+//   one address from the other, and never write dequantized W to global memory.
+//
+// Aligned call sites:
+//   FC1: A [M,hidden], W1 [E,2*ffn,hidden], Y1 FP32 [M,2*ffn].
+//        Y1[:, :ffn] is gate; Y1[:, ffn:] is up.
+//   FC2: A [M,ffn], W2 [E,hidden,ffn], Y2 FP32 [M,hidden].
+//   Both require K % 32 == 0. M may be 1; empty expert groups are valid.
+//
+// Numeric profiles:
+//   strict: one-row/unpadded geometry, ascending serial reduction, no split-K,
+//           no atomics, no fused multiply-add reassociation.
+//   WGMMA is deliberately not implemented in this skeleton. A future
+//   performance path must use a separate numeric profile and provenance.
+
+
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime_api.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+// Namespace-local names avoid collisions with existing FUSED_LOGP_* macros and
+// the unrelated K_TREE_LEAF constant in det_gemm_kernel.cu.
+constexpr int kMoeMxBlockSize = 32;
+constexpr int kMoeE8m0Bias = 127;
+constexpr int kMoeE4m3ExponentMax = 8;
+constexpr int kMoeE2m1ExponentMax = 2;
+constexpr int kMoeE4m3MaxFinite = 448;
+constexpr int kMoeE2m1MaxFinite = 6;
+
+// Single source of truth for the strict numeric-profile fingerprint. Must match
+// CudaP5GemmProvider.provenance()["kernel_fingerprint"] in
+// rl_engine/moe/provider.py character-for-character (manually synced).
+constexpr const char* kMoeGroupedGemmKernelFingerprint =
+    "mxfp8-mxfp4-grouped-gemm-strict-v1";
+
+/****************************** launch descriptor structs***********/
+
+struct MoeQuantizeArgs {
+  const void* input_ptr;                 // BF16/FP32 [M,K]
+  std::uint8_t* activation_codes_ptr;   // E4M3 uint8 [M,K]
+  std::uint8_t* activation_scales_ptr;  // E8M0 uint8 [M,K/32]
+  int rows_m;
+  int input_k;
+};
+
+// These descriptors mirror the vLLM grouped-pointer preparation pattern, but
+// retain P5's independent code/scale allocations and [E+1] interval offsets.
+// They are written on device by the prep kernels and consumed by the strict
+// GEMM kernels (the strict path is fully device-side).
+struct MoeGroupedGemmExpert {
+  int expert_id;
+  int row_begin;
+  int row_count;
+  int output_n;
+  int input_k;
+  int block_count;
+  const std::uint8_t* activation_codes_ptr;   // row_begin * K bytes
+  const std::uint8_t* activation_scales_ptr;  // row_begin * (K/32) bytes
+  const std::uint8_t* packed_weight_codes_ptr; // e * N * (K/2) bytes
+  const std::uint8_t* weight_scales_ptr;      // e * N * (K/32) bytes
+  float* output_ptr;                           // row_begin * N floats
+  int64_t activation_row_stride;
+  int64_t activation_scale_row_stride;
+  // Reserved for the future WGMMA per-expert grouped-GEMM path, which strides
+  // experts by N*(K/2) / N*(K/32). Unread by the strict one-row kernel — do not
+  // delete.
+  int64_t weight_expert_stride;
+  int64_t weight_scale_expert_stride;
+  int64_t output_row_stride;
+};
+
+// Backward descriptor: mirrors MoeGroupedGemmExpert's grouped-pointer layout,
+// but the backward reads dy/w and writes dX only (no output, no dW).
+struct MoeGroupedGemmBwdExpert {
+  int expert_id;
+  int row_begin;
+  int row_count;
+  int output_n;
+  int input_k;
+  int block_count;
+  const __nv_bfloat16* dy_ptr;                 // row_begin * N BF16
+  const std::uint8_t* packed_weight_codes_ptr; // e * N * (K/2) bytes
+  const std::uint8_t* weight_scales_ptr;       // e * N * (K/32) bytes
+  float* dx_ptr;                               // row_begin * K floats
+  int64_t dy_row_stride;
+  int64_t dx_row_stride;
+  // Reserved for the future WGMMA per-expert grouped-GEMM path, which strides
+  // experts by N*(K/2) / N*(K/32). Unread by the strict one-row kernel — do not
+  // delete.
+  int64_t weight_expert_stride;
+  int64_t weight_scale_expert_stride;
+};
+
+
+//**********************check tools*********************** */
+void moe_check_cuda_contiguous(const torch::Tensor& tensor, const char* name) {
+  TORCH_CHECK(tensor.is_cuda(), name, " must be a CUDA tensor");
+  TORCH_CHECK(tensor.is_contiguous(), name, " must be contiguous");
+}
+
+void moe_check_same_device(const torch::Tensor& first,
+                          const torch::Tensor& other,
+                          const char* name) {
+  TORCH_CHECK(other.device() == first.device(), name,
+              " must be on the same device as the first tensor");
+}
+
+// P5 offsets live on CUDA. Copying this small metadata vector to CPU is only
+// wrapper validation; future launches must keep all data and dequantization on
+// device and must not use this path as a numerical implementation.
+std::vector<std::int32_t> moe_copy_offsets(const torch::Tensor& offsets) {
+  auto host = offsets.to(torch::kCPU).contiguous();
+  const auto* data = host.data_ptr<std::int32_t>();
+  return std::vector<std::int32_t>(data, data + host.numel());
+}
+
+void moe_check_h100_sm90(const torch::Tensor& tensor) {
+#if defined(RL_KERNEL_ENABLE_SM90) || defined(KERNEL_ALIGN_WITH_SM90)
+  cudaDeviceProp properties{};
+  TORCH_CHECK(cudaGetDeviceProperties(&properties, tensor.get_device()) == cudaSuccess,
+              "P5-4 failed to query CUDA device properties");
+  TORCH_CHECK(properties.major == 9,
+              "P5-4 strict wrapper requires an H100/SM90 CUDA device, got compute capability ",
+              properties.major, ".", properties.minor, ".");
+#else
+  (void)tensor;
+  TORCH_CHECK(false,
+              "P5-4 strict wrapper is not compiled; build the H100/SM90 path first");
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Device-side expert descriptor preparation. Each expert's per-group pointers
+// and strides are computed on device from expert_offsets (read directly, never
+// copied to CPU) and written into a POD descriptor array [E]. The strict GEMM
+// kernels consume these descriptors instead of re-deriving base pointers.
+// ---------------------------------------------------------------------------
+
+constexpr int kMoePrepBlock = 128;
+
+// Forward prep: thread e builds MoeGroupedGemmExpert[e]. The activation/weight
+// base pointers sit at row_begin / e in the flat tensors; every offset is
+// promoted to int64 to avoid 32-bit overflow.
+__global__ void moe_prepare_experts_fwd_device(
+    MoeGroupedGemmExpert* __restrict__ experts,      // [E]
+    const std::uint8_t* __restrict__ a_codes,        // [M,K]
+    const std::uint8_t* __restrict__ a_scales,       // [M,K/32]
+    const std::uint8_t* __restrict__ w_codes,        // [E,N,K/2]
+    const std::uint8_t* __restrict__ w_scales,       // [E,N,K/32]
+    float* __restrict__ out,                         // [M,N]
+    const std::int32_t* __restrict__ expert_offsets, // [E+1]
+    int M, int N, int K, int E) {
+  const int e = blockIdx.x * blockDim.x + threadIdx.x;
+  if (e >= E) return;
+  const int row_begin = expert_offsets[e];
+  const int row_count = expert_offsets[e + 1] - row_begin;
+  const int blocks = K >> 5;
+  experts[e] = {
+      e,
+      row_begin,
+      row_count,
+      N,
+      K,
+      blocks,
+      a_codes + static_cast<std::int64_t>(row_begin) * K,
+      a_scales + static_cast<std::int64_t>(row_begin) * blocks,
+      w_codes + static_cast<std::int64_t>(e) * N * (K >> 1),
+      w_scales + static_cast<std::int64_t>(e) * N * blocks,
+      out + static_cast<std::int64_t>(row_begin) * N,
+      static_cast<std::int64_t>(K),
+      static_cast<std::int64_t>(blocks),
+      static_cast<std::int64_t>(N) * (K >> 1),
+      static_cast<std::int64_t>(N) * blocks,
+      static_cast<std::int64_t>(N),
+  };
+  (void)M;  //for wgmma
+}
+
+// Backward prep: same layout, but dy/dx replace activation/output. No output
+// pointer and no dW (frozen base); the bwd kernel reads dy/w and writes dX.
+__global__ void moe_prepare_experts_bwd_device(
+    MoeGroupedGemmBwdExpert* __restrict__ experts,   // [E]
+    const __nv_bfloat16* __restrict__ dy,            // [M,N]
+    const std::uint8_t* __restrict__ w_codes,        // [E,N,K/2]
+    const std::uint8_t* __restrict__ w_scales,       // [E,N,K/32]
+    float* __restrict__ dx,                          // [M,K]
+    const std::int32_t* __restrict__ expert_offsets, // [E+1]
+    int M, int N, int K, int E) {
+  const int e = blockIdx.x * blockDim.x + threadIdx.x;
+  if (e >= E) return;
+  const int row_begin = expert_offsets[e];
+  const int row_count = expert_offsets[e + 1] - row_begin;
+  const int blocks = K >> 5;
+  experts[e] = {
+      e,
+      row_begin,
+      row_count,
+      N,
+      K,
+      blocks,
+      dy + static_cast<std::int64_t>(row_begin) * N,
+      w_codes + static_cast<std::int64_t>(e) * N * (K >> 1),
+      w_scales + static_cast<std::int64_t>(e) * N * blocks,
+      dx + static_cast<std::int64_t>(row_begin) * K,
+      static_cast<std::int64_t>(N),
+      static_cast<std::int64_t>(K),
+      static_cast<std::int64_t>(N) * (K >> 1),
+      static_cast<std::int64_t>(N) * blocks,
+  };
+  (void)M;  //for wgmma
+}
+
+// Host entry for prep: device guard + current stream + launch the prep kernel.
+// Mirrors vLLM's run_get_group_gemm_starts (no alpha / cute layout / TMA assert
+// for P5). The caller owns experts_buf (a byte tensor reinterpreted as the
+// descriptor type).
+void moe_run_prepare_experts_fwd(
+    MoeGroupedGemmExpert* experts,
+    const torch::Tensor& activation_codes,
+    const torch::Tensor& activation_scales,
+    const torch::Tensor& packed_weight_codes,
+    const torch::Tensor& weight_scales,
+    torch::Tensor& output,
+    const torch::Tensor& expert_offsets,
+    int M, int N, int K, int E) {
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(activation_codes));
+  moe_check_h100_sm90(activation_codes);
+  auto stream = at::cuda::getCurrentCUDAStream();
+  const int grid = (E + kMoePrepBlock - 1) / kMoePrepBlock;
+  moe_prepare_experts_fwd_device<<<grid, kMoePrepBlock, 0, stream>>>(
+      experts,
+      activation_codes.data_ptr<std::uint8_t>(),
+      activation_scales.data_ptr<std::uint8_t>(),
+      packed_weight_codes.data_ptr<std::uint8_t>(),
+      weight_scales.data_ptr<std::uint8_t>(),
+      output.data_ptr<float>(),
+      expert_offsets.data_ptr<std::int32_t>(),
+      M, N, K, E);
+}
+
+void moe_run_prepare_experts_bwd(
+    MoeGroupedGemmBwdExpert* experts,
+    const torch::Tensor& dy,
+    const torch::Tensor& packed_weight_codes,
+    const torch::Tensor& weight_scales,
+    torch::Tensor& dx,
+    const torch::Tensor& expert_offsets,
+    int M, int N, int K, int E) {
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(dy));
+  moe_check_h100_sm90(dy);
+  auto stream = at::cuda::getCurrentCUDAStream();
+  const int grid = (E + kMoePrepBlock - 1) / kMoePrepBlock;
+  moe_prepare_experts_bwd_device<<<grid, kMoePrepBlock, 0, stream>>>(
+      experts,
+      reinterpret_cast<const __nv_bfloat16*>(dy.data_ptr<at::BFloat16>()),
+      packed_weight_codes.data_ptr<std::uint8_t>(),
+      weight_scales.data_ptr<std::uint8_t>(),
+      dx.data_ptr<float>(),
+      expert_offsets.data_ptr<std::int32_t>(),
+      M, N, K, E);
+}
+
+/*********MXFP8/4 turn fp32 and find expert for per token*********** */
+
+// ---------------------------------------------------------------------------
+// P5-4 strict numeric path (bit-exact vs rl_engine/moe/mx_format.py + oracle).
+// ---------------------------------------------------------------------------
+
+// OCP E4M3 ("float8_e4m3fn"): 1 sign (bit 7), 4 exp (bits 6..3), 3 mant
+// (bits 2..0), bias 7. exp == 0 is the subnormal 2^-6 * mant/8; exp in 1..15
+// is 2^(exp-7) * (1 + mant/8). exp == 15 with mant == 7 is NaN, which the
+// oracle's satfinite encode never produces, so it is not handled here.
+__device__ __forceinline__ float moe_e4m3_to_f32(std::uint8_t code) {
+  const std::uint32_t sign = code >> 7;
+  const std::uint32_t exp = (code >> 3) & 0xF;
+  const std::uint32_t mant = code & 0x7;
+  const float frac = static_cast<float>(mant) * (1.0f / 8.0f);
+  if (exp == 0) {
+    return sign ? -ldexpf(frac, -6) : ldexpf(frac, -6);
+  }
+  const float value = ldexpf(1.0f + frac, static_cast<int>(exp) - 7);
+  return sign ? -value : value;
+}
+
+// OCP E2M1 nibble (0..15): magnitude in {0, 0.5, 1, 1.5, 2, 3, 4, 6}, sign in
+// bit 3. The decoded value is exact in FP32.
+__device__ __forceinline__ float moe_e2m1_nibble_to_f32(std::uint8_t nibble) {
+  constexpr float kMag[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+  const float mag = kMag[nibble & 0x7];
+  return (nibble & 0x8) ? -mag : mag;
+}
+
+// OCP E8M0 scale: 2^(code - 127). Code 255 (NaN) is rejected by the wrapper.
+__device__ __forceinline__ float moe_e8m0_to_f32(std::uint8_t code) {
+  return ldexpf(1.0f, static_cast<int>(code) - 127);
+}
+
+// Rows are pre-sorted by expert; expert_offsets is non-decreasing with first 0
+// and last M. Returns the expert e such that offsets[e] <= m < offsets[e+1].
+// Empty groups are skipped automatically because no row m lands inside them.
+__device__ __forceinline__ int moe_find_expert(int m,
+                                              const std::int32_t* __restrict__ offsets,
+                                              int E) {
+  int lo = 0, hi = E - 1;
+  while (lo < hi) {
+    const int mid = (lo + hi + 1) >> 1;
+    if (offsets[mid] <= m) lo = mid; else hi = mid - 1;
+  }
+  return lo;
+}
+
+/******************fwd and bwd strict compute kernel************/
+
+
+// Forward: C[m,n] = sum over 32-blocks j of ((sum_k â_k * ŵ_k) * sa_j) * sw_j.
+// k ascends within each block; every multiply/add rounds separately via
+// __fmul_rn/__fadd_rn (no FMA), matching oracle._block_scaled_dot byte-for-byte.
+__global__ void moe_grouped_gemm_fwd_strict(
+    const MoeGroupedGemmExpert* __restrict__ experts,  // [E]
+    const std::int32_t* __restrict__ expert_offsets,   // [E+1]
+    int M, int N, int K, int E) {
+  const std::int64_t total = static_cast<std::int64_t>(M) * N;
+  const std::int64_t idx =
+      static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total) return;
+  const int m = static_cast<int>(idx / N);
+  const int n = static_cast<int>(idx % N);
+  const int e = moe_find_expert(m, expert_offsets, E);
+  const MoeGroupedGemmExpert& ex = experts[e];
+  const int dr = m - ex.row_begin;
+
+  const int blocks = K >> 5;
+  const std::uint8_t* a_row =
+      ex.activation_codes_ptr + dr * ex.activation_row_stride;
+  const std::uint8_t* a_srow =
+      ex.activation_scales_ptr + dr * ex.activation_scale_row_stride;
+  const std::uint8_t* w_row =
+      ex.packed_weight_codes_ptr + static_cast<std::int64_t>(n) * (K >> 1);
+  const std::uint8_t* w_srow =
+      ex.weight_scales_ptr + static_cast<std::int64_t>(n) * ex.block_count;
+
+  float acc = 0.0f;
+  for (int j = 0; j < blocks; ++j) {
+    float partial = 0.0f;
+#pragma unroll
+    for (int kk = 0; kk < 32; ++kk) {
+      const int k = (j << 5) + kk;
+      const float av = moe_e4m3_to_f32(a_row[k]);
+      const std::uint8_t nib = (w_row[k >> 1] >> ((k & 1) << 2)) & 0xF;
+      partial = __fadd_rn(partial, __fmul_rn(av, moe_e2m1_nibble_to_f32(nib)));
+    }
+    const float sc = __fmul_rn(__fmul_rn(partial, moe_e8m0_to_f32(a_srow[j])),
+                               moe_e8m0_to_f32(w_srow[j]));
+    acc = __fadd_rn(acc, sc);
+  }
+  ex.output_ptr[dr * ex.output_row_stride + n] = acc;
+}
+
+// Backward: dX[m,k] = sum_n dy[m,n] * bf16(w_decoded[e,n,k]), n ascending,
+// FP32 accumulate. W is dequantized to BF16 exactly as oracle w_full.to(bf16).
+__global__ void moe_grouped_gemm_bwd_strict(
+    const MoeGroupedGemmBwdExpert* __restrict__ experts,  // [E]
+    const std::int32_t* __restrict__ expert_offsets,      // [E+1]
+    int M, int N, int K, int E) {
+  const std::int64_t total = static_cast<std::int64_t>(M) * K;
+  const std::int64_t idx =
+      static_cast<std::int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (idx >= total) return;
+  const int m = static_cast<int>(idx / K);
+  const int k = static_cast<int>(idx % K);
+  const int e = moe_find_expert(m, expert_offsets, E);
+  const MoeGroupedGemmBwdExpert& ex = experts[e];
+  const int dr = m - ex.row_begin;
+
+  const int blocks = K >> 5;
+  const int b = k >> 5;
+  const int half_k = k >> 1;
+  const int nib_shift = (k & 1) << 2;
+  const std::uint8_t* w_codes_e = ex.packed_weight_codes_ptr;
+  const std::uint8_t* w_scales_e = ex.weight_scales_ptr;
+  const __nv_bfloat16* dy_row = ex.dy_ptr + dr * ex.dy_row_stride;
+
+  float acc = 0.0f;
+  for (int n = 0; n < N; ++n) {
+    const std::uint8_t nib =
+        (w_codes_e[static_cast<std::int64_t>(n) * (K >> 1) + half_k] >> nib_shift) & 0xF;
+    const float wfull =
+        __fmul_rn(moe_e2m1_nibble_to_f32(nib),
+                  moe_e8m0_to_f32(w_scales_e[static_cast<std::int64_t>(n) * blocks + b]));
+    const float wbf = __bfloat162float(__float2bfloat16(wfull));
+    acc = __fadd_rn(acc, __fmul_rn(__bfloat162float(dy_row[n]), wbf));
+  }
+  ex.dx_ptr[dr * ex.dx_row_stride + k] = acc;
+}
+
+constexpr int kMoeStrictBlock = 128;
+
+/*****************launch fwd and bwd strict compute kernel*********/
+
+void moe_launch_grouped_gemm_fwd_strict(
+    const MoeGroupedGemmExpert* experts, const std::int32_t* expert_offsets,
+    int M, int N, int K, int E, cudaStream_t stream) {
+  const std::int64_t total = static_cast<std::int64_t>(M) * N;
+  if (total == 0) return;
+  const int grid = static_cast<int>((total + kMoeStrictBlock - 1) / kMoeStrictBlock);
+  moe_grouped_gemm_fwd_strict<<<grid, kMoeStrictBlock, 0, stream>>>(
+      experts, expert_offsets, M, N, K, E);
+}
+
+void moe_launch_grouped_gemm_bwd_strict(
+    const MoeGroupedGemmBwdExpert* experts, const std::int32_t* expert_offsets,
+    int M, int N, int K, int E, cudaStream_t stream) {
+  const std::int64_t total = static_cast<std::int64_t>(M) * K;
+  if (total == 0) return;
+  const int grid = static_cast<int>((total + kMoeStrictBlock - 1) / kMoeStrictBlock);
+  moe_grouped_gemm_bwd_strict<<<grid, kMoeStrictBlock, 0, stream>>>(
+      experts, expert_offsets, M, N, K, E);
+}
+
+}  // namespace
+
+
+
+torch::Tensor moe_mxfp8_mxfp4_grouped_gemm_forward(
+    torch::Tensor activation_codes,
+    torch::Tensor activation_scales,
+    torch::Tensor packed_weight_codes,
+    torch::Tensor weight_scales,
+    torch::Tensor expert_offsets) {
+  moe_check_cuda_contiguous(activation_codes, "P5-4 activation_codes");
+  moe_check_cuda_contiguous(activation_scales, "P5-4 activation_scales");
+  moe_check_cuda_contiguous(packed_weight_codes, "P5-4 packed_weight_codes");
+  moe_check_cuda_contiguous(weight_scales, "P5-4 weight_scales");
+  moe_check_cuda_contiguous(expert_offsets, "P5-4 expert_offsets");
+  moe_check_same_device(activation_codes, activation_scales, "activation_scales");
+  moe_check_same_device(activation_codes, packed_weight_codes, "packed_weight_codes");
+  moe_check_same_device(activation_codes, weight_scales, "weight_scales");
+  moe_check_same_device(activation_codes, expert_offsets, "expert_offsets");
+  TORCH_CHECK(activation_codes.scalar_type() == torch::kUInt8,
+              "P5-4 activation_codes must be uint8 E4M3 codes");
+  TORCH_CHECK(activation_scales.scalar_type() == torch::kUInt8,
+              "P5-4 activation_scales must be uint8 E8M0 codes");
+  TORCH_CHECK(packed_weight_codes.scalar_type() == torch::kUInt8,
+              "P5-4 packed_weight_codes must be uint8 E2M1x2 codes");
+  TORCH_CHECK(weight_scales.scalar_type() == torch::kUInt8,
+              "P5-4 weight_scales must be uint8 E8M0 codes");
+  TORCH_CHECK(expert_offsets.scalar_type() == torch::kInt32,
+              "P5-4 expert_offsets must be int32");
+  TORCH_CHECK(activation_codes.dim() == 2,
+              "P5-4 activation_codes must be [M,K]");
+  TORCH_CHECK(activation_scales.dim() == 2,
+              "P5-4 activation_scales must be [M,K/32]");
+  TORCH_CHECK(packed_weight_codes.dim() == 3,
+              "P5-4 packed_weight_codes must be [E,N,K/2]");
+  TORCH_CHECK(weight_scales.dim() == 3,
+              "P5-4 weight_scales must be [E,N,K/32]");
+  TORCH_CHECK(expert_offsets.dim() == 1,
+              "P5-4 expert_offsets must be [E+1]");
+
+  const auto M = activation_codes.size(0);
+  const auto K = activation_codes.size(1);
+  const auto E = packed_weight_codes.size(0);
+  const auto N = packed_weight_codes.size(1);
+  TORCH_CHECK(K > 0 && K % kMoeMxBlockSize == 0,
+              "P5-4 K must be positive and divisible by 32");
+  TORCH_CHECK(activation_scales.size(0) == M &&
+                  activation_scales.size(1) == K / kMoeMxBlockSize,
+              "P5-4 activation_scales must have shape [M,K/32]");
+  TORCH_CHECK(packed_weight_codes.size(2) == K / 2,
+              "P5-4 packed_weight_codes must have shape [E,N,K/2]");
+  TORCH_CHECK(weight_scales.size(0) == E && weight_scales.size(1) == N &&
+                  weight_scales.size(2) == K / kMoeMxBlockSize,
+              "P5-4 weight_scales must have shape [E,N,K/32]");
+  TORCH_CHECK(expert_offsets.size(0) == E + 1,
+              "P5-4 expert_offsets must have E+1 entries");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(activation_codes));
+  const auto offsets = moe_copy_offsets(expert_offsets);
+  TORCH_CHECK(offsets.front() == 0,
+              "P5-4 expert_offsets must start at 0");
+  TORCH_CHECK(offsets.back() == M,
+              "P5-4 expert_offsets must end at M");
+  for (int64_t e = 0; e < E; ++e) {
+    TORCH_CHECK(offsets[e] <= offsets[e + 1],
+                "P5-4 expert_offsets must be non-decreasing");
+  }
+
+  auto output = torch::empty({M, N}, activation_codes.options().dtype(torch::kFloat32));
+
+  // Allocate the device descriptor array [E], fill it on device via the prep
+  // kernel, then hand it (plus expert_offsets) to the strict GEMM launch.
+  const auto experts_bytes =
+      static_cast<int64_t>(E) * static_cast<int64_t>(sizeof(MoeGroupedGemmExpert));
+  auto experts_buf =
+      torch::empty({experts_bytes}, activation_codes.options().dtype(torch::kByte));
+  auto* experts =
+      reinterpret_cast<MoeGroupedGemmExpert*>(experts_buf.data_ptr<std::uint8_t>());
+
+  moe_run_prepare_experts_fwd(
+      experts, activation_codes, activation_scales, packed_weight_codes,
+      weight_scales, output, expert_offsets,
+      static_cast<int>(M), static_cast<int>(N), static_cast<int>(K),
+      static_cast<int>(E));
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+  moe_launch_grouped_gemm_fwd_strict(
+      experts, expert_offsets.data_ptr<std::int32_t>(),
+      static_cast<int>(M), static_cast<int>(N), static_cast<int>(K),
+      static_cast<int>(E), stream);
+  return output;
+}
+
+torch::Tensor moe_mxfp8_mxfp4_grouped_gemm_backward(
+    torch::Tensor dy,
+    torch::Tensor packed_weight_codes,
+    torch::Tensor weight_scales,
+    torch::Tensor expert_offsets) {
+  moe_check_cuda_contiguous(dy, "P5-4 dy");
+  moe_check_cuda_contiguous(packed_weight_codes, "P5-4 packed_weight_codes");
+  moe_check_cuda_contiguous(weight_scales, "P5-4 weight_scales");
+  moe_check_cuda_contiguous(expert_offsets, "P5-4 expert_offsets");
+  moe_check_same_device(dy, packed_weight_codes, "packed_weight_codes");
+  moe_check_same_device(dy, weight_scales, "weight_scales");
+  moe_check_same_device(dy, expert_offsets, "expert_offsets");
+  TORCH_CHECK(dy.scalar_type() == torch::kBFloat16,
+              "P5-4 dy must be BF16 [M,N]");
+  TORCH_CHECK(packed_weight_codes.scalar_type() == torch::kUInt8,
+              "P5-4 packed_weight_codes must be uint8 E2M1x2 codes");
+  TORCH_CHECK(weight_scales.scalar_type() == torch::kUInt8,
+              "P5-4 weight_scales must be uint8 E8M0 codes");
+  TORCH_CHECK(expert_offsets.scalar_type() == torch::kInt32,
+              "P5-4 expert_offsets must be int32");
+  TORCH_CHECK(dy.dim() == 2, "P5-4 dy must be [M,N]");
+  TORCH_CHECK(packed_weight_codes.dim() == 3,
+              "P5-4 packed_weight_codes must be [E,N,K/2]");
+  TORCH_CHECK(weight_scales.dim() == 3,
+              "P5-4 weight_scales must be [E,N,K/32]");
+  TORCH_CHECK(expert_offsets.dim() == 1,
+              "P5-4 expert_offsets must be [E+1]");
+
+  const auto M = dy.size(0);
+  const auto N = dy.size(1);
+  const auto E = packed_weight_codes.size(0);
+  const auto packed_k = packed_weight_codes.size(2);
+  const auto K = packed_k * 2;
+  TORCH_CHECK(K > 0 && K % kMoeMxBlockSize == 0,
+              "P5-4 K must be positive and divisible by 32");
+  TORCH_CHECK(packed_weight_codes.size(1) == N,
+              "P5-4 dy N must match packed weight N");
+  TORCH_CHECK(weight_scales.size(0) == E && weight_scales.size(1) == N &&
+                  weight_scales.size(2) == K / kMoeMxBlockSize,
+              "P5-4 weight_scales must have shape [E,N,K/32]");
+  TORCH_CHECK(expert_offsets.size(0) == E + 1,
+              "P5-4 expert_offsets must have E+1 entries");
+
+  const c10::cuda::OptionalCUDAGuard device_guard(device_of(dy));
+  const auto offsets = moe_copy_offsets(expert_offsets);
+  TORCH_CHECK(offsets.front() == 0,
+              "P5-4 expert_offsets must start at 0");
+  TORCH_CHECK(offsets.back() == M,
+              "P5-4 expert_offsets must end at M");
+  for (int64_t e = 0; e < E; ++e) {
+    TORCH_CHECK(offsets[e] <= offsets[e + 1],
+                "P5-4 expert_offsets must be non-decreasing");
+  }
+
+  auto dx = torch::empty({M, K}, dy.options().dtype(torch::kFloat32));
+
+  // Allocate the device descriptor array [E], fill it on device via the prep
+  // kernel, then hand it (plus expert_offsets) to the strict GEMM launch.
+  const auto experts_bytes =
+      static_cast<int64_t>(E) * static_cast<int64_t>(sizeof(MoeGroupedGemmBwdExpert));
+  auto experts_buf =
+      torch::empty({experts_bytes}, dy.options().dtype(torch::kByte));
+  auto* experts =
+      reinterpret_cast<MoeGroupedGemmBwdExpert*>(experts_buf.data_ptr<std::uint8_t>());
+
+  moe_run_prepare_experts_bwd(
+      experts, dy, packed_weight_codes, weight_scales, dx, expert_offsets,
+      static_cast<int>(M), static_cast<int>(N), static_cast<int>(K),
+      static_cast<int>(E));
+
+  auto stream = at::cuda::getCurrentCUDAStream();
+  moe_launch_grouped_gemm_bwd_strict(
+      experts, expert_offsets.data_ptr<std::int32_t>(),
+      static_cast<int>(M), static_cast<int>(N), static_cast<int>(K),
+      static_cast<int>(E), stream);
+  return dx;
+}

--- a/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu
+++ b/csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu
@@ -71,14 +71,6 @@ constexpr const char* kMoeGroupedGemmKernelFingerprint =
 
 /****************************** launch descriptor structs***********/
 
-struct MoeQuantizeArgs {
-  const void* input_ptr;                 // BF16/FP32 [M,K]
-  std::uint8_t* activation_codes_ptr;   // E4M3 uint8 [M,K]
-  std::uint8_t* activation_scales_ptr;  // E8M0 uint8 [M,K/32]
-  int rows_m;
-  int input_k;
-};
-
 // These descriptors mirror the vLLM grouped-pointer preparation pattern, but
 // retain P5's independent code/scale allocations and [E+1] interval offsets.
 // They are written on device by the prep kernels and consumed by the strict

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -118,6 +118,21 @@ torch::Tensor det_gemm_fwd_rhs_transposed(torch::Tensor a, torch::Tensor bt);
 torch::Tensor det_gemm_da(torch::Tensor dc, torch::Tensor b);
 torch::Tensor det_gemm_db(torch::Tensor a, torch::Tensor dc);
 torch::Tensor det_gemm_db_transposed(torch::Tensor a, torch::Tensor dc);
+
+// P5 MX routed-expert interface skeleton. Quantization returns independent
+// [E4M3 codes, E8M0 scales] tensors; grouped GEMM keeps MXFP4 weights packed.
+std::vector<torch::Tensor> moe_mxfp8_act_quant_forward(torch::Tensor input);
+torch::Tensor moe_mxfp8_mxfp4_grouped_gemm_forward(
+    torch::Tensor activation_codes,
+    torch::Tensor activation_scales,
+    torch::Tensor packed_weight_codes,
+    torch::Tensor weight_scales,
+    torch::Tensor expert_offsets);
+torch::Tensor moe_mxfp8_mxfp4_grouped_gemm_backward(
+    torch::Tensor dy,
+    torch::Tensor packed_weight_codes,
+    torch::Tensor weight_scales,
+    torch::Tensor expert_offsets);
 // SiLU / SwiGLU Declarations (elementwise activation, general CUDA)
 torch::Tensor silu_forward_cuda(torch::Tensor x);
 torch::Tensor silu_backward_cuda(torch::Tensor dy, torch::Tensor x);
@@ -482,6 +497,25 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "det_gemm_db_transposed",
         &det_gemm_db_transposed,
         "Batch-invariant deterministic GEMM backward in canonical [N,K] layout");
+    m.def(
+        "moe_mxfp8_act_quant_forward",
+        &moe_mxfp8_act_quant_forward,
+        "P5-1 MXFP8 activation quantization interface skeleton (codes, scales)",
+        py::arg("input"));
+    m.def(
+        "moe_mxfp8_mxfp4_grouped_gemm_forward",
+        &moe_mxfp8_mxfp4_grouped_gemm_forward,
+        "P5-4 strict grouped GEMM interface skeleton",
+        py::arg("activation_codes"), py::arg("activation_scales"),
+        py::arg("packed_weight_codes"), py::arg("weight_scales"),
+        py::arg("expert_offsets"));
+    m.def(
+        "moe_mxfp8_mxfp4_grouped_gemm_backward",
+        &moe_mxfp8_mxfp4_grouped_gemm_backward,
+        "P5-4 strict grouped GEMM dX-only interface skeleton",
+        py::arg("dy"), py::arg("packed_weight_codes"),
+        py::arg("weight_scales"), py::arg("expert_offsets"));
+
     // registry RMSNorm
     m.def("rmsnorm_forward", &rmsnorm_forward, "Batch-invariant RMSNorm forward CUDA");
     m.def("rmsnorm_backward_dx", &rmsnorm_backward_dx, "Batch-invariant RMSNorm backward dx CUDA");

--- a/docs/design/dsv4_p5_expert_start_kit.zh-CN.md
+++ b/docs/design/dsv4_p5_expert_start_kit.zh-CN.md
@@ -1,0 +1,79 @@
+# P5 Expert 启动套件（`P5-S0`）
+
+启动套件为所有 P5 子议题（P5-1…P5-9）解除阻塞：冻结数据契约，为五个 WS1 算子提供位精确的 FP32 oracle，生成带种子的 golden fixture，并提供一条任何后端 PR 都可以独立运行的验收命令。
+
+## 子议题命名（开发顺序发布于 #8）
+
+`P5-N` 是 #8 中排序评论所定义的开发顺序标签；GitHub issue 编号仍然是链接引用的权威来源。
+
+| 标签 | 范围 |
+| --- | --- |
+| P5-S0 | 本启动套件（契约、oracle、fixture、验收命令） |
+| P5-1 | `mxfp8_act_quant`（前向 + STE 反向） |
+| P5-2 | `clamp_swiglu_weighted`（前向 + dgate/dup/dp_s） |
+| P5-3 | `shared_grouped_lora_delta`（前向 + dX/dA/dB） |
+| P5-4 | `mxfp8_mxfp4_grouped_gemm`（前向 + 仅 dX） |
+| P5-5 | `shared_expert_mlp`（前向 + 仅 dX） |
+| P5-6 | `moe_provider_adapter`（Megatron + vLLM 注入） |
+| P5-7 | WS2：EP placement、`expert_tensor_parallel_size = 1` gate |
+| P5-8 | WS2：shared expert TP/SP + shared-once gate |
+| P5-9 | WS2：EP>1 / 各种 placement 下 adapter fail-closed |
+
+## 套件内容
+
+| 模块 | 内容 |
+| --- | --- |
+| `rl_engine/moe/mx_format.py` | OCP MX 编解码器：E8M0 / E4M3 / E2M1、block-32 量化/反量化、半字节打包。定义 P5-1/P5-4 的 golden 字节。 |
+| `rl_engine/moe/contract.py` | `ExpertBatch`、`SharedBatch`、`LoRAParams`、clamp 常量、张量 fingerprint。它是 Foundation `ExpertBatch` ABI（`p5-expertbatch-v1`）在 P5 中的本地子集。 |
+| `rl_engine/moe/oracle.py` | 五个算子的 FP32 参考实现，以及完整的 routed/shared 前向—反向组合实现。 |
+| `rl_engine/moe/provider.py` | `ExpertProvider` 协议、由 oracle 支持的 `ReferenceProvider`、fail-closed 的 `StubProvider`。 |
+| `rl_engine/moe/fixtures.py` | 带种子的 fixture 用例和 golden-hash manifest（`tests/fixtures/p5/golden_hashes.json`，CI 锚点）。 |
+| `rl_engine/moe/trace.py` | 边界哈希和 `first_divergence`（P5 本地的 `TraceEnvelope` 替代实现）。 |
+| `scripts/check_p5.py` | 验收命令。 |
+
+## 冻结的数值契约（#8 内容及本次决定的总结）
+
+来自各 issue 的约定：
+
+1. 仅进行 LoRA 微调；基础权重保持冻结——任何位置都**不包含 `dW`**。
+2. Routed base 使用 MXFP8 activation × MXFP4 frozen weight；block = 32，scale = E8M0，元素格式为 E4M3 / E2M1（OCP Microscaling v1.0）。
+3. 反向使用 BF16（不重新量化为 MXFP8）；每次归约都使用 FP32 累加器。
+4. 路由权重 `p_s` 在 `clamp_swiglu_weighted` 中应用（`h = SiLU(min(gate,10)) · clamp(up,−10,10) · p_s`），在全局范围内恰好应用一次。
+5. `mxfp8_act_quant` 的 amax 是行内 32 个元素的归约；反向使用 STE。
+6. 单轮 SwiGLU：使用 FP32 数学运算，并仅在输出上进行一次 BF16 舍入。
+
+本套件必须冻结的决定（已在 #8 标记为待评审；修改其中任何一项都需要重新生成 manifest，并递增 schema/profile id）：
+
+| # | 决定 | 理由 |
+| --- | --- | --- |
+| D1 | **E4M3 编码：先在 FP32 中截断到 ±448，再执行 RNE 转换**（torch `float8_e4m3fn`）。直接使用 torch cast 会将溢出映射为 NaN；clamp+cast 等价于 PTX `cvt.satfinite`。 | 与硬件 satfinite 行为一致；由 golden 测试固定。 |
+| D2 | **E8M0 scale 计算规则**：`shared_exp = floor(log2(amax)) − emax_elem`（E4M3 为 8，E2M1 为 2）；全零 block → code 127（scale 为 1）。`floor(log2)` 通过 `frexp` 精确计算。 | OCP 推荐规则；使用精确的整数运算。 |
+| D3 | **Oracle 数值 profile `oracle-fp32-serial-v1`**：按索引升序串行累加，采用先乘后加的舍入方式（**不进行 FMA 融合**）。严格的 CUDA kernel 必须使用 `__fmul_rn`/`__fadd_rn` 以匹配该行为，或注册自己的 profile。 | 为实现字节级相等，必须固定归约顺序；升序串行归约便于审计。 |
+| D4 | **LoRA 的 GEMM 间舍入**：`U = X·Aᵀ` 在执行 `Y = U·Bᵀ·α` 前舍入为 BF16；反向过程中，`dY·α` 和 `dU` 也在 GEMM 之间舍入为 BF16。 | 与双 GEMM BF16 pipeline 一致；两个引擎都必须遵守。 |
+| D5 | **clamp 子梯度恰好位于边界时为零**（只有严格不等式范围内才传递梯度）。 | 边界取值规则必须确定且可复现；由测试固定。 |
+| D6 | **Shared expert 不使用 clamp**（`h = SiLU(gate)·up`），按照 P5-5（#64）中固定的数学定义，复用单轮 SwiGLU，并令 `p_s = None`。 | P5-5（#64）的文字描述说“复用 `clamp_swiglu_weighted`（不带 `p_s`）”，但其数学公式显示不使用 clamp——**该问题已在 issue 上提出，尚待解决**。 |
+| D7 | 反向返回的梯度为 FP32（累加器数据类型）；在下一个算子边界处舍入为 BF16。 | 与“BF16 backward，FP32 reductions”保持一致。 |
+
+## 字节相等的适用范围
+
+严格的字节级相等要求只适用于：**训练端与推理端使用相同数值 profile 且运行在相同设备上**。已提交的 manifest 固定了 CPU x86 oracle；`scripts/check_p5.py` 会在 provider 所使用的设备上重新计算 oracle，因此超越函数（如 sigmoid）不会在严格比较过程中跨设备传递。
+
+不具备等效能力的硬件（例如没有 FP8 MMA、fnuz 格式或原生 MX 指令）必须注册自己的 profile，并明确给出容差——绝不能静默放宽要求（P5-4/P5-6 契约）。
+
+## 子议题 PR 如何使用该套件
+
+1. 继承 `ReferenceProvider`，只重写 PR 实际交付的算子（其余部分继续使用 oracle），并设置 `name`/`numeric_profile`。
+2. 运行 `python scripts/check_p5.py --provider your.module:YourProvider [--device cuda]`。每个边界都必须字节级相等；否则退出码为 1。
+3. 在 PR 描述中附上检查输出以及 `provenance()` 的结果。
+
+Fixture 用例包括：`base_only_one_row`、`base_only_packed`、`lora_only`、`base_plus_lora`、`uneven_experts`（零行 expert）、`shared_t1`、`shared_t16`；此外还有算子边界用例 `act_quant_edges`（2 的幂、RNE ties、零行）和 `swiglu_boundary`（位于 clamp 边界、边界内及边界外的值）。
+
+在有意修改契约后，重新生成 manifest：
+
+```bash
+python -m rl_engine.moe.fixtures --write-manifest
+```
+
+## 本套件不包含的内容
+
+不包含 CUDA/Triton kernel，不包含 Megatron/vLLM 注入（P5-6），不包含 EP transport 或 combine（P4/P6），也不包含多 rank gate（P5-7…P5-9）。`output_slot` 会原样传递，为 P6 保留。

--- a/docs/design/p5-wgmma-sm90-grouped-gemm-design.md
+++ b/docs/design/p5-wgmma-sm90-grouped-gemm-design.md
@@ -1,0 +1,301 @@
+# SM90 WGMMA 高性能 Grouped GEMM 设计文档
+
+| 项 | 内容 |
+| --- | --- |
+| 版本 | v1.0（设计稿） |
+| 目标算子 | `mxfp8_mxfp4_grouped_gemm_fwd`（P5-4） |
+| 目标硬件 | NVIDIA H100 / SM90（Hopper） |
+| 数值立场 | 本方案为独立性能 profile（`p5-wgmma-sm90-v1`），不顶替 strict 路径的字节级一致性 |
+
+---
+
+## 目录
+
+1. [设计目标与约束](#0-设计目标与约束)
+2. [总体架构：Persistent Kernel + 全局 Work Queue](#1-总体架构persistent-kernel--全局-work-queue)
+3. [线程组织：CTA 内两个 Warpgroup](#2-线程组织cta-内两个-warpgroup)
+4. [TMA 描述符（Host 端）](#3-tma-描述符host-端)
+5. [软件流水线（多级 mbarrier）](#4-软件流水线多级-mbarrier)
+6. [fp4 → fp8 解码（Producer 侧，smem 内）](#5-fp4--fp8-解码producer-侧smem-内)
+7. [WGMMA 指令形态（SM90 fp8）](#6-wgmma-指令形态sm90-fp8)
+8. [Epilogue：E8M0 scale 后移](#7-epiloguee8m0-scale-后移)
+9. [内存布局总结](#8-内存布局总结)
+10. [Tile 分级](#9-tile-分级)
+11. [优化清单（按收益排序）](#10-优化清单按收益排序)
+12. [主循环伪代码骨架](#11-主循环伪代码骨架)
+13. [与 prep kernel 的最终分工](#12-与-prep-kernel-的最终分工)
+14. [风险与偏离记录](#13-风险与偏离记录)
+
+---
+
+## 0. 设计目标与约束
+
+| 项目 | 内容 |
+| --- | --- |
+| 语义 | MoE 分组 GEMM：每个 expert 用自己的权重 `W[e]` 对自己的 token 组做矩阵乘 |
+| 输入 | `A` = MXFP8 激活（E4M3，按 token 已按 expert 重排）；`W` = MXFP4 冻结权重（E2M1，nibble 打包）；`expert_offsets` = 每个 expert 的 token 区间 |
+| 输出 | `C` = BF16 结果 `[M, N]` |
+| 块粒度 | 32 元素一 block，E8M0 scale |
+| 核心约束 | 权重冻结（无 dW），backward 为 BF16，FP32 累加 |
+
+### 三条不可违背的数值语义
+
+> 虽然本 profile 会偏离，但需显式记录偏离点：
+
+1. K 方向升序串行累加
+2. mul/add 分开 round（无 FMA 融合）
+3. 括号 `(partial × sa) × sw`
+
+**偏离说明**：WGMMA 路径在 epilogue 里把 scale 后移、用 fp22 累加，这两点偏离 strict，故只能作为独立 profile 存在。
+
+---
+
+## 1. 总体架构：Persistent Kernel + 全局 Work Queue
+
+不采用「每 expert 一次 launch」，而是一次 launch 处理所有 expert：
+
+```
+launch：gridDim = num_SMs × 2（固定），blockDim = 256（固定）
+每个 CTA 常驻，循环抢任务：
+    e = atomicAdd(&g_work_counter, 1)
+    if e >= E: break
+    m_e = expert_m[e]
+    if m_e == 0: continue          // 空 expert 跳过
+    // 本 CTA 处理 expert e，M 大则内部循环多个 M-tile
+    for (mt = 0; mt < m_e; mt += TM):
+        mainloop_one_tile(...)
+```
+
+**为什么这样**：
+
+- grid/block 大小在 launch 时固定，不随 `m_e` 变化而重算，避免几百次微型 launch 的启动开销与 tail 效应。
+- `atomicAdd` 抢任务天然负载均衡，大 expert 被不同 CTA 分块处理。
+- 空 expert 直接 `continue`，零开销跳过。
+
+---
+
+## 2. 线程组织：CTA 内两个 Warpgroup
+
+```
+CTA (256 线程 = 8 warps)
+├── Warpgroup 0 — Producer (4 warps = 128 线程)
+│     职责：TMA 异步搬运（gmem→smem）
+│           nibble → E4M3 解码（smem 内）
+│           mbarrier.arrive 通知 Consumer
+│
+└── Warpgroup 1 — Consumer (4 warps = 128 线程)
+      职责：mbarrier.try_wait 等数据就绪
+           wgmma.mma_async 算 GEMM
+           读寄存器 D 片段做 epilogue（乘 scale + 写回）
+```
+
+**关键点**：
+
+- Producer/Consumer 是同一 CTA 内的两个 warpgroup，**不是两个 block**。
+- 用 `setmaxnreg` 分别设寄存器上限：Consumer 需要大寄存器存 D 累加器，Producer 需要更多线程带宽。
+- Consumer 至少 1 warp 可发 wgmma，多 warp 让多个 tile 同时在飞以隐藏延迟。
+
+---
+
+## 3. TMA 描述符（Host 端）
+
+用 prep kernel（`__get_group_gemm_starts` 的类比）算出每个 expert 的 `a_off / b_off / scale_off / m_e` 后，host 端用 `cuTensorMapEncodeTiled` 为每个 expert 编描述符：
+
+```cpp
+// 权重 B：每 expert 一张描述符，uint8 打包态（不解码）
+CUtensorMap desc_b[E];
+for (int e = 0; e < E; ++e) {
+  cuTensorMapEncodeTiled(
+    &desc_b[e],
+    CU_TENSOR_MAP_DATA_TYPE_UINT8,   // fp4 nibble 打包态按 uint8 搬
+    2,                                // 2D
+    b_base + expert_b_off[e],
+    size, stride, box, estride,
+    CU_TENSOR_MAP_INTERLEAVE_NONE,
+    CU_TENSOR_MAP_SWIZZLE_NONE,       // 不解码，swizzle 关
+    CU_TENSOR_MAP_L2_PROMOTION_NONE,
+    CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+}
+```
+
+**要点**：
+
+- TMA 搬的是打包 nibble（uint8，2 元素/字节），**不做解码**，解码留给 Producer。
+- 地址/偏移已 bake 进描述符，per-expert 描述符最直接。
+- 必须满足 128 字节对齐（对应 prep 的 `% 128` 断言）。
+
+---
+
+## 4. 软件流水线（多级 mbarrier）
+
+重叠靠 N-stage 流水线，smem 开 2~4 份缓冲，mbarrier 用 phase 奇偶翻转同步：
+
+```
+smem 布局（per stage）：
+    sB_packed[STAGES][...]   — TMA 直接落地（打包态 uint8）
+    sB_fp8   [STAGES][...]   — 解码后的 E4M3
+    mbar[STAGES]             — 每 stage 一个 mbarrier
+
+Producer 循环：
+    cp.async.bulk.tensor.2d ... (sB_packed[stage], desc_b, {x,y}, mbar[stage])
+    mbarrier.arrive.expect_tx(mbar[stage], bytes)
+    // TMA 完成 → 读 sB_packed 解码 → 写 sB_fp8[stage]
+    mbarrier.arrive(mbar[stage])         // 通知 Consumer
+
+Consumer 循环：
+    mbarrier.try_wait.parity(mbar[stage], phase)
+    wgmma.mma_async(... sB_fp8[stage] ...)
+    phase ^= 1
+```
+
+Producer 在 stage `i+1` 上 TMA+解码时，Consumer 在 stage `i` 上 WGMMA，二者并行，隐藏 TMA 与解码延迟。
+
+---
+
+## 5. fp4 → fp8 解码（Producer 侧，smem 内）
+
+分两段，解码只发生在 smem，**绝不写回 gmem**：
+
+1. **TMA 搬运**：gmem 的打包 nibble → `sB_packed`（纯搬运，无解码）。
+2. **Producer 解码**：读 `sB_packed`，用 E2M1→E4M3 解码（`kMag[8]={0, 0.5, 1, 1.5, 2, 3, 4, 6}` 映射），在寄存器里解出值，再 `st.shared` 写 `sB_fp8`（E4M3）。
+
+> E2M1 → E4M3 是无损精确（E2M1 的 16 个值全在 E4M3 表示范围内），此解码不引入误差。Consumer 读 `sB_fp8`，完全不接触 nibble。
+
+---
+
+## 6. WGMMA 指令形态（SM90 fp8）
+
+Consumer 用 fp8 `wgmma.mma_async`（A 在 smem，B 在 smem，累加到 FP32 寄存器）：
+
+```
+wgmma.mma_async.sync.aligned.m64n128k16.f32.e4m3.e4m3
+  {d0..d7},                    // D 累加器在寄存器
+  desc_a, desc_b,              // A/B 的 smem 描述符
+  scale_a, scale_b,            // fp8 WGMMA 可选乘性 scale
+  1;                           // imm
+```
+
+- `A` = 激活（E4M3，P5-1 量化输出，直接 TMA 进 smem）。
+- `B` = 解码后的权重（E4M3，来自 `sB_fp8`）。
+- tile 形状 `m64n128k16` 由架构约束，128/256 对齐到 warp。
+
+**SM90 硬件事实（必须记住）**：
+
+- SM90 **没有 TMEM**（那是 SM100 的东西），累加器在寄存器。
+- SM90 fp8 WGMMA 内部累加是 ≈fp22 降精度，因此本路径不能顶替 strict。
+- WGMMA **无 FP4 操作数**，所以必须先把 E2M1 解码成 E4M3（第 5 节）。
+
+---
+
+## 7. Epilogue：E8M0 scale 后移
+
+block scale（每 32 元素一个 E8M0）不进 WGMMA 主循环，放在 epilogue：
+
+```
+D 在寄存器（fp32）
+  → 每个 32-block 对应的 (sa × sw) 乘到对应列/块
+  → round 成 BF16
+  → 写回 gmem
+```
+
+- scale 按 K 的 32-block 分，K-tile（256 = 8×32）正好对齐 8 个 scale-block，epilogue 按列查 scale 乘回。
+- 此步偏离 strict 的 `(partial×sa)×sw` 顺序，故属 perf profile。
+
+---
+
+## 8. 内存布局总结
+
+| 数据 | gmem 存放 | smem 存放 | 谁负责转换 |
+| --- | --- | --- | --- |
+| A 激活 | E4M3 打包（每元素 1B） | E4M3（TMA 直搬） | TMA |
+| W 权重 | E2M1 nibble 打包（2 元素/字节） | 先 `sB_packed` 再 `sB_fp8`（E4M3） | Producer 解码 |
+| scale | E8M0（每 32 元素 1B） | 直接读 | epilogue |
+
+---
+
+## 9. Tile 分级
+
+只有 M 需要按 `m_e` 分级（N 是模型常量，K 是编译期常量）：
+
+| 条件 | M-tile | 处理方式 |
+| --- | --- | --- |
+| `m_e > 256` | 256 | 内部循环 `ceil(m_e/256)` 次 |
+| `128 < m_e ≤ 256` | 128 | 单次 |
+| `m_e ≤ 128` | 128（或直接一次性） | 单次 |
+
+- **N tile** = 128 / 256（架构期常量，wgmma 指令形态决定），不随 `m_e` 变。
+- **K tile** = 256 = 8×32，对齐 E8M0 scale-block，便于 epilogue 整齐落 scale。
+
+---
+
+## 10. 优化清单（按收益排序）
+
+1. **B（权重）常驻 smem，跨 M-tile 复用** — per-expert 最大红利，`W[e]` 只搬一次，之后只有 A 在流。
+2. **多级流水线 + 双缓冲** — 隐藏 TMA/解码延迟，比单纯加大 tile 更有效。
+3. **解码放 Producer 侧** — Consumer 只读 fp8，不碰 nibble。
+4. **空 expert 跳过** — `if (m_e == 0) continue;`
+5. **work-queue chunking** — `atomicAdd` 一次抢一组，减少全局原子竞争。
+6. **smem swizzle 匹配** — 解码写 fp8 时 swizzle 与 wgmma 要求一致，避免 bank conflict。
+7. **cluster 广播（可选）** — 大 expert 多 CTA 分头算时用 TMA multicast 广播 `W[e]`。
+8. **分级 tile 先简化后优化** — 先做固定 tile + 边界 tail 跑通，再决定是否按 `m_e` 分级。
+
+---
+
+## 11. 主循环伪代码骨架
+
+```cpp
+__device__ unsigned g_work = 0;
+
+__global__ void grouped_gemm_sm90(
+    const CUtensorMap* desc_a, const CUtensorMap* desc_b,
+    const uint8_t* scales_a, const uint8_t* scales_w,
+    float* out, const int* expert_m, const int* a_off, const int* b_off, ...)
+{
+  while (true) {
+    unsigned e = atomicAdd(&g_work, 1);
+    if (e >= E) break;
+    int M_e = expert_m[e];
+    if (M_e == 0) continue;
+
+    // B 权重解码进 smem（只一次，复用）
+    load_and_decode_W(desc_b[e]);          // TMA → sB_packed → sB_fp8
+
+    for (int mt = 0; mt < M_e; mt += TM) {
+      // Producer: TMA 搬 A tile → sA
+      // Consumer: wgmma.mma_async(A, B) → D 寄存器
+      // epilogue: D × (sa × sw) → round BF16 → out
+    }
+  }
+}
+```
+
+---
+
+## 12. 与 prep kernel 的最终分工
+
+| 职责 | 位置 |
+| --- | --- |
+| tensor → data_ptr / shape 校验 | host 绑定层 |
+| per-expert 偏移、M、stride、scale 布局、对齐校验 | prep kernel（`__get_group_gemm_starts`） |
+| 用偏移生成 TMA 描述符 | host（`cuTensorMapEncodeTiled`） |
+| nibble → E4M3 解码 | 主 kernel Producer，smem 内 |
+| GEMM 数值计算 | 主 kernel Consumer，wgmma |
+| scale 乘回 + 写 out | 主 kernel epilogue |
+
+---
+
+## 13. 风险与偏离记录
+
+| 风险/偏离 | 说明 | 缓解 |
+| --- | --- | --- |
+| fp22 累加精度 | 非 strict | 独立 profile，注册独立 `numeric_profile` |
+| scale 括号顺序 | epilogue 后移 `(sa×sw)` | 同上，禁止用于 strict 验收 |
+| nibble 解码开销 | Producer 多一步 | 流水线重叠，E2M1→E4M3 无损 |
+| 空 expert 尾效 | 大量小 expert | work-queue + `continue` + chunking |
+| 描述符开销 | 每 expert 一张 | host 一次性生成，kernel 内复用 |
+
+---
+
+## 一句话总结
+
+> SM90 上的高性能 grouped GEMM = **persistent CTA + atomic work-queue 调度**，CTA 内分 **Producer**（TMA 搬 nibble + smem 解码成 E4M3）与 **Consumer**（fp8 WGMMA 累加）两个 warpgroup，靠 **多级 mbarrier 流水线**重叠，epilogue 后移 E8M0 scale——prep kernel 只算 per-expert 地址/形状/scale 布局供 host 编 TMA 描述符，本身不解码不搬数。

--- a/docs/mxfp8_mxfp4_grouped_gemm_explained.md
+++ b/docs/mxfp8_mxfp4_grouped_gemm_explained.md
@@ -1,0 +1,462 @@
+# `mxfp8_mxfp4_grouped_gemm.cu` 自顶向下详解
+
+> 学习笔记 · 目标文件：`csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu`（共 591 行）
+> 面向读者：已经熟悉 CUDA / PyTorch C++ extension 基础，想逐层读懂这个 strict MX 分组 GEMM 实现。
+
+---
+
+## 0. 一句话定位
+
+本文件实现 **P5-4 算子 `mxfp8_mxfp4_grouped_gemm` 的 strict CUDA 后端**：
+
+- **MXFP8 激活**（E4M3 code + E8M0 scale，block=32）× **MXFP4 冻结权重**（E2M1 nibble + E8M0 scale，block=32）
+- 输出为 **分组 GEMM** 的前向结果，以及 **仅 dX** 的反向
+- 数值契约：与 CPU FP32 oracle **逐字节相等（bit-exact）**
+
+关键词：分组 GEMM（grouped GEMM）、MoE 专家路由、MX（Microscaling）编码、串行升序累加、fail-closed。
+
+---
+
+## 1. 顶层架构：三个层次
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  L1  对外 API 层（PyTorch binding，文件末尾 437–590 行）             │
+│      moe_mxfp8_act_quant_forward          (fail-closed 占位)        │
+│      moe_mxfp8_mxfp4_grouped_gemm_forward (完整实现)                │
+│      moe_mxfp8_mxfp4_grouped_gemm_backward(完整实现)                │
+│      ── 职责：收 torch::Tensor → 校验形状/dtype → 调 L2 → 返回 Tensor│
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │ 调用
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  L2  调度/校验层（anonymous namespace 内）                           │
+│      moe_launch_grouped_gemm_fwd_strict / _bwd_strict  (启动 kernel) │
+│      moe_check_cuda_contiguous / moe_check_same_device /            │
+│      moe_copy_offsets / moe_check_h100_sm90 / moe_prepare_experts   │
+│      ── 职责：算 grid/block、启动 <<<>>>、host 端元数据准备           │
+└──────────────────────────────┬──────────────────────────────────────┘
+                               │ <<<grid, block, 0, stream>>>
+┌──────────────────────────────▼──────────────────────────────────────┐
+│  L3  设备计算层（__global__ / __device__）                           │
+│      moe_grouped_gemm_fwd_strict   (前向 kernel)                    │
+│      moe_grouped_gemm_bwd_strict   (反向 kernel)                    │
+│      小部件：moe_find_expert（路由）                                 │
+│      小部件：moe_e4m3_to_f32 / moe_e2m1_nibble_to_f32 /             │
+│               moe_e8m0_to_f32（三种 MX 解码器）                      │
+│      ── 职责：真正的数值计算，bit-exact 串行累加                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**支撑层（数据契约）**：结构体 `MoeGroupedGemmExpert / MoeGroupedGemmArgs / MoeGroupedGemmBackwardArgs`（138–193 行）定义了 A/B/C/scale 的指针布局；常量块（131–136 行）固定了 block=32 等合同值。
+
+---
+
+## 2. 数据契约：三种 MX 编码
+
+这是理解所有内核的前提，先把它吃透。
+
+### 2.1 激活：E4M3（1 字节 / 元素）
+
+```
+bit:   7    6 5 4 3    2 1 0
+      [sign][ exp ][ mant ]
+```
+
+- 1 符号位、4 指数位（bias 7）、3 尾数位
+- 逻辑形状 `[M, K]`，`activation_codes[m*K + k]` 存一个 E4M3 code byte
+
+### 2.2 权重：E2M1（半个字节 / 元素，2 个打包进 1 字节）
+
+```
+bit:   3     2 1     0
+      [sign][exp][mant]
+```
+
+- 1 符号位、2 指数位、1 尾数位
+- 物理形状 `[E, N, K/2]`，**低 nibble = 偶 k，高 nibble = 奇 k**
+- 地址公式：`packed_weight_codes[e*N*(K/2) + n*(K/2) + (k/2)]`
+
+### 2.3 scale：E8M0（1 字节 / 块）
+
+```
+bit:   7 6 5 4 3 2 1 0
+      [      exp(8)     ]
+```
+
+- 8 位纯指数，无符号位无尾数，表示 `2^(code - 127)`
+- 每 32 个连续元素共享一个 scale（block = 32）
+- code=127 → scale=1.0（全零 block 用）；code=255 → NaN（被 wrapper 拒绝）
+- 激活 scale 形状 `[M, K/32]`；权重 scale 形状 `[E, N, K/32]`
+
+### 2.4 专家路由：`expert_offsets`
+
+- 长度 `E+1` 的 int32 数组，非递减，`first==0`，`last==M`
+- 专家 e 负责连续行区间 `[offsets[e], offsets[e+1])`
+- 相邻相等 = 空专家，应安全跳过
+
+---
+
+## 3. L1 对外 API 层（三个对外函数）
+
+### ① `moe_mxfp8_act_quant_forward`（437–445 行）
+
+**功能**：P5-1 激活量化。**当前是 fail-closed 占位**——只做输入校验，最后调用
+`moe_cuda_skeleton_unimplemented("mxfp8_act_quant_fwd")` 直接 `TORCH_CHECK(false, ...)` 抛错。
+
+**为什么这样做**：注释明确「P5-1 只保留前向 CUDA ABI，尚未实现实际量化 kernel」，
+目的是让任何 provider **不能静默声称支持 P5**（fail-closed 契约）。
+
+### ② `moe_mxfp8_mxfp4_grouped_gemm_forward`（447–523 行）
+
+**功能**：前向入口。内部小部件构成：
+
+1. **一连串 `moe_check_cuda_contiguous` / `moe_check_same_device`**（453–461 行）
+   —— 校验每个 tensor 是 CUDA、连续、同设备。
+2. **dtype 校验**（462–471 行）：四个 code/scale 必须是 `uint8`，`expert_offsets` 必须是 `int32`。
+3. **shape 校验**（472–498 行）：
+   - `activation_codes [M,K]`
+   - `activation_scales [M,K/32]`
+   - `packed_weight_codes [E,N,K/2]`
+   - `weight_scales [E,N,K/32]`
+   - `expert_offsets [E+1]`
+4. **offsets 语义校验**（501–509 行）：通过 `moe_copy_offsets` 拷回 CPU，
+   检查 `front()==0`、`back()==M`、非递减。
+5. **分配输出 + 启动**（511–521 行）：`torch::empty({M,N}, float32)`，取 stream，
+   调 `moe_launch_grouped_gemm_fwd_strict`。
+
+### ③ `moe_mxfp8_mxfp4_grouped_gemm_backward`（525–590 行）
+
+**功能**：反向入口（只算 dX）。结构与 forward 几乎对称，区别：
+
+- 输入是 `dy`（BF16 `[M,N]`），不需要 activation code/scale。
+- `K` 由 `packed_k * 2` 反推（557 行），因为权重只有打包后的 `K/2`。
+- 输出 `dx` 是 FP32 `[M,K]`。
+- 调 `moe_launch_grouped_gemm_bwd_strict`。
+
+---
+
+## 4. L2 调度/校验层
+
+| 函数 | 位置 | 功能 |
+|---|---|---|
+| `moe_check_cuda_contiguous` | 195–198 | 校验 tensor 是 CUDA 且连续 |
+| `moe_check_same_device` | 200–205 | 校验与第一个 tensor 同设备 |
+| `moe_copy_offsets` | 210–214 | 把 int32 offsets 拷到 CPU vector（仅用于校验） |
+| `moe_check_h100_sm90` | 216–229 | 若启用了 SM90 宏则校验 `major==9`（**当前未被调用，死代码**） |
+| `moe_prepare_experts` | 231–270 | **host 端**预计算每个 expert 的起始指针 + stride（vLLM `__get_group_gemm_starts` 的镜像，当前也未被 hot path 使用） |
+| `moe_cuda_skeleton_unimplemented` | 272–275 | `[[noreturn]]` 统一抛「未实现」错 |
+| `moe_launch_grouped_gemm_fwd_strict` | 410–420 | 算 grid 并 `<<<>>>` 启动前向 kernel |
+| `moe_launch_grouped_gemm_bwd_strict` | 422–431 | 同上，反向 |
+
+### 关键实现：两个 launch 函数
+
+```cpp
+constexpr int kMoeStrictBlock = 128;   // 408 行，每个 block 128 线程
+const std::int64_t total = M * N;       // 总输出元素数
+const int grid = (total + 127) / 128;   // 向上取整分 block
+moe_grouped_gemm_fwd_strict<<<grid, 128, 0, stream>>>(...);
+```
+
+**设计**：每个线程算一个输出元素，grid 用「总数 / 128 向上取整」，kernel 内部再做
+`if (idx >= total) return;` 越界保护。
+
+### 附：`moe_prepare_experts`（231–270 行）详解
+
+这是 vLLM `__get_group_gemm_starts`（设备端 prep kernel）的 **host 端镜像**，逐字段对应：
+
+| vLLM `__get_group_gemm_starts` | 本文件对应字段 | 含义 |
+|---|---|---|
+| `a_offsets[i] = a_base + expert_offset * half_k` | `activation_codes_ptr + row_begin*K` | A 起始指针 |
+| `a_scales_offsets[i] = a_scales_base + sf_offset*gk` | `activation_scales_ptr + row_begin*blocks` | A scale |
+| `b_offsets[i] = b_base + expert_id*n*half_k` | `packed_weight_codes_ptr + e*N*(K/2)` | B（按 expert 分块） |
+| `b_scales_offsets[i] = b_scales_base + expert_id*n*gk` | `weight_scales_ptr + e*N*blocks` | B scale |
+| `out_offsets[i] = out_base + expert_offset*n` | `output_ptr + row_begin*N` | C 起始指针 |
+| `a/b/c_strides` | 各 stride 字段 | stride |
+
+**关键区别**：vLLM 在 **device** 上算（喂给 CUTLASS grouped GEMM）；本文件在 **host** 上算，
+且当前 strict kernel 并不消费这个 vector（而是用 `moe_find_expert` 现场反推）。
+
+---
+
+## 5. L3 设备计算层
+
+### 5.1 三种 MX 解码器（codec，最底层原子操作）
+
+#### ① `moe_e4m3_to_f32`（285–295 行）—— 激活解码
+
+OCP **E4M3**（1 符号 / 4 指数 / 3 尾数，bias 7）：
+
+```cpp
+sign = code >> 7;                      // 取符号位
+exp  = (code >> 3) & 0xF;              // 取 4 位指数
+mant = code & 0x7;                     // 取 3 位尾数
+frac = mant * (1.0f/8.0f);             // 尾数小数部分
+if (exp == 0) return ± ldexpf(frac, -6);   // 次正规数：2^-6 * mant/8
+value = ldexpf(1.0f + frac, exp - 7);  // 正规数：2^(exp-7) * (1 + mant/8)
+return sign ? -value : value;
+```
+
+`ldexpf(x, e)` = `x * 2^e`，用精确的指数缩放避免浮点误差，保证与 oracle 逐字节一致。
+
+#### ② `moe_e2m1_nibble_to_f32`（299–303 行）—— 权重解码
+
+OCP **E2M1**（1 符号 / 2 指数 / 1 尾数），4 bit 打包在一个 nibble 里。用查表法：
+
+```cpp
+constexpr float kMag[8] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f};
+mag = kMag[nibble & 0x7];          // 低 3 位 → 幅值
+return (nibble & 0x8) ? -mag : mag; // bit3 是符号
+```
+
+这些值在 FP32 里**都是精确的**（0.5/1/1.5/2/3/4/6），所以查表无损。
+
+#### ③ `moe_e8m0_to_f32`（306–308 行）—— scale 解码
+
+OCP **E8M0** 是纯指数格式，表示 `2^(code-127)`：
+
+```cpp
+return ldexpf(1.0f, code - 127);   // 1.0 * 2^(code-127)
+```
+
+---
+
+### 5.2 `moe_find_expert`（313–322 行）—— 专家路由
+
+**功能**：给定行号 `m`，返回它属于哪个 expert。行已按 expert 排序，`offsets[e] <= m < offsets[e+1]`。
+
+```cpp
+int lo = 0, hi = E - 1;
+while (lo < hi) {
+  int mid = (lo + hi + 1) >> 1;         // 向上取整的二分
+  if (offsets[mid] <= m) lo = mid;       // m 在右半
+  else hi = mid - 1;                     // m 在左半
+}
+return lo;
+```
+
+这是「找最后一个满足 `offsets[mid] <= m` 的位置」的二分。空 expert
+（`offsets[e]==offsets[e+1]`）自动跳过，因为没有 m 落进它。
+
+---
+
+### 5.3 前向 kernel `moe_grouped_gemm_fwd_strict`（327–366 行）
+
+**线程映射**：一个线程负责一个 `(m, n)` 输出元素。
+
+```cpp
+idx = blockIdx.x * blockDim.x + threadIdx.x;   // 全局线程号
+if (idx >= M*N) return;
+m = idx / N;  n = idx % N;                     // 反解出 (m, n)
+e = moe_find_expert(m, expert_offsets, E);     // 路由到专家
+```
+
+**指针定位**（4 个基址，全部按打包布局偏移）：
+
+```cpp
+blocks = K >> 5;                                  // K/32 个 scale 块
+a_row   = a_codes + m * K;                        // 第 m 行 E4M3 code
+a_srow  = a_scales + m * blocks;                  // 第 m 行 E8M0 scale
+w_row   = w_codes + (e*N + n) * (K >> 1);         // 专家 e、第 n 列的 E2M1 打包权重
+w_srow  = w_scales + (e*N + n) * blocks;          // 专家 e、第 n 列的权重 scale
+```
+
+**双层累加**（外层按 32 元素块，内层块内按 k 升序）：
+
+```cpp
+float acc = 0.0f;
+for (int j = 0; j < blocks; ++j) {                 // 外层：块 j
+  float partial = 0.0f;
+  #pragma unroll
+  for (int kk = 0; kk < 32; ++kk) {                // 内层：块内 kk
+    int k = (j << 5) + kk;
+    float av = moe_e4m3_to_f32(a_row[k]);          // 解激活
+    uint8_t nib = (w_row[k >> 1] >> ((k & 1) << 2)) & 0xF;  // 取权重 nibble
+    partial = __fadd_rn(partial, __fmul_rn(av, moe_e2m1_nibble_to_f32(nib)));
+  }
+  float sc = __fmul_rn(__fmul_rn(partial, moe_e8m0_to_f32(a_srow[j])),
+                       moe_e8m0_to_f32(w_srow[j]));   // 先乘 a_scale 再乘 w_scale
+  acc = __fadd_rn(acc, sc);
+}
+out[m*N + n] = acc;
+```
+
+**三个关键点**：
+
+1. **nibble 提取**：`w_row[k>>1]` 是包含第 k 个权重的那一字节；`(k&1)<<2` 决定位移量
+   ——偶 k 取低 4 位（位移 0），奇 k 取高 4 位（位移 4）。`& 0xF` 隔离出 nibble。
+2. **`__fmul_rn` / `__fadd_rn`**：强制「乘 / 加各自独立舍入到最近偶数」
+   （round-to-nearest-even），**禁止 FMA 融合**。这是与 oracle 逐字节相等的关键。
+3. **scale 应用顺序**：`(partial * scale_a) * scale_w`，括号顺序固定，也是 bit-exact 契约的一部分。
+
+---
+
+### 5.4 反向 kernel `moe_grouped_gemm_bwd_strict`（370–406 行）
+
+**线程映射**：一个线程负责一个 `dX[m,k]` 元素。
+
+```cpp
+idx = blockIdx.x * blockDim.x + threadIdx.x;
+if (idx >= M*K) return;
+m = idx / K;  k = idx % K;
+e = moe_find_expert(m, expert_offsets, E);
+```
+
+**预计算**：
+
+```cpp
+b        = k >> 5;              // k 属于哪个 32 块
+half_k   = k >> 1;              // k 对应的字节下标（2 个 fp4 打包）
+nib_shift = (k & 1) << 2;       // 该 k 是低 nibble(0) 还是高 nibble(4)
+w_codes_e = w_codes + e * N * (K>>1);   // 专家 e 的权重 code 基址
+w_scales_e = w_scales + e * N * blocks; // 专家 e 的权重 scale 基址
+dy_row = dy + m * N;                    // 第 m 行 dy
+```
+
+**沿 N 累加**（dX = dy × W^T，转置权重）：
+
+```cpp
+float acc = 0.0f;
+for (int n = 0; n < N; ++n) {
+  uint8_t nib = (w_codes_e[n*(K>>1) + half_k] >> nib_shift) & 0xF;   // W[e,n,k]
+  float wfull = __fmul_rn(moe_e2m1_nibble_to_f32(nib),
+                          moe_e8m0_to_f32(w_scales_e[n*blocks + b])); // 反量化权重
+  float wbf = __bfloat162float(__float2bfloat16(wfull));              // 截断到 BF16
+  acc = __fadd_rn(acc, __fmul_rn(__bfloat162float(dy_row[n]), wbf));
+}
+dx[m*K + k] = acc;
+```
+
+**关键点**：`__float2bfloat16` 把反量化后的权重**舍入成 BF16**（对应 oracle 的
+`w_full.to(bf16)`），体现「BF16 backward」契约——反向在 BF16 精度下做，但累加器仍是 FP32。
+
+---
+
+## 6. 数据流 Pipeline 图
+
+### 6.1 前向数据流
+
+```
+        ┌───────────────┐   ┌────────────────────┐   ┌──────────────────────┐
+        │ activation    │   │ packed weight      │   │ expert_offsets       │
+        │ E4M3 [M,K]    │   │ E2M1 nibbles       │   │ int32 [E+1]          │
+        └───────┬───────┘   │ [E,N,K/2]          │   └──────────┬───────────┘
+                │           └─────────┬──────────┘              │
+   ┌────────────┴───────────┐         │                         │
+   │ activation scales     │         │   ┌─────────────────────┴───┐
+   │ E8M0 [M,K/32]         │         │   │ weight scales           │
+   └────────────┬───────────┘         │   │ E8M0 [E,N,K/32]         │
+                │                     │   └────────────┬────────────┘
+                ▼                     ▼                ▼
+   ┌──────────────────────────────────────────────────────────────┐
+   │  一个线程 = 一个输出元素 (m,n)                                  │
+   │  1) moe_find_expert(m)  →  e                                  │
+   │  2) 定位 a_row / a_srow / w_row / w_srow                       │
+   │  3) 外层循环 block j（K/32 个）:                               │
+   │       内层 kk∈[0,32):                                         │
+   │         av  = E4M3_decode(a_row[k])                           │
+   │         nib = (w_row[k>>1] >> ((k&1)<<2)) & 0xF               │
+   │         wv  = E2M1_decode(nib)                                │
+   │         partial += av * wv        (__fmul_rn + __fadd_rn)     │
+   │       sc  = (partial * E8M0_decode(a_srow[j]))                │
+   │              * E8M0_decode(w_srow[j])                         │
+   │       acc += sc                                                │
+   └──────────────────────────────────────────────────────────────┘
+                │
+                ▼
+        ┌───────────────┐
+        │ output FP32   │
+        │ [M,N]         │
+        └───────────────┘
+```
+
+### 6.2 反向数据流（dX only）
+
+```
+   dy BF16 [M,N]        weight codes E2M1x2 [E,N,K/2]   weight scales E8M0 [E,N,K/32]
+        │                          │                             │
+        ▼                          ▼                             ▼
+   ┌─────────────────────────────────────────────────────────────────────┐
+   │  一个线程 = 一个 dX 元素 (m,k)                                       │
+   │  1) moe_find_expert(m) → e                                          │
+   │  2) 预计算 b=k>>5, half_k=k>>1, nib_shift=(k&1)<<2                  │
+   │  3) 沿 n 累加:                                                       │
+   │       nib   = 取出 W[e,n,k] 的 nibble                                │
+   │       wfull = E2M1_decode(nib) * E8M0_decode(w_scales_e[n,b])       │
+   │       wbf   = float2bfloat16(wfull)   ← 反量化后截断到 BF16         │
+   │       acc  += dy[m,n] * wbf            (__fmul_rn + __fadd_rn)      │
+   └─────────────────────────────────────────────────────────────────────┘
+        │
+        ▼
+   dx FP32 [M,K]
+```
+
+### 6.3 三种编码的 bit 级解码图
+
+```
+E4M3 (activation code, 1 byte):
+  ┌───┬───────────┬─────────┐
+  │ s │ exp(4bit) │ mant(3) │   →  value = ± 2^(exp-7) · (1 + mant/8)
+  └───┴───────────┴─────────┘        (exp==0 → 次正规 2^-6·mant/8)
+
+E2M1 (weight, 半个字节 / nibble):
+  ┌───┬──────┬────┐
+  │ s │exp(2)│m(1)│   →  value = ± kMag[ {exp,m} ]
+  └───┴──────┴────┘         kMag = {0, 0.5, 1, 1.5, 2, 3, 4, 6}
+   打包: 1 byte 存 2 个元素，偶 k 在低 nibble，奇 k 在高 nibble
+
+E8M0 (scale, 1 byte):
+  ┌────────────────┐
+  │   exp(8bit)    │   →  scale = 2^(code - 127)
+  └────────────────┘         code=127 → 1.0；code=255 → NaN(拒绝)
+```
+
+---
+
+## 7. 组件依赖关系总图
+
+```
+L1:  forward/backward/act_quant  (对外 API)
+        │ 调用
+        ▼
+L2:  moe_launch_*_strict  ──校验──>  moe_check_* / moe_copy_offsets
+        │ <<<grid,128,0,stream>>>      （moe_prepare_experts / moe_check_h100_sm90 目前未接线）
+        ▼
+L3:  moe_grouped_gemm_fwd_strict / bwd_strict
+        │                    │
+        ├─ 路由 ── moe_find_expert (二分查找)
+        │
+        └─ 解码 ── moe_e4m3_to_f32 (仅 fwd)
+                 ├ moe_e2m1_nibble_to_f32 (fwd+bwd)
+                 └ moe_e8m0_to_f32      (fwd+bwd)
+```
+
+---
+
+## 8. 关键语法点速查
+
+| 语法 | 含义 |
+|---|---|
+| `__global__` | 从 host 启动、device 执行的 kernel |
+| `__device__ __forceinline__` | device 函数，强制内联（消除调用开销） |
+| `__restrict__` | 告知编译器指针不重叠，便于优化 |
+| `__fmul_rn(x,y)` | FP32 乘法 + round-to-nearest-even，**不融合** |
+| `__fadd_rn(x,y)` | FP32 加法 + RNE，**不融合** |
+| `__bfloat162float` / `__float2bfloat16` | BF16 ↔ FP32 转换 |
+| `ldexpf(x,e)` | 精确计算 `x · 2^e` |
+| `<<<grid, block, shmem, stream>>>` | kernel 启动配置 |
+| `TORCH_CHECK(cond, msg)` | PyTorch 侧断言，失败抛 C++ 异常 |
+| `data_ptr<T>()` | 取 tensor 的设备端裸指针（类型 T） |
+| `[[noreturn]]` | 标记函数永不返回（总是抛异常） |
+| `constexpr` | 编译期常量 |
+| `static_cast<T>(x)` | 显式类型转换 |
+| `#pragma unroll` | 提示编译器展开循环 |
+
+---
+
+## 9. 一句话总结
+
+- **L1** 三个 PyTorch 入口负责「收 tensor → 校验 → 分发」，其中 act_quant 是 fail-closed 占位。
+- **L2** launch 函数负责「算 grid/block 并启动 kernel」，另外 host 端还预留了
+  `moe_prepare_experts`（vLLM prep kernel 的镜像）但未接入 hot path。
+- **L3** 两个 strict kernel 用「一线程一输出元素 + 二分路由 + 软件解码 + 串行升序累加」
+  实现 bit-exact 的分组 GEMM，前向复用 E4M3/E2M1/E8M0 三种解码器，反向复用后两种。

--- a/rl_engine/moe/__init__.py
+++ b/rl_engine/moe/__init__.py
@@ -14,7 +14,13 @@ from rl_engine.moe.contract import (
     tensor_sha256,
 )
 from rl_engine.moe.mx_format import MX_BLOCK, MXTensor, mx_dequantize, mx_quantize
-from rl_engine.moe.provider import ExpertProvider, ReferenceProvider, StubProvider, resolve_provider
+from rl_engine.moe.provider import (
+    CudaP5GemmProvider,
+    ExpertProvider,
+    ReferenceProvider,
+    StubProvider,
+    resolve_provider,
+)
 from rl_engine.moe.trace import ExpertTrace, first_divergence
 
 __all__ = [
@@ -32,6 +38,7 @@ __all__ = [
     "ReferenceProvider",
     "SharedBatch",
     "StubProvider",
+    "CudaP5GemmProvider",
     "first_divergence",
     "mx_dequantize",
     "mx_quantize",

--- a/rl_engine/moe/provider.py
+++ b/rl_engine/moe/provider.py
@@ -109,6 +109,63 @@ class ReferenceProvider:
     shared_expert_mlp_bwd = staticmethod(oracle.shared_expert_mlp_bwd)
 
 
+class NativeP5Provider(ReferenceProvider):
+    """Fail-closed adapter for the P5 CUDA ABI skeleton.
+
+    The native entry points currently expose the documented pointer/shape
+    contract but intentionally raise until strict kernels are implemented.
+    This adapter must never silently call the Python oracle.
+    """
+
+    name = "native-p5"
+    numeric_profile = "p5-strict-skeleton-unimplemented"
+
+    @staticmethod
+    def _extension():
+        try:
+            from rl_engine import _C
+        except ImportError as exc:
+            raise RuntimeError("P5 native extension is not built") from exc
+        return _C
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "backend": "cuda-p5-skeleton",
+            "geometry": ["one-row"],
+            "devices": ["cuda"],
+            "implemented": [],
+        }
+
+    def provenance(self) -> dict[str, Any]:
+        return {
+            "requested_backend": self.name,
+            "actual_backend": self.name,
+            "numeric_profile": self.numeric_profile,
+            "implementation": "interface-skeleton",
+        }
+
+    def mxfp8_act_quant_fwd(self, x: torch.Tensor) -> MXTensor:
+        codes, scales = self._extension().moe_mxfp8_act_quant_forward(x)
+        return MXTensor(codes, scales, "e4m3", tuple(x.shape))
+
+    def mxfp8_mxfp4_grouped_gemm_fwd(
+        self, a: MXTensor, w: MXTensor, expert_offsets: torch.Tensor
+    ) -> torch.Tensor:
+        return self._extension().moe_mxfp8_mxfp4_grouped_gemm_forward(
+            a.codes, a.scales, w.codes, w.scales, expert_offsets
+        )
+
+    def mxfp8_mxfp4_grouped_gemm_bwd(
+        self, dy: torch.Tensor, w: MXTensor, expert_offsets: torch.Tensor
+    ) -> torch.Tensor:
+        return self._extension().moe_mxfp8_mxfp4_grouped_gemm_backward(
+            dy, w.codes, w.scales, expert_offsets
+        )
+
+    def mxfp8_act_quant_bwd(self, dy: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError("P5-1 native backward is not part of this skeleton")
+
+
 class StubProvider(ReferenceProvider):
     """Fail-closed placeholder: every operator raises until a backend claims it.
 
@@ -177,11 +234,70 @@ class StubProvider(ReferenceProvider):
         raise self._todo("P5-5 (#64)")
 
 
+class CudaP5GemmProvider(ReferenceProvider):
+    """Strict CUDA GEMM backend for P5-4 only.
+
+    Overrides the MXFP8xMXFP4 grouped GEMM fwd/bwd with the hand-written strict
+    FFMA kernel (bit-exact vs the FP32 oracle). Every other operator stays on
+    the oracle. Fail-closed: raises if the native extension is not built.
+    """
+
+    name = "cuda-p5-gemm"
+    numeric_profile = "p5-strict-ffma-v1"
+
+    @staticmethod
+    def _extension():
+        try:
+            from rl_engine import _C
+        except ImportError as exc:
+            raise RuntimeError("P5 CUDA extension is not built") from exc
+        return _C
+
+    def capabilities(self) -> dict[str, Any]:
+        return {
+            "backend": "cuda-p5-strict",
+            "geometry": ["one-row"],
+            "devices": ["cuda"],
+            "implemented": [
+                "mxfp8_mxfp4_grouped_gemm_fwd",
+                "mxfp8_mxfp4_grouped_gemm_bwd",
+            ],
+        }
+
+    def provenance(self) -> dict[str, Any]:
+        return {
+            "requested_backend": self.name,
+            "actual_backend": "cuda-strict",
+            "numeric_profile": self.numeric_profile,  # "p5-strict-ffma-v1"
+            "geometry": "one-row-unpadded",
+            "tile": None,  # no tiling in the strict one-row path
+            "split_k": 1,  # no split-K
+            "kernel_fingerprint": "mxfp8-mxfp4-grouped-gemm-strict-v1",
+            "torch_version": torch.__version__,
+            "cuda_version": torch.version.cuda,
+        }
+
+    def mxfp8_mxfp4_grouped_gemm_fwd(
+        self, a: MXTensor, w: MXTensor, expert_offsets: torch.Tensor
+    ) -> torch.Tensor:
+        return self._extension().moe_mxfp8_mxfp4_grouped_gemm_forward(
+            a.codes, a.scales, w.codes, w.scales, expert_offsets
+        )
+
+    def mxfp8_mxfp4_grouped_gemm_bwd(
+        self, dy: torch.Tensor, w: MXTensor, expert_offsets: torch.Tensor
+    ) -> torch.Tensor:
+        return self._extension().moe_mxfp8_mxfp4_grouped_gemm_backward(
+            dy, w.codes, w.scales, expert_offsets
+        )
+
+
 def resolve_provider(spec: str) -> ExpertProvider:
     """Instantiate a provider from ``"module.path:ClassName"`` (or an alias)."""
     aliases = {
         "reference": "rl_engine.moe.provider:ReferenceProvider",
         "stub": "rl_engine.moe.provider:StubProvider",
+        "cuda": "rl_engine.moe.provider:CudaP5GemmProvider",
     }
     spec = aliases.get(spec, spec)
     if ":" not in spec:

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ def get_extensions():
             "csrc/cuda/gemm/det_gemm_kernel.cu",
             "csrc/cuda/rmsnorm.cu",
             "csrc/cuda/activation.cu",
+            "csrc/cuda/moe/mxfp8_mxfp4_grouped_gemm.cu",
             "csrc/cuda/attention/deterministic_attention.cu",
             "csrc/cuda/distributed/deterministic_collective.cu",
         ]


### PR DESCRIPTION
中文：
    实现 mxfp8_mxfp4_grouped_gemm_fwd/bwd（P5-4，父 Issue #8），遵循 P5-S0 合同：Routed Expert 的 fc1/fc2 frozen-base GEMM —— MXFP8（E4M3）激活 × MXFP4（E2M1）权重，共享 E8M0 scale。前向输出 FP32 [M,N]；反向只写 dX（FP32 [M,K]），不写 dW（base weight 冻结）。权重保持 E2M1 nibble 打包，反量化只发生在寄存器中，不写回 global memory。
fwd：
设 e = expert(m)（token m 所属的 expert）。对输出 Y[m,n]：
Y[m,n] = Σ_{j=0}^{K/32-1} ( ( Σ_{k=32j}^{32j+31} â[m,k] · ŵ[e,n,k] ) · sa[m,j] ) · sw[e,n,j]
bwd：
这里w_bf16是和fwd一样的转码并逐元素乘上对应scale：
W_bf16[e,n,k] = bf16( ŵ[e,n,k] · sw[e,n,k>>5] )  
dX[m,k] = Σ_{n=0}^{N-1} dy[m,n] · W_bf16[e,n,k]

EN：
    Implement mxfp8_mxfp4_grouped_gemm_fwd/bwd (P5-4, parent Issue #8), following the P5-S0 contract: frozen-base GEMM for the Routed Expert's fc1/fc2 — MXFP8 (E4M3) activations × MXFP4 (E2M1) weights, with a shared E8M0 scale. The forward output is FP32 [M,N]; the backward pass writes only dX (FP32 [M,K]) and does not write dW (the base weight is frozen). Weights remain E2M1 nibble-packed; dequantization occurs only in registers and is not written back to global memory.
fwd:
Let e = expert(m) (the expert to which token m belongs). For output Y[m,n]:
Y[m,n] = Σ_{j=0}^{K/32-1} ( ( Σ_{k=32j}^{32j+31} â[m,k] · ŵ[e,n,k] ) · sa[m,j] ) · sw[e,n,j]
bwd:
Here W_bf16 is transcoded the same as in fwd and elementwise multiplied by the corresponding scale:
W_bf16[e,n,k] = bf16( ŵ[e,n,k] · sw[e,n,k>>5] )
dX[m,k] = Σ_{n=0}^{N-1} dy[m,n] · W_bf16[e,n,k]
